### PR TITLE
Adding support to build cassandra-reaper docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,9 @@ To rebuild both the UI and Reaper :
 
 ```mvn clean package -Pbuild-ui```
 
+To build the docker image :
+
+```mvn clean package docker:build```
 
 ### Running Reaper
 

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,25 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.4.13</version>
+                        <configuration>
+                            <imageName>cassandra-reaper</imageName>
+                            <dockerDirectory>src/main/docker</dockerDirectory>
+                            <buildArgs>
+                                <SHADED_JAR>cassandra-reaper-${project.version}.jar</SHADED_JAR>
+                            </buildArgs>
+                            <resources>
+                                <resource>
+                                    <targetPath>/</targetPath>
+                                    <directory>${project.build.directory}</directory>
+                                    <include>cassandra-reaper-${project.version}.jar</include>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,8 +35,8 @@ ENV REAPER_SEGMENT_COUNT=200 \
     REAPER_CASS_AUTH_PASSWORD="cassandra" \
     REAPER_DB_DRIVER_CLASS="org.h2.Driver" \
     REAPER_DB_URL="jdbc:h2:/var/lib/cassandra-reaper/db;MODE=PostgreSQL" \
-    DB_REAPER_DB_USERNAME="" \
-    DB_REAPER_DB_PASSWORD="" \
+    REAPER_DB_USERNAME="" \
+    REAPER_DB_PASSWORD="" \
     JAVA_OPTS=""
 
 ADD cassandra-reaper.yml /etc/cassandra-reaper.yml
@@ -46,12 +46,8 @@ RUN addgroup -S reaper && \
     adduser -S reaper reaper && \
     apk add --no-cache 'su-exec>=0.2' && \
     mkdir -p /var/lib/cassandra-reaper && \
-    chown reaper:reaper /etc/cassandra-reaper.yml && \
-    chown reaper:reaper /var/lib/cassandra-reaper && \
-    chown reaper:reaper /usr/local/bin/entrypoint.sh && \
-    chown reaper:reaper /usr/local/bin/append-persistence.sh && \
-    chmod u+x /usr/local/bin/entrypoint.sh && \
-    chmod u+x /usr/local/bin/append-persistence.sh
+    chown reaper:reaper /etc/cassandra-reaper.yml /var/lib/cassandra-reaper /usr/local/bin/entrypoint.sh /usr/local/bin/append-persistence.sh && \
+    chmod u+x /usr/local/bin/entrypoint.sh /usr/local/bin/append-persistence.sh
 
 VOLUME /var/lib/cassandra-reaper
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -2,53 +2,60 @@ FROM openjdk:8-jre-alpine
 
 ARG SHADED_JAR
 
-ENV DW_REAPER_SEGMENT_COUNT=200 \
-    DW_REAPER_REPAIR_PARALELLISM=DATACENTER_AWARE \
-    DW_REAPER_REPAIR_INTENSITY=0.9 \
-    DW_REAPER_SCHEDULE_DAYS_BETWEEN=7 \
-    DW_REAPER_REPAIR_RUN_THREADS=15 \
-    DW_REAPER_HANING_REPAIR_TIMEOUT_MINS=30 \
-    DW_REAPER_STORAGE_TYPE=memory \
-    DW_REAPER_ENABLE_CORS=true \
-    DW_REAPER_INCREMENTAL_REPAIR=false \
-    DW_REAPER_ALLOW_UNREACHABLE_NODES=false \
-    DW_REAPER_ENABLE_DYNAMIC_SEEDS=true \
-    DW_REAPER_AUTO_SCHEDULE_ENABLED=false \
-    DW_REAPER_AUTO_SCHEDULE_INITIAL_DELAY_PERIOD=PT15S \
-    DW_REAPER_AUTO_SCHEDULE_PERIOD_BETWEEN_POLLS=PT10M \
-    DW_REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE=PT5M \
-    DW_REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE=PT6H \
-    DW_REAPER_AUTO_SCHEDULE_EXCLUDED_KEYSPACES="[]" \
-    DW_REAPER_JMX_PORTS="{}" \
-    DW_REAPER_LOGGING_ROOT_LEVEL=INFO \
-    DW_REAPER_LOGGERS="{}" \
-    DW_REAPER_LOGGING_FORMAT='"%-6level [%d] [%t] %logger{5} - %msg %n"' \
-    DW_REAPER_APP_PORT=8080 \
-    DW_REAPER_APP_BIND_HOST="0.0.0.0" \
-    DW_REAPER_ADMIN_PORT=8081 \
-    DW_REAPER_ADMIN_BIND_HOST="0.0.0.0" \
-    DW_REAPER_CASS_CLUSTER_NAME="clutername" \
-    DW_REAPER_CASS_CONTACT_POINTS="[]" \
-    DW_REAPER_CASS_KEYSPACE="cassandra-reaper" \
-    DW_REAPER_CASS_AUTH_ENABLED="false" \
-    DW_REAPER_CASS_AUTH_USERNAME="cassandra" \
-    DW_REAPER_CASS_AUTH_PASSWORD="cassandra" \
-    DW_REAPER_DB_DRIVER_CLASS="org.h2.Driver" \
-    DW_REAPER_DB_URL="jdbc:h2:/var/lib/cassandra-reaper/db;MODE=PostgreSQL" \
+ENV REAPER_SEGMENT_COUNT=200 \
+    REAPER_REPAIR_PARALELLISM=DATACENTER_AWARE \
+    REAPER_REPAIR_INTENSITY=0.9 \
+    REAPER_SCHEDULE_DAYS_BETWEEN=7 \
+    REAPER_REPAIR_RUN_THREADS=15 \
+    REAPER_HANING_REPAIR_TIMEOUT_MINS=30 \
+    REAPER_STORAGE_TYPE=memory \
+    REAPER_ENABLE_CORS=true \
+    REAPER_INCREMENTAL_REPAIR=false \
+    REAPER_ALLOW_UNREACHABLE_NODES=false \
+    REAPER_ENABLE_DYNAMIC_SEEDS=true \
+    REAPER_AUTO_SCHEDULE_ENABLED=false \
+    REAPER_AUTO_SCHEDULE_INITIAL_DELAY_PERIOD=PT15S \
+    REAPER_AUTO_SCHEDULE_PERIOD_BETWEEN_POLLS=PT10M \
+    REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE=PT5M \
+    REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE=PT6H \
+    REAPER_AUTO_SCHEDULE_EXCLUDED_KEYSPACES="[]" \
+    REAPER_JMX_PORTS="{}" \
+    REAPER_LOGGING_ROOT_LEVEL=INFO \
+    REAPER_LOGGERS="{}" \
+    REAPER_LOGGING_FORMAT='"%-6level [%d] [%t] %logger{5} - %msg %n"' \
+    REAPER_APP_PORT=8080 \
+    REAPER_APP_BIND_HOST="0.0.0.0" \
+    REAPER_ADMIN_PORT=8081 \
+    REAPER_ADMIN_BIND_HOST="0.0.0.0" \
+    REAPER_CASS_CLUSTER_NAME="clutername" \
+    REAPER_CASS_CONTACT_POINTS="[]" \
+    REAPER_CASS_KEYSPACE="cassandra-reaper" \
+    REAPER_CASS_AUTH_ENABLED="false" \
+    REAPER_CASS_AUTH_USERNAME="cassandra" \
+    REAPER_CASS_AUTH_PASSWORD="cassandra" \
+    REAPER_DB_DRIVER_CLASS="org.h2.Driver" \
+    REAPER_DB_URL="jdbc:h2:/var/lib/cassandra-reaper/db;MODE=PostgreSQL" \
     DB_REAPER_DB_USERNAME="" \
     DB_REAPER_DB_PASSWORD="" \
     JAVA_OPTS=""
 
-ADD cassandra-reaper.yml /root/cassandra-reaper.yml
-ADD entrypoint.sh /root/entrypoint.sh
-ADD append-persistence.sh /root/append-persistence.sh
-RUN mkdir -p /var/lib/cassandra-reaper/data && \
-    chmod u+x /root/entrypoint.sh && \
-    chmod u+x /root/append-persistence.sh
+ADD cassandra-reaper.yml /etc/cassandra-reaper.yml
+ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+ADD append-persistence.sh /usr/local/bin/append-persistence.sh
+RUN addgroup -S reaper && \
+    adduser -S reaper reaper && \
+    apk add --no-cache 'su-exec>=0.2' && \
+    mkdir -p /var/lib/cassandra-reaper && \
+    chown reaper:reaper /etc/cassandra-reaper.yml && \
+    chown reaper:reaper /var/lib/cassandra-reaper && \
+    chown reaper:reaper /usr/local/bin/entrypoint.sh && \
+    chown reaper:reaper /usr/local/bin/append-persistence.sh && \
+    chmod u+x /usr/local/bin/entrypoint.sh && \
+    chmod u+x /usr/local/bin/append-persistence.sh
 
-VOLUME /var/lib/cassandra-reaper/data
+VOLUME /var/lib/cassandra-reaper
 
-ADD ${SHADED_JAR} /root/cassandra-reaper.jar
+ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
 
-ENTRYPOINT ["/root/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["cassandra-reaper"]

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,54 @@
+FROM openjdk:8-jre-alpine
+
+ARG SHADED_JAR
+
+ENV DW_REAPER_SEGMENT_COUNT=200 \
+    DW_REAPER_REPAIR_PARALELLISM=DATACENTER_AWARE \
+    DW_REAPER_REPAIR_INTENSITY=0.9 \
+    DW_REAPER_SCHEDULE_DAYS_BETWEEN=7 \
+    DW_REAPER_REPAIR_RUN_THREADS=15 \
+    DW_REAPER_HANING_REPAIR_TIMEOUT_MINS=30 \
+    DW_REAPER_STORAGE_TYPE=memory \
+    DW_REAPER_ENABLE_CORS=true \
+    DW_REAPER_INCREMENTAL_REPAIR=false \
+    DW_REAPER_ALLOW_UNREACHABLE_NODES=false \
+    DW_REAPER_ENABLE_DYNAMIC_SEEDS=true \
+    DW_REAPER_AUTO_SCHEDULE_ENABLED=false \
+    DW_REAPER_AUTO_SCHEDULE_INITIAL_DELAY_PERIOD=PT15S \
+    DW_REAPER_AUTO_SCHEDULE_PERIOD_BETWEEN_POLLS=PT10M \
+    DW_REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE=PT5M \
+    DW_REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE=PT6H \
+    DW_REAPER_AUTO_SCHEDULE_EXCLUDED_KEYSPACES="[]" \
+    DW_REAPER_JMX_PORTS="{}" \
+    DW_REAPER_LOGGING_ROOT_LEVEL=INFO \
+    DW_REAPER_LOGGERS="{}" \
+    DW_REAPER_LOGGING_FORMAT='"%-6level [%d] [%t] %logger{5} - %msg %n"' \
+    DW_REAPER_APP_PORT=8080 \
+    DW_REAPER_APP_BIND_HOST="0.0.0.0" \
+    DW_REAPER_ADMIN_PORT=8081 \
+    DW_REAPER_ADMIN_BIND_HOST="0.0.0.0" \
+    DW_REAPER_CASS_CLUSTER_NAME="clutername" \
+    DW_REAPER_CASS_CONTACT_POINTS="[]" \
+    DW_REAPER_CASS_KEYSPACE="cassandra-reaper" \
+    DW_REAPER_CASS_AUTH_ENABLED="false" \
+    DW_REAPER_CASS_AUTH_USERNAME="cassandra" \
+    DW_REAPER_CASS_AUTH_PASSWORD="cassandra" \
+    DW_REAPER_DB_DRIVER_CLASS="org.h2.Driver" \
+    DW_REAPER_DB_URL="jdbc:h2:/var/lib/cassandra-reaper/db;MODE=PostgreSQL" \
+    DB_REAPER_DB_USERNAME="" \
+    DB_REAPER_DB_PASSWORD="" \
+    JAVA_OPTS=""
+
+ADD cassandra-reaper.yml /root/cassandra-reaper.yml
+ADD entrypoint.sh /root/entrypoint.sh
+ADD append-persistence.sh /root/append-persistence.sh
+RUN mkdir -p /var/lib/cassandra-reaper/data && \
+    chmod u+x /root/entrypoint.sh && \
+    chmod u+x /root/append-persistence.sh
+
+VOLUME /var/lib/cassandra-reaper/data
+
+ADD ${SHADED_JAR} /root/cassandra-reaper.jar
+
+ENTRYPOINT ["/root/entrypoint.sh"]
+CMD ["cassandra-reaper"]

--- a/src/main/docker/append-persistence.sh
+++ b/src/main/docker/append-persistence.sh
@@ -1,30 +1,30 @@
 #!/bin/sh
 
-case ${DW_REAPER_STORAGE_TYPE} in
+case ${REAPER_STORAGE_TYPE} in
     "cassandra")
-cat <<EOT >> /root/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper.yml
 cassandra:
-  clusterName: ${DW_REAPER_CASS_CLUSTER_NAME}
-  contactPoints: ${DW_REAPER_CASS_CONTACT_POINTS}
-  keyspace: ${DW_REAPER_CASS_KEYSPACE}
+  clusterName: ${REAPER_CASS_CLUSTER_NAME}
+  contactPoints: ${REAPER_CASS_CONTACT_POINTS}
+  keyspace: ${REAPER_CASS_KEYSPACE}
 EOT
 
-if [ "true" = "${DW_REAPER_CASS_AUTH_ENABLED}" ]; then
-cat <<EOT >> /root/cassandra-reaper.yml
+if [ "true" = "${REAPER_CASS_AUTH_ENABLED}" ]; then
+cat <<EOT >> /etc/cassandra-reaper.yml
   authProvider:
     type: plainText
-    username: ${DW_REAPER_CASS_AUTH_USERNAME}
-    password: ${DW_REAPER_CASS_AUTH_PASSWORD}
+    username: ${REAPER_CASS_AUTH_USERNAME}
+    password: ${REAPER_CASS_AUTH_PASSWORD}
 EOT
 fi
     ;;
     "database")
-cat <<EOT >> /root/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper.yml
 database:
-  driverClass: ${DW_REAPER_DB_DRIVER_CLASS}
-  url: ${DW_REAPER_DB_URL}
-  user: ${DW_REAPER_DB_USERNAME}
-  password: ${DW_REAPER_DB_PASSWORD}
+  driverClass: ${REAPER_DB_DRIVER_CLASS}
+  url: ${REAPER_DB_URL}
+  user: ${REAPER_DB_USERNAME}
+  password: ${REAPER_DB_PASSWORD}
 EOT
 
 esac

--- a/src/main/docker/append-persistence.sh
+++ b/src/main/docker/append-persistence.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+case ${DW_REAPER_STORAGE_TYPE} in
+    "cassandra")
+cat <<EOT >> /root/cassandra-reaper.yml
+cassandra:
+  clusterName: ${DW_REAPER_CASS_CLUSTER_NAME}
+  contactPoints: ${DW_REAPER_CASS_CONTACT_POINTS}
+  keyspace: ${DW_REAPER_CASS_KEYSPACE}
+EOT
+
+if [ "true" = "${DW_REAPER_CASS_AUTH_ENABLED}" ]; then
+cat <<EOT >> /root/cassandra-reaper.yml
+  authProvider:
+    type: plainText
+    username: ${DW_REAPER_CASS_AUTH_USERNAME}
+    password: ${DW_REAPER_CASS_AUTH_PASSWORD}
+EOT
+fi
+    ;;
+    "database")
+cat <<EOT >> /root/cassandra-reaper.yml
+database:
+  driverClass: ${DW_REAPER_DB_DRIVER_CLASS}
+  url: ${DW_REAPER_DB_URL}
+  user: ${DW_REAPER_DB_USERNAME}
+  password: ${DW_REAPER_DB_PASSWORD}
+EOT
+
+esac

--- a/src/main/docker/cassandra-reaper.yml
+++ b/src/main/docker/cassandra-reaper.yml
@@ -1,43 +1,43 @@
 
-segmentCount: ${DW_REAPER_SEGMENT_COUNT}
-repairParallelism: ${DW_REAPER_REPAIR_PARALELLISM}
-repairIntensity: ${DW_REAPER_REPAIR_INTENSITY}
-scheduleDaysBetween: ${DW_REAPER_SCHEDULE_DAYS_BETWEEN}
-repairRunThreadCount: ${DW_REAPER_REPAIR_RUN_THREADS}
-hangingRepairTimeoutMins: ${DW_REAPER_HANING_REPAIR_TIMEOUT_MINS}
-storageType: ${DW_REAPER_STORAGE_TYPE}
-enableCrossOrigin: ${DW_REAPER_ENABLE_CORS}
-incrementalRepair: ${DW_REAPER_INCREMENTAL_REPAIR}
-allowUnreachableNodes: ${DW_REAPER_ALLOW_UNREACHABLE_NODES}
-enableDynamicSeedList: ${DW_REAPER_ENABLE_DYNAMIC_SEEDS}
+segmentCount: ${REAPER_SEGMENT_COUNT}
+repairParallelism: ${REAPER_REPAIR_PARALELLISM}
+repairIntensity: ${REAPER_REPAIR_INTENSITY}
+scheduleDaysBetween: ${REAPER_SCHEDULE_DAYS_BETWEEN}
+repairRunThreadCount: ${REAPER_REPAIR_RUN_THREADS}
+hangingRepairTimeoutMins: ${REAPER_HANING_REPAIR_TIMEOUT_MINS}
+storageType: ${REAPER_STORAGE_TYPE}
+enableCrossOrigin: ${REAPER_ENABLE_CORS}
+incrementalRepair: ${REAPER_INCREMENTAL_REPAIR}
+allowUnreachableNodes: ${REAPER_ALLOW_UNREACHABLE_NODES}
+enableDynamicSeedList: ${REAPER_ENABLE_DYNAMIC_SEEDS}
 
 autoScheduling:
-  enabled: ${DW_REAPER_AUTO_SCHEDULE_ENABLED}
-  initialDelayPeriod: ${DW_REAPER_AUTO_SCHEDULE_INITIAL_DELAY_PERIOD}
-  periodBetweenPolls: ${DW_REAPER_AUTO_SCHEDULE_PERIOD_BETWEEN_POLLS}
-  timeBeforeFirstSchedule: ${DW_REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE}
-  scheduleSpreadPeriod: ${DW_REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE}
-  excludedKeyspaces: ${DW_REAPER_AUTO_SCHEDULE_EXCLUDED_KEYSPACES}
+  enabled: ${REAPER_AUTO_SCHEDULE_ENABLED}
+  initialDelayPeriod: ${REAPER_AUTO_SCHEDULE_INITIAL_DELAY_PERIOD}
+  periodBetweenPolls: ${REAPER_AUTO_SCHEDULE_PERIOD_BETWEEN_POLLS}
+  timeBeforeFirstSchedule: ${REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE}
+  scheduleSpreadPeriod: ${REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE}
+  excludedKeyspaces: ${REAPER_AUTO_SCHEDULE_EXCLUDED_KEYSPACES}
 
-jmxPorts: ${DW_REAPER_JMX_PORTS}
+jmxPorts: ${REAPER_JMX_PORTS}
 
 logging:
-  level: ${DW_REAPER_LOGGING_ROOT_LEVEL}
-  loggers: ${DW_REAPER_LOGGERS}
+  level: ${REAPER_LOGGING_ROOT_LEVEL}
+  loggers: ${REAPER_LOGGERS}
   appenders:
     - type: console
-      logFormat: ${DW_REAPER_LOGGING_FORMAT}
+      logFormat: ${REAPER_LOGGING_FORMAT}
 
 server:
   type: default
   applicationConnectors:
     - type: http
-      port: ${DW_REAPER_APP_PORT}
-      bindHost: ${DW_REAPER_APP_BIND_HOST}
+      port: ${REAPER_APP_PORT}
+      bindHost: ${REAPER_APP_BIND_HOST}
   adminConnectors:
     - type: http
-      port: ${DW_REAPER_ADMIN_PORT}
-      bindHost: ${DW_REAPER_ADMIN_BIND_HOST}
+      port: ${REAPER_ADMIN_PORT}
+      bindHost: ${REAPER_ADMIN_BIND_HOST}
   requestLog:
     appenders: []
 

--- a/src/main/docker/cassandra-reaper.yml
+++ b/src/main/docker/cassandra-reaper.yml
@@ -1,0 +1,43 @@
+
+segmentCount: ${DW_REAPER_SEGMENT_COUNT}
+repairParallelism: ${DW_REAPER_REPAIR_PARALELLISM}
+repairIntensity: ${DW_REAPER_REPAIR_INTENSITY}
+scheduleDaysBetween: ${DW_REAPER_SCHEDULE_DAYS_BETWEEN}
+repairRunThreadCount: ${DW_REAPER_REPAIR_RUN_THREADS}
+hangingRepairTimeoutMins: ${DW_REAPER_HANING_REPAIR_TIMEOUT_MINS}
+storageType: ${DW_REAPER_STORAGE_TYPE}
+enableCrossOrigin: ${DW_REAPER_ENABLE_CORS}
+incrementalRepair: ${DW_REAPER_INCREMENTAL_REPAIR}
+allowUnreachableNodes: ${DW_REAPER_ALLOW_UNREACHABLE_NODES}
+enableDynamicSeedList: ${DW_REAPER_ENABLE_DYNAMIC_SEEDS}
+
+autoScheduling:
+  enabled: ${DW_REAPER_AUTO_SCHEDULE_ENABLED}
+  initialDelayPeriod: ${DW_REAPER_AUTO_SCHEDULE_INITIAL_DELAY_PERIOD}
+  periodBetweenPolls: ${DW_REAPER_AUTO_SCHEDULE_PERIOD_BETWEEN_POLLS}
+  timeBeforeFirstSchedule: ${DW_REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE}
+  scheduleSpreadPeriod: ${DW_REAPER_AUTO_SCHEDULE_TIME_BETWEEN_FIRST_SCHEDULE}
+  excludedKeyspaces: ${DW_REAPER_AUTO_SCHEDULE_EXCLUDED_KEYSPACES}
+
+jmxPorts: ${DW_REAPER_JMX_PORTS}
+
+logging:
+  level: ${DW_REAPER_LOGGING_ROOT_LEVEL}
+  loggers: ${DW_REAPER_LOGGERS}
+  appenders:
+    - type: console
+      logFormat: ${DW_REAPER_LOGGING_FORMAT}
+
+server:
+  type: default
+  applicationConnectors:
+    - type: http
+      port: ${DW_REAPER_APP_PORT}
+      bindHost: ${DW_REAPER_APP_BIND_HOST}
+  adminConnectors:
+    - type: http
+      port: ${DW_REAPER_ADMIN_PORT}
+      bindHost: ${DW_REAPER_ADMIN_BIND_HOST}
+  requestLog:
+    appenders: []
+

--- a/src/main/docker/entrypoint.sh
+++ b/src/main/docker/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
 if [ "$1" = 'cassandra-reaper' ]; then
-    /root/append-persistence.sh
-    exec java -jar ${JAVA_OPTS} /root/cassandra-reaper.jar server /root/cassandra-reaper.yml
+    su-exec reaper /usr/local/bin/append-persistence.sh
+    exec su-exec reaper java -jar ${JAVA_OPTS} \
+        /usr/local/lib/cassandra-reaper.jar server /etc/cassandra-reaper.yml
 fi
 
 exec "$@"

--- a/src/main/docker/entrypoint.sh
+++ b/src/main/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$1" = 'cassandra-reaper' ]; then
+    /root/append-persistence.sh
+    exec java -jar ${JAVA_OPTS} /root/cassandra-reaper.jar server /root/cassandra-reaper.yml
+fi
+
+exec "$@"

--- a/src/main/java/com/spotify/reaper/ReaperApplication.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplication.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
 
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.flywaydb.core.Flyway;
@@ -97,6 +99,11 @@ public class ReaperApplication extends Application<ReaperApplicationConfiguratio
   public void initialize(Bootstrap<ReaperApplicationConfiguration> bootstrap) {
     bootstrap.addBundle(new AssetsBundle("/assets/", "/webui", "index.html"));
     bootstrap.getObjectMapper().registerModule(new JavaTimeModule());
+
+    // enable using environment variables in yml files
+    final SubstitutingSourceProvider envSourceProvider = new SubstitutingSourceProvider(
+            bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false));
+    bootstrap.setConfigurationSourceProvider(envSourceProvider);
   }
 
   @Override


### PR DESCRIPTION
Resolves #75 

- Including environment variable substitution functionality for
  application yml

- Including spotify docker build dependency

- Adding initial Dockerfile and supporting startup shell scripts

There are some additional changes I can do but I wanted to get some feedback first. Some ideas that I can include in this or future pull requests.

* Including a docker-compose.yml example that demonstrates multiple configurations
* Update documentation to include all possible environment variable tweaks