### PR TITLE
Create a full integration test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,36 @@ language: java
 jdk:
 - oraclejdk8
 install: true
+env:
+  global:
+    - LOCAL_JMX=no
+  matrix:
+    - CASSANDRA_VERSION=2.1.16
+    - CASSANDRA_VERSION=2.2.8
+    - CASSANDRA_VERSION=3.0.9
+    - CASSANDRA_VERSION=3.9
+
+before_install:
+  - sudo apt-get install libjna-java > /dev/null
+  - sudo apt-get install python-support > /dev/null
+  - sudo easy_install pyYaml > /dev/null
+  - sudo easy_install pip > /dev/null
+  - sudo pip install ccm > /dev/null
+
+install:
+  - ccm create test -v $CASSANDRA_VERSION > /dev/null
+  - ccm populate -n 3 > /dev/null
+  - sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/travis/.ccm/test/node1/conf/cassandra-env.sh
+  - sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/travis/.ccm/test/node2/conf/cassandra-env.sh
+  - sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/travis/.ccm/test/node3/conf/cassandra-env.sh
+  - ccm start > /dev/null
+
+#before_script:
+#  - npm install -g bower
 script:
-  - mvn clean package
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=tlp-cassandra-reaper -Dsonar.github.oauth=$GITHUB_TOKEN -Dsonar.github.repository=thelastpickle/cassandra-reaper -Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST -Dsonar.analysis.mode=preview; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" ]; then mvn sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=tlp-cassandra-reaper -Dsonar.github.oauth=$GITHUB_TOKEN -Dsonar.github.repository=thelastpickle/cassandra-reaper; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" != "master" ]; then mvn sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=tlp-cassandra-reaper -Dsonar.github.oauth=$GITHUB_TOKEN -Dsonar.github.repository=thelastpickle/cassandra-reaper  -Dsonar.analysis.mode=preview; fi'
+  - mvn clean package | grep -v "Download"
+  - mvn install -Pintegration-tests | grep -v "Download"
+  # We only run the sonar analysis once, so we'll pick the build with Cassandra 2.1.16
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" -a "$CASSANDRA_VERSION" = "2.1.16" ]; then mvn sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=tlp-cassandra-reaper -Dsonar.github.oauth=$GITHUB_TOKEN -Dsonar.github.repository=thelastpickle/cassandra-reaper -Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST -Dsonar.analysis.mode=preview; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" -a "$CASSANDRA_VERSION" = "2.1.16" ]; then mvn sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=tlp-cassandra-reaper -Dsonar.github.oauth=$GITHUB_TOKEN -Dsonar.github.repository=thelastpickle/cassandra-reaper; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" != "master" -a "$CASSANDRA_VERSION" = "2.1.16" ]; then mvn sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=tlp-cassandra-reaper -Dsonar.github.oauth=$GITHUB_TOKEN -Dsonar.github.repository=thelastpickle/cassandra-reaper  -Dsonar.analysis.mode=preview; fi'

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,41 @@
                         </configuration>
                     </plugin>
                     <plugin>
+				        <artifactId>maven-surefire-plugin</artifactId>
+				        <version>2.19</version>
+				        <configuration>
+				          <argLine>${surefireArgLine}</argLine>
+				          <failIfNoTests>false</failIfNoTests>
+				          <excludes>
+				            <exclude>**/IT*.java</exclude>
+				            <exclude>**/*IT.java</exclude>
+				          </excludes>
+				          <workingDirectory>${project.build.directory}</workingDirectory>
+				        </configuration>
+				    </plugin>				
+				    <plugin>
+				        <groupId>org.apache.maven.plugins</groupId>
+				        <artifactId>maven-failsafe-plugin</artifactId>
+				        <version>2.19</version>
+				        <executions>
+				          <execution>
+				            <id>integration-tests</id>
+				            <goals>
+				              <goal>integration-test</goal>
+				              <goal>verify</goal>
+				            </goals>
+				            <configuration>
+				              <skipTests>true</skipTests>
+				              <argLine>${failsafeArgLine}</argLine>
+				              <failIfNoTests>false</failIfNoTests>
+				              <includes>
+					            <include>**/ReaperIT.java</include>
+					          </includes>
+				            </configuration>
+				          </execution>
+				        </executions>
+        			</plugin>    
+                    <plugin>
                         <!-- To know which version of your application you have deployed on 
                             a machine -->
                         <groupId>org.apache.maven.plugins</groupId>
@@ -170,6 +205,61 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+        	<id>integration-tests</id>
+        	<activation>
+        		<activeByDefault>false</activeByDefault>
+        	</activation>
+        	<build>
+        		<plugins>
+        			<plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.1</version>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                    </plugin>
+	        		<plugin>
+				        <artifactId>maven-surefire-plugin</artifactId>
+				        <version>2.19</version>
+				        <configuration>
+				          <skipTests>true</skipTests>
+				          <argLine>${surefireArgLine}</argLine>
+				          <failIfNoTests>false</failIfNoTests>
+				          <excludes>
+				            <exclude>**/IT*.java</exclude>
+				            <exclude>**/*IT.java</exclude>
+				          </excludes>
+				          <workingDirectory>${project.build.directory}</workingDirectory>
+				        </configuration>
+				    </plugin>	
+        			<plugin>
+				        <groupId>org.apache.maven.plugins</groupId>
+				        <artifactId>maven-failsafe-plugin</artifactId>
+				        <version>2.19</version>
+				        <executions>
+				          <execution>
+				            <id>integration-tests</id>
+				            <goals>
+				              <goal>integration-test</goal>
+				              <goal>verify</goal>
+				            </goals>
+				            <configuration>
+				              <argLine>${failsafeArgLine}</argLine>
+				              <failIfNoTests>false</failIfNoTests>
+				              <includes>
+					            <include>**/ReaperIT.java</include>
+					          </includes>
+				            </configuration>
+				          </execution>
+				        </executions>
+        			</plugin>
+        		</plugins>
+        	</build>
         </profile>
         <profile>
             <id>build-ui</id>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
             <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+         </dependency>
     </dependencies>
 
     <profiles>
@@ -116,40 +122,40 @@
                         </configuration>
                     </plugin>
                     <plugin>
-				        <artifactId>maven-surefire-plugin</artifactId>
-				        <version>2.19</version>
-				        <configuration>
-				          <argLine>${surefireArgLine}</argLine>
-				          <failIfNoTests>false</failIfNoTests>
-				          <excludes>
-				            <exclude>**/IT*.java</exclude>
-				            <exclude>**/*IT.java</exclude>
-				          </excludes>
-				          <workingDirectory>${project.build.directory}</workingDirectory>
-				        </configuration>
-				    </plugin>				
-				    <plugin>
-				        <groupId>org.apache.maven.plugins</groupId>
-				        <artifactId>maven-failsafe-plugin</artifactId>
-				        <version>2.19</version>
-				        <executions>
-				          <execution>
-				            <id>integration-tests</id>
-				            <goals>
-				              <goal>integration-test</goal>
-				              <goal>verify</goal>
-				            </goals>
-				            <configuration>
-				              <skipTests>true</skipTests>
-				              <argLine>${failsafeArgLine}</argLine>
-				              <failIfNoTests>false</failIfNoTests>
-				              <includes>
-					            <include>**/ReaperIT.java</include>
-					          </includes>
-				            </configuration>
-				          </execution>
-				        </executions>
-        			</plugin>    
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19</version>
+                        <configuration>
+                          <argLine>${surefireArgLine}</argLine>
+                          <failIfNoTests>false</failIfNoTests>
+                          <excludes>
+                            <exclude>**/IT*.java</exclude>
+                            <exclude>**/*IT.java</exclude>
+                          </excludes>
+                          <workingDirectory>${project.build.directory}</workingDirectory>
+                        </configuration>
+                    </plugin>                
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.19</version>
+                        <executions>
+                          <execution>
+                            <id>integration-tests</id>
+                            <goals>
+                              <goal>integration-test</goal>
+                              <goal>verify</goal>
+                            </goals>
+                            <configuration>
+                              <skipTests>true</skipTests>
+                              <argLine>${failsafeArgLine}</argLine>
+                              <failIfNoTests>false</failIfNoTests>
+                              <includes>
+                                <include>**/ReaperIT.java</include>
+                              </includes>
+                            </configuration>
+                          </execution>
+                        </executions>
+                    </plugin>    
                     <plugin>
                         <!-- To know which version of your application you have deployed on 
                             a machine -->
@@ -207,13 +213,13 @@
             </build>
         </profile>
         <profile>
-        	<id>integration-tests</id>
-        	<activation>
-        		<activeByDefault>false</activeByDefault>
-        	</activation>
-        	<build>
-        		<plugins>
-        			<plugin>
+            <id>integration-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.1</version>
@@ -223,43 +229,43 @@
                             <encoding>UTF-8</encoding>
                         </configuration>
                     </plugin>
-	        		<plugin>
-				        <artifactId>maven-surefire-plugin</artifactId>
-				        <version>2.19</version>
-				        <configuration>
-				          <skipTests>true</skipTests>
-				          <argLine>${surefireArgLine}</argLine>
-				          <failIfNoTests>false</failIfNoTests>
-				          <excludes>
-				            <exclude>**/IT*.java</exclude>
-				            <exclude>**/*IT.java</exclude>
-				          </excludes>
-				          <workingDirectory>${project.build.directory}</workingDirectory>
-				        </configuration>
-				    </plugin>	
-        			<plugin>
-				        <groupId>org.apache.maven.plugins</groupId>
-				        <artifactId>maven-failsafe-plugin</artifactId>
-				        <version>2.19</version>
-				        <executions>
-				          <execution>
-				            <id>integration-tests</id>
-				            <goals>
-				              <goal>integration-test</goal>
-				              <goal>verify</goal>
-				            </goals>
-				            <configuration>
-				              <argLine>${failsafeArgLine}</argLine>
-				              <failIfNoTests>false</failIfNoTests>
-				              <includes>
-					            <include>**/ReaperIT.java</include>
-					          </includes>
-				            </configuration>
-				          </execution>
-				        </executions>
-        			</plugin>
-        		</plugins>
-        	</build>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19</version>
+                        <configuration>
+                          <skipTests>true</skipTests>
+                          <argLine>${surefireArgLine}</argLine>
+                          <failIfNoTests>false</failIfNoTests>
+                          <excludes>
+                            <exclude>**/IT*.java</exclude>
+                            <exclude>**/*IT.java</exclude>
+                          </excludes>
+                          <workingDirectory>${project.build.directory}</workingDirectory>
+                        </configuration>
+                    </plugin>    
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.19</version>
+                        <executions>
+                          <execution>
+                            <id>integration-tests</id>
+                            <goals>
+                              <goal>integration-test</goal>
+                              <goal>verify</goal>
+                            </goals>
+                            <configuration>
+                              <argLine>${failsafeArgLine}</argLine>
+                              <failIfNoTests>false</failIfNoTests>
+                              <includes>
+                                <include>**/ReaperIT.java</include>
+                              </includes>
+                            </configuration>
+                          </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>build-ui</id>

--- a/src/main/java/com/spotify/reaper/resources/view/ClusterStatus.java
+++ b/src/main/java/com/spotify/reaper/resources/view/ClusterStatus.java
@@ -37,4 +37,5 @@ public class ClusterStatus {
     this.repairRuns = repairRuns;
     this.repairSchedules = repairSchedules;
   }
+  
 }

--- a/src/test/java/com/spotify/reaper/SimpleReaperClient.java
+++ b/src/test/java/com/spotify/reaper/SimpleReaperClient.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.reaper.resources.view.ClusterStatus;
 import com.spotify.reaper.resources.view.RepairRunStatus;
 import com.spotify.reaper.resources.view.RepairScheduleStatus;
 import com.sun.jersey.api.client.Client;
@@ -93,6 +94,16 @@ public class SimpleReaperClient {
 
   public static RepairRunStatus parseRepairRunStatusJSON(String json) {
     return parseJSON(json, new TypeReference<RepairRunStatus>() {
+    });
+  }
+  
+  public static Map<String, Object> parseClusterStatusJSON(String json) {
+    return parseJSON(json, new TypeReference<Map<String, Object> >() {
+    });
+  }
+  
+  public static List<String> parseClusterNameListJSON(String json) {
+    return parseJSON(json, new TypeReference<List<String> >() {
     });
   }
 

--- a/src/test/java/com/spotify/reaper/acceptance/ReaperIT.java
+++ b/src/test/java/com/spotify/reaper/acceptance/ReaperIT.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spotify.reaper.acceptance;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = "classpath:com.spotify.reaper.acceptance/integration_reaper_functionality.feature"
+)
+public class ReaperIT {
+  // Required only to get the Cucumber acceptance tests actually run.
+}

--- a/src/test/java/com/spotify/reaper/acceptance/TestContext.java
+++ b/src/test/java/com/spotify/reaper/acceptance/TestContext.java
@@ -12,6 +12,7 @@ public class TestContext {
 
   public static  String TEST_USER = "test_user";
   public static String SEED_HOST;
+  public static String TEST_CLUSTER;
 
   /* Used for targeting an object accessed in last test step. */
   public static Long LAST_MODIFIED_ID;

--- a/src/test/java/com/spotify/reaper/acceptance/TestUtils.java
+++ b/src/test/java/com/spotify/reaper/acceptance/TestUtils.java
@@ -1,0 +1,41 @@
+package com.spotify.reaper.acceptance;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+
+public class TestUtils {
+
+  private static Cluster cluster;
+  private static Session session;
+ 
+  /** Holder */
+  private static class SingletonHolder
+  {   
+    /** Instance unique non préinitialisée */
+    private final static TestUtils instance = new TestUtils();
+  }
+ 
+  /** Point d'accès pour l'instance unique du singleton */
+  public static TestUtils getInstance()
+  {
+    return SingletonHolder.instance;
+  }
+  
+  private TestUtils(){
+    cluster = Cluster.builder().addContactPoint("127.0.0.1").build();
+    session = cluster.connect();    
+  }
+  
+  public void createKeyspace(String keyspaceName){
+    session.execute("CREATE KEYSPACE IF NOT EXISTS " + keyspaceName + " WITH replication={'class':'SimpleStrategy', 'replication_factor':3}");
+  }
+  
+  public void createTable(String keyspaceName, String tableName){
+    session.execute("CREATE TABLE IF NOT EXISTS " + keyspaceName + "." + tableName + "(id int PRIMARY KEY, value text)");
+    for(int i=0;i<100;i++){
+      session.execute("INSERT INTO " + keyspaceName + "." + tableName + "(id, value) VALUES(" + i + ",'" + i + "')");
+    }
+  }
+  
+ 
+}

--- a/src/test/resources/cassandra-reaper-at.yaml
+++ b/src/test/resources/cassandra-reaper-at.yaml
@@ -28,6 +28,11 @@ server:
       port: 8084
       bindHost: 127.0.0.1
 
+jmxPorts:
+  127.0.0.1: 7100
+  127.0.0.2: 7200
+  127.0.0.3: 7300
+
 # database section will be ignored if storageType is set to "memory"
 database:
   # the name of your JDBC driver

--- a/src/test/resources/cassandra-reaper.yaml
+++ b/src/test/resources/cassandra-reaper.yaml
@@ -26,10 +26,10 @@ storageType: memory
 enableCrossOrigin: true
 
 # custom jmx port mappings that will be used instead of the default port for specified hosts (optional)
-#jmxPorts:
-#  127.0.0.1: 7100
-#  127.0.0.2: 7200
-#  127.0.0.3: 7300
+jmxPorts:
+  127.0.0.1: 7100
+  127.0.0.2: 7200
+  127.0.0.3: 7300
 
 # Use following credential for JMX authentication
 #jmxAuth:

--- a/src/test/resources/com.spotify.reaper.acceptance/basic_reaper_functionality.feature
+++ b/src/test/resources/com.spotify.reaper.acceptance/basic_reaper_functionality.feature
@@ -56,7 +56,7 @@ Feature: Using Reaper to launch repairs
     And a new repair is added for "other_cluster" and keyspace "system"
     Then reaper has 1 repairs for cluster called "other_cluster"
     And deleting cluster called "other_cluster" fails
-    When the last added repair run is deleted for cluster called "other_cluster"
+    When the last added repair run is deleted
     And cluster called "other_cluster" is deleted
     Then reaper has no cluster called "other_cluster" in storage
   

--- a/src/test/resources/com.spotify.reaper.acceptance/integration_reaper_functionality.feature
+++ b/src/test/resources/com.spotify.reaper.acceptance/integration_reaper_functionality.feature
@@ -1,0 +1,62 @@
+Feature: Using Reaper to launch repairs and schedule them
+
+  ## TODO: clean-up and split the scenarios to be more like Given -> When -> Then [-> But]
+
+  Background:
+    Given cluster seed host "127.0.0.1" points to cluster with name "test_cluster"
+    And ccm cluster "test_cluster" has keyspace "booya" with tables "booya1, booya2"
+    And a real reaper service is running
+
+  Scenario: Registering a cluster
+    Given that we are going to use "127.0.0.1" as cluster seed host
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    When the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+    
+
+  Scenario: Create a cluster and a scheduled repair run and delete them
+    Given that we are going to use "127.0.0.1" as cluster seed host
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for the last added cluster
+    When a new daily repair schedule is added for the last added cluster and keyspace "booya"
+    Then reaper has 1 scheduled repairs for the last added cluster
+    And deleting the last added cluster fails
+    When the last added schedule is deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+ 
+  Scenario: Create a cluster and a repair run and delete them
+    Given that we are going to use "127.0.0.1" as cluster seed host
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 repairs for the last added cluster
+    When a new repair is added for the last added cluster and keyspace "booya"
+    And deleting the last added cluster fails
+    And the last added repair is activated
+    And we wait for at least 1 segments to be repaired
+    Then reaper has 1 repairs for the last added cluster
+    When the last added repair is stopped
+    And the last added repair run is deleted
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+    
+  Scenario: Create a cluster and an incremental repair run and delete them
+    Given that we are going to use "127.0.0.1" as cluster seed host
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 repairs for the last added cluster
+    When a new incremental repair is added for the last added cluster and keyspace "booya"
+    And deleting the last added cluster fails
+    And the last added repair is activated
+    And we wait for at least 1 segments to be repaired
+    Then reaper has 1 repairs for the last added cluster
+    When the last added repair is stopped
+    And the last added repair run is deleted
+    And the last added cluster is deleted
+ 


### PR DESCRIPTION
I've added a full generic test suite in Cucumber to run on real ccm clusters.
Travis build is modified to run those tests on different versions of Cassandra (2.1.16, 2.2.8, 3.0.9 and 3.9 for now).

Made so that the SonarQube analysis only runs in one build and not all four.