### PR TITLE
Use new repair API and adapt notification handler

### DIFF
--- a/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
+++ b/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
@@ -44,14 +44,18 @@ import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.db.compaction.CompactionManager;
 import org.apache.cassandra.db.compaction.CompactionManagerMBean;
 import org.apache.cassandra.repair.RepairParallelism;
+import org.apache.cassandra.repair.messages.RepairOption;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.service.StorageServiceMBean;
+import org.apache.cassandra.utils.progress.ProgressEventType;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.spotify.reaper.ReaperException;
 import com.spotify.reaper.core.Cluster;
 import com.spotify.reaper.service.RingRange;
@@ -464,27 +468,21 @@ public class JmxProxy implements NotificationListener, AutoCloseable {
   
   
   public int triggerRepairPost2dot1(boolean fullRepair, RepairParallelism repairParallelism, String keyspace, Collection<String> columnFamilies, BigInteger beginToken, BigInteger endToken, String cassandraVersion) {
-    if (fullRepair) {
-      // full repair
-      if (repairParallelism.equals(RepairParallelism.DATACENTER_AWARE)) {
-          return ((StorageServiceMBean) ssProxy).forceRepairRangeAsync(beginToken.toString(), endToken.toString(),
-              keyspace, repairParallelism.ordinal(), cassandraVersion.startsWith("2.2")?new HashSet<String>():null, cassandraVersion.startsWith("2.2")?new HashSet<String>():null, fullRepair,
-              columnFamilies.toArray(new String[columnFamilies.size()]));        
-      }
-      
-      boolean snapshotRepair = repairParallelism.equals(RepairParallelism.SEQUENTIAL);
-
-      return ((StorageServiceMBean) ssProxy).forceRepairRangeAsync(beginToken.toString(), endToken.toString(),
-          keyspace, snapshotRepair ? RepairParallelism.SEQUENTIAL.ordinal() : RepairParallelism.PARALLEL.ordinal(),
-              cassandraVersion.startsWith("2.2")?new HashSet<String>():null, cassandraVersion.startsWith("2.2")?new HashSet<String>():null, fullRepair,
-          columnFamilies.toArray(new String[columnFamilies.size()]));
-
-    } 
-
-    // incremental repair
-    return ((StorageServiceMBean) ssProxy).forceRepairAsync(keyspace, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE,
-          fullRepair, columnFamilies.toArray(new String[columnFamilies.size()]));
+    Map<String, String> options = new HashMap<>();
     
+    options.put(RepairOption.PARALLELISM_KEY, repairParallelism.getName());
+    //options.put(RepairOption.PRIMARY_RANGE_KEY, Boolean.toString(primaryRange));
+    options.put(RepairOption.INCREMENTAL_KEY, Boolean.toString(!fullRepair));
+    options.put(RepairOption.JOB_THREADS_KEY, Integer.toString(1));
+    options.put(RepairOption.TRACE_KEY, Boolean.toString(Boolean.FALSE));
+    options.put(RepairOption.COLUMNFAMILIES_KEY, StringUtils.join(columnFamilies, ","));
+    //options.put(RepairOption.PULL_REPAIR_KEY, Boolean.FALSE);
+    options.put(RepairOption.RANGES_KEY, beginToken.toString() + ":" + endToken.toString());
+    
+    //options.put(RepairOption.DATACENTERS_KEY, StringUtils.join(specificDataCenters, ","));
+    //options.put(RepairOption.HOSTS_KEY, StringUtils.join(specificHosts, ","));
+    
+    return ((StorageServiceMBean) ssProxy).repairAsync(keyspace, options);
   }
   
   
@@ -514,8 +512,21 @@ public class JmxProxy implements NotificationListener, AutoCloseable {
     Thread.currentThread().setName(clusterName);
     // we're interested in "repair"
     String type = notification.getType();
-    LOG.debug("Received notification: {}", notification);
+    LOG.debug("Received notification: {} with type {} and repairStatusHandler {}", notification, type, repairStatusHandler);
     if (repairStatusHandler.isPresent() && ("repair").equals(type)) {
+      processOldApiNotification(notification);
+    }
+    
+    if (repairStatusHandler.isPresent() && ("progress").equals(type)) {
+      processNewApiNotification(notification);
+    }
+  }
+  
+  /**
+   * Handles notifications from the old repair API (forceRepairAsync)
+   */
+  private void processOldApiNotification(Notification notification) {
+    try {
       int[] data = (int[]) notification.getUserData();
       // get the repair sequence number
       int repairNo = data[0];
@@ -524,7 +535,30 @@ public class JmxProxy implements NotificationListener, AutoCloseable {
       // this is some text message like "Starting repair...", "Finished repair...", etc.
       String message = notification.getMessage();
       // let the handler process the event
-      repairStatusHandler.get().handle(repairNo, status, message);
+      repairStatusHandler.get().handle(repairNo, Optional.of(status), Optional.absent(), message);
+    } catch (Exception e) {
+      // TODO Auto-generated catch block
+      LOG.error("Error while processing JMX notification", e);
+    }
+  }
+  
+  /**
+   * Handles notifications from the new repair API (repairAsync)
+   */
+  private void processNewApiNotification(Notification notification) {
+    Map<String, Integer> data = (Map<String, Integer>) notification.getUserData();
+    try {
+      // get the repair sequence number
+      int repairNo = Integer.parseInt(((String) notification.getSource()).split(":")[1]);
+      // get the progress status
+      ProgressEventType progress = ProgressEventType.values()[data.get("type")];
+      // this is some text message like "Starting repair...", "Finished repair...", etc.
+      String message = notification.getMessage();
+      // let the handler process the event
+      repairStatusHandler.get().handle(repairNo, Optional.absent(), Optional.of(progress), message);
+    } catch (Exception e) {
+      // TODO Auto-generated catch block
+      LOG.error("Error while processing JMX notification", e);
     }
   }
 

--- a/src/main/java/com/spotify/reaper/cassandra/RepairStatusHandler.java
+++ b/src/main/java/com/spotify/reaper/cassandra/RepairStatusHandler.java
@@ -14,6 +14,10 @@
 package com.spotify.reaper.cassandra;
 
 import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.streaming.StreamEvent;
+import org.apache.cassandra.utils.progress.ProgressEventType;
+
+import com.google.common.base.Optional;
 
 public interface RepairStatusHandler {
 
@@ -24,9 +28,10 @@ public interface RepairStatusHandler {
    * state.
    *
    * @param repairNumber repair sequence number, obtained when triggering a repair
-   * @param status       new status of the repair
+   * @param status       new status of the repair (old API)
+   * @param progress     new status of the repair (new API)
    * @param message      additional information about the repair
    */
-  void handle(int repairNumber, ActiveRepairService.Status status, String message);
+  void handle(int repairNumber, Optional<ActiveRepairService.Status> status, Optional<ProgressEventType> progress, String message);
 
 }

--- a/src/test/java/com/spotify/reaper/unit/service/SegmentRunnerTest.java
+++ b/src/test/java/com/spotify/reaper/unit/service/SegmentRunnerTest.java
@@ -98,7 +98,7 @@ public class SegmentRunnerTest {
                 future.setValue(executor.submit(new Thread() {
                   @Override
                   public void run() {
-                    handler.get().handle(1, ActiveRepairService.Status.STARTED,
+                    handler.get().handle(1, Optional.of(ActiveRepairService.Status.STARTED), Optional.absent(),
                                          "Repair command 1 has started");
                     assertEquals(RepairSegment.State.RUNNING,
                                  context.storage.getRepairSegment(segmentId).get().getState());
@@ -161,18 +161,18 @@ public class SegmentRunnerTest {
                 future.setValue(executor.submit(new Runnable() {
                   @Override
                   public void run() {
-                    handler.get().handle(1, ActiveRepairService.Status.STARTED,
+                    handler.get().handle(1, Optional.of(ActiveRepairService.Status.STARTED), Optional.absent(),
                                          "Repair command 1 has started");
                     assertEquals(RepairSegment.State.RUNNING,
                                  storage.getRepairSegment(segmentId).get().getState());
                     // report about an unrelated repair. Shouldn't affect anything.
-                    handler.get().handle(2, ActiveRepairService.Status.SESSION_FAILED,
+                    handler.get().handle(2, Optional.of(ActiveRepairService.Status.SESSION_FAILED), Optional.absent(),
                                          "Repair command 2 has failed");
-                    handler.get().handle(1, ActiveRepairService.Status.SESSION_SUCCESS,
+                    handler.get().handle(1, Optional.of(ActiveRepairService.Status.SESSION_SUCCESS), Optional.absent(),
                                          "Repair session succeeded in command 1");
                     assertEquals(RepairSegment.State.DONE,
                                  storage.getRepairSegment(segmentId).get().getState());
-                    handler.get().handle(1, ActiveRepairService.Status.FINISHED,
+                    handler.get().handle(1, Optional.of(ActiveRepairService.Status.FINISHED), Optional.absent(),
                                          "Repair command 1 has finished");
                     assertEquals(RepairSegment.State.DONE,
                                  storage.getRepairSegment(segmentId).get().getState());
@@ -235,15 +235,15 @@ public class SegmentRunnerTest {
                 future.setValue(executor.submit(new Runnable() {
                   @Override
                   public void run() {
-                    handler.get().handle(1, ActiveRepairService.Status.STARTED,
+                    handler.get().handle(1, Optional.of(ActiveRepairService.Status.STARTED), Optional.absent(),
                                          "Repair command 1 has started");
                     assertEquals(RepairSegment.State.RUNNING,
                                  storage.getRepairSegment(segmentId).get().getState());
-                    handler.get().handle(1, ActiveRepairService.Status.SESSION_FAILED,
-                                         "Repair command 1 has failed");
+                    handler.get().handle(1, Optional.of(ActiveRepairService.Status.SESSION_FAILED), Optional.absent(),
+                        "Repair command 1 has failed");
                     assertEquals(RepairSegment.State.NOT_STARTED,
                                  storage.getRepairSegment(segmentId).get().getState());
-                    handler.get().handle(1, ActiveRepairService.Status.FINISHED,
+                    handler.get().handle(1, Optional.of(ActiveRepairService.Status.FINISHED), Optional.absent(),
                         "Repair command 1 has finished");
                     assertEquals(RepairSegment.State.NOT_STARTED,
                         storage.getRepairSegment(segmentId).get().getState());


### PR DESCRIPTION
Fix for issue #15 

The old repair API was deprecated since Cassandra 2.1 and will be removed in Cassandra 4.0.
This PR uses the new repair API and notification service for Cassandra 2.1 onwards.