### PR TITLE
postgresql: the stored repair parallelism can be lowercase

### DIFF
--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairParametersMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairParametersMapper.java
@@ -31,8 +31,14 @@ public class RepairParametersMapper implements ResultSetMapper<RepairParameters>
     RingRange range = new RingRange(r.getBigDecimal("start_token").toBigInteger(),
                                     r.getBigDecimal("end_token").toBigInteger());
     String[] columnFamilies = (String[]) r.getArray("column_families").getArray();
-    RepairParallelism repairParallelism =
-        RepairParallelism.valueOf(r.getString("repair_parallelism"));
+
+    String repairParallelismStr = r.getString("repair_parallelism");
+    if (repairParallelismStr != null)
+    {
+      repairParallelismStr = repairParallelismStr.toUpperCase();
+    }
+    RepairParallelism repairParallelism = RepairParallelism.fromName(repairParallelismStr);
+
     return new RepairParameters(range,
                                 r.getString("keyspace_name"),
                                 Sets.newHashSet(columnFamilies),

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
@@ -35,8 +35,12 @@ public class RepairRunStatusMapper implements ResultSetMapper<RepairRunStatus> {
     DateTime pauseTime = RepairRunMapper.getDateTimeOrNull(r, "pause_time");
     Double intensity = r.getDouble("intensity");
     Boolean incrementalRepair = r.getBoolean("incremental_repair");
-    RepairParallelism repairParallelism =
-        RepairParallelism.valueOf(r.getString("repair_parallelism"));
+    String repairParallelismStr = r.getString("repair_parallelism");
+    if (repairParallelismStr != null)
+    {
+      repairParallelismStr = repairParallelismStr.toUpperCase();
+    }
+    RepairParallelism repairParallelism = RepairParallelism.fromName(repairParallelismStr);
 
     return new RepairRunStatus(runId, clusterName, keyspaceName, columnFamilies, segmentsRepaired,
         totalSegments, state, startTime, endTime, cause, owner, lastEvent,

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -31,6 +31,14 @@ public class RepairScheduleStatusMapper implements ResultSetMapper<RepairSchedul
   @Override
   public RepairScheduleStatus map(int index, ResultSet r, StatementContext ctx)
       throws SQLException {
+
+    String repairParallelismStr = r.getString("repair_parallelism");
+    if (repairParallelismStr != null)
+    {
+      repairParallelismStr = repairParallelismStr.toUpperCase();
+    }
+    RepairParallelism repairParallelism = RepairParallelism.fromName(repairParallelismStr);
+
     return new RepairScheduleStatus(
         r.getLong("id"),
         r.getString("owner"),
@@ -44,7 +52,7 @@ public class RepairScheduleStatusMapper implements ResultSetMapper<RepairSchedul
         r.getDouble("intensity"),
         r.getBoolean("incremental_repair"),
         r.getInt("segment_count"),
-        RepairParallelism.valueOf(r.getString("repair_parallelism")),
+        repairParallelism,
         r.getInt("days_between")
     );
   }


### PR DESCRIPTION
Hi,

so I just switched back to using postgresql for storage because the Cassandra storage is super slow right now, and I noticed that newly created repair runs in the table `repair_run` have the field `repair_parallelism` in lowercase now, resulting in an error whenever `RepairParallelism.valueOf` is called.

Fix this by uppercasing the string if not null.