### PR TITLE
Add dynamic discovery of seeds for clusters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 0.5.0
  * Add configurable auto-scheduling of repairs for all (non system) keyspaces
  * Fix bad segment count display on scheduled repairs
+ * Add dynamic discovery of seeds for clusters
 0.4.1
  * Fix for getting active/pending compactions and repairs in Cassandra 2.2+
 0.4.0

--- a/resource/cassandra-reaper-cassandra.yaml
+++ b/resource/cassandra-reaper-cassandra.yaml
@@ -11,6 +11,8 @@ storageType: cassandra
 enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
+enableDynamicSeedList: true
+
 jmxPorts:
   127.0.0.1: 7100
   127.0.0.2: 7200

--- a/resource/cassandra-reaper-h2.yaml
+++ b/resource/cassandra-reaper-h2.yaml
@@ -11,6 +11,8 @@ storageType: database
 enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
+enableDynamicSeedList: true
+
 jmxPorts:
   127.0.0.1: 7100
   127.0.0.2: 7200

--- a/resource/cassandra-reaper-memory.yaml
+++ b/resource/cassandra-reaper-memory.yaml
@@ -11,6 +11,8 @@ storageType: memory
 enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
+enableDynamicSeedList: true
+
 jmxPorts:
   127.0.0.1: 7100
   127.0.0.2: 7200

--- a/resource/cassandra-reaper-postgres.yaml
+++ b/resource/cassandra-reaper-postgres.yaml
@@ -11,6 +11,8 @@ storageType: database
 enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
+enableDynamicSeedList: true
+
 jmxPorts:
   127.0.0.1: 7100
   127.0.0.2: 7200

--- a/resource/cassandra-reaper.yaml
+++ b/resource/cassandra-reaper.yaml
@@ -11,6 +11,8 @@ storageType: memory
 enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
+enableDynamicSeedList: true
+
 jmxPorts:
   127.0.0.1: 7100
   127.0.0.2: 7200

--- a/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
@@ -83,8 +83,13 @@ public class ReaperApplicationConfiguration extends Configuration {
   @JsonProperty
   @DefaultValue("false")
   private Boolean allowUnreachableNodes;
+  
   @JsonProperty
   private AutoSchedulingConfiguration autoScheduling;
+  
+  @JsonProperty
+  @DefaultValue("true")
+  private Boolean enableDynamicSeedList;
 
   public int getSegmentCount() {
     return segmentCount;
@@ -197,6 +202,14 @@ public class ReaperApplicationConfiguration extends Configuration {
 
   public void setAutoScheduling(AutoSchedulingConfiguration autoRepairScheduling) {
     this.autoScheduling = autoRepairScheduling;
+  }
+  
+  public void setEnableDynamicSeedList(Boolean enableDynamicSeedList) {
+    this.enableDynamicSeedList = enableDynamicSeedList;
+  }
+  
+  public Boolean getEnableDynamicSeedList() {
+    return this.enableDynamicSeedList==null?Boolean.TRUE:this.enableDynamicSeedList;
   }
 
   public static class JmxCredentials {

--- a/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
+++ b/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
@@ -629,6 +629,17 @@ public class JmxProxy implements NotificationListener, AutoCloseable {
       throw new ReaperException(e);
     }
   }
+  
+  public List<String> getLiveNodes()
+      throws ReaperException {
+    checkNotNull(ssProxy, "Looks like the proxy is not connected");
+    try {
+      return ((StorageServiceMBean) ssProxy).getLiveNodes();
+    } catch (Exception e) {
+      LOG.error(e.getMessage());
+      throw new ReaperException(e.getMessage(), e);
+    }
+  }
 }
 
 /**

--- a/src/main/java/com/spotify/reaper/resources/ClusterResource.java
+++ b/src/main/java/com/spotify/reaper/resources/ClusterResource.java
@@ -174,7 +174,7 @@ public class ClusterResource {
     Optional<String> clusterName = Optional.absent();
     Optional<String> partitioner = Optional.absent();
     Optional<List<String>> liveNodes = Optional.absent();
-    Set<String> seedHosts = parseSeedHosts(seedHostInput);
+    Set<String> seedHosts = CommonTools.parseSeedHosts(seedHostInput);
     for(String seedHost:seedHosts) {
       try (JmxProxy jmxProxy = context.jmxConnectionFactory.connect(seedHost)) {
         clusterName = Optional.of(jmxProxy.getClusterName());
@@ -224,7 +224,7 @@ public class ClusterResource {
           .build();
     }
 
-    Set<String> newSeeds = parseSeedHosts(seedHost.get());
+    Set<String> newSeeds = CommonTools.parseSeedHosts(seedHost.get());
     Optional<List<String>> liveNodes = Optional.absent();
     
     if(context.config.getEnableDynamicSeedList()) {

--- a/src/main/java/com/spotify/reaper/resources/CommonTools.java
+++ b/src/main/java/com/spotify/reaper/resources/CommonTools.java
@@ -3,6 +3,7 @@ package com.spotify.reaper.resources;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -369,6 +371,10 @@ public class CommonTools {
 
   public static double roundDoubleNicely(double intensity) {
     return Math.round(intensity * 10000f) / 10000f;
+  }
+
+  public static Set<String> parseSeedHosts(String seedHost) {
+    return Arrays.stream(seedHost.split(",")).map(String::trim).collect(Collectors.toSet());
   }
 
 }

--- a/src/test/java/com/spotify/reaper/acceptance/BasicSteps.java
+++ b/src/test/java/com/spotify/reaper/acceptance/BasicSteps.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,6 +76,8 @@ public class BasicSteps {
       when(jmx.getPartitioner()).thenReturn("org.apache.cassandra.dht.RandomPartitioner");
       when(jmx.getKeyspaces()).thenReturn(Lists.newArrayList(clusterKeyspaces.keySet()));
       when(jmx.getTokens()).thenReturn(Lists.newArrayList(new BigInteger("0")));
+      when(jmx.getLiveNodes()).thenReturn(Arrays.asList(seedHost));
+      
       for (String keyspace : clusterKeyspaces.keySet()) {
         when(jmx.getTableNamesForKeyspace(keyspace)).thenReturn(clusterKeyspaces.get(keyspace));
       }

--- a/src/test/java/com/spotify/reaper/resources/CommonToolsTest.java
+++ b/src/test/java/com/spotify/reaper/resources/CommonToolsTest.java
@@ -4,7 +4,11 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
+import com.google.common.collect.Sets;
+
 import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
 
 public class CommonToolsTest {
 
@@ -12,5 +16,15 @@ public class CommonToolsTest {
   public void testDateTimeToISO8601() {
     DateTime dateTime = new DateTime(2015, 2, 20, 15, 24, 45, DateTimeZone.UTC);
     assertEquals("2015-02-20T15:24:45Z", CommonTools.dateTimeToISO8601(dateTime));
+  }
+  
+  @Test
+  public void testParseSeedHost() {
+    String seedHostStringList = "127.0.0.1 , 127.0.0.2,  127.0.0.3";
+    Set<String> seedHostSet = CommonTools.parseSeedHosts(seedHostStringList);
+    Set<String> seedHostExpectedSet = Sets.newHashSet("127.0.0.2","127.0.0.1","127.0.0.3");
+    
+    assertEquals(seedHostSet, seedHostExpectedSet);
+    
   }
 }

--- a/src/test/java/com/spotify/reaper/unit/resources/ClusterResourceTest.java
+++ b/src/test/java/com/spotify/reaper/unit/resources/ClusterResourceTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Arrays;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -51,6 +52,7 @@ public class ClusterResourceTest {
     jmxProxy = mock(JmxProxy.class);
     when(jmxProxy.getClusterName()).thenReturn(CLUSTER_NAME);
     when(jmxProxy.getPartitioner()).thenReturn(PARTITIONER);
+    when(jmxProxy.getLiveNodes()).thenReturn(Arrays.asList(SEED_HOST));
     context.jmxConnectionFactory = new JmxConnectionFactory() {
       @Override
       public JmxProxy connect(Optional<RepairStatusHandler> handler, String host)
@@ -109,10 +111,12 @@ public class ClusterResourceTest {
   }
 
   @Test
-  public void testModifyClusterSeeds() {
+  public void testModifyClusterSeeds() throws ReaperException {
     ClusterResource clusterResource = new ClusterResource(context);
     clusterResource.addCluster(uriInfo, Optional.of(SEED_HOST));
 
+    when(jmxProxy.getLiveNodes()).thenReturn(Arrays.asList(SEED_HOST+1));
+    
     Response response = clusterResource.modifyClusterSeed(uriInfo, CLUSTER_NAME,
         Optional.of(SEED_HOST + 1));
 
@@ -126,6 +130,7 @@ public class ClusterResourceTest {
 
     response = clusterResource.modifyClusterSeed(uriInfo, CLUSTER_NAME, Optional.of(SEED_HOST + 1));
     assertEquals(304, response.getStatus());
+    when(jmxProxy.getLiveNodes()).thenReturn(Arrays.asList(SEED_HOST));
   }
 
   @Test

--- a/src/test/resources/cassandra-reaper-at.yaml
+++ b/src/test/resources/cassandra-reaper-at.yaml
@@ -8,6 +8,7 @@ repairRunThreadCount: 15
 hangingRepairTimeoutMins: 1
 storageType: memory
 incrementalRepair: false
+enableDynamicSeedList: false
 
 logging:
   level: DEBUG


### PR DESCRIPTION
Currently Reaper has the data model to accept multiple seed nodes but doesn't use it, as it only takes a single seed as input.

This PR adds 2 things : 
* the ability to add multiple seed nodes separated by commas
* the ability for reaper to fill in dynamically the list of nodes by calling JmxProxy.getLiveNodes()

The list of nodes won't get updated afterwards though, and it is necessary to call `modifyClusterSeed`(PUT /cluster/{clusterName}) in order to have a fresh list of nodes. 

The dynamic seed list is enabled by default and can be disabled in the yaml file.  