### PR TITLE
Fix wierdness on 14.04

### DIFF
--- a/debian/reaper.init
+++ b/debian/reaper.init
@@ -32,11 +32,10 @@ case "$1" in
         echo "Already started"
     else
         echo "Starting $name"
-        cd "$dir"
         if [ -z "$user" ]; then
-            sudo $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            sudo $dir/$cmd >> "$stdout_log" 2>> "$stderr_log" &
         else
-            sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            sudo -u "$user" $dir/$cmd >> "$stdout_log" 2>> "$stderr_log" &
         fi
         echo $! > "$pid_file"
         if ! is_running; then


### PR DESCRIPTION
For some reason the `cd $dir` isn't working in the init file. I've gone ahead and modified it to fix this. Seems to be a thing on ubuntu 14.04 (probably some upstart weirdness)