### PR TITLE
Ec2MultiRegionAddressTranslator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dropwizard.version>1.1.0</dropwizard.version>
         <dropwizard.cassandra.version>4.1.0</dropwizard.cassandra.version>
         <cassandra.version>2.2.7</cassandra.version>
-        <cucumber.version>1.tered 2.5</cucumber.version>
+        <cucumber.version>1.2.5</cucumber.version>
     </properties>
 
     <dependencies>
@@ -120,11 +120,11 @@
             <exclusions>
                <exclusion>
                   <groupId>org.mockito</groupId>
-                  <artifactId>mockito-core</artifactId>   
+                  <artifactId>mockito-core</artifactId>
                </exclusion>
                <exclusion>
                   <groupId>org.mockito</groupId>
-                  <artifactId>mockito-all</artifactId>   
+                  <artifactId>mockito-all</artifactId>
                </exclusion>
             </exclusions>
         </dependency>
@@ -190,7 +190,7 @@
                           </excludes>
                           <workingDirectory>${project.build.directory}</workingDirectory>
                         </configuration>
-                    </plugin>                
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
@@ -212,9 +212,9 @@
                             </configuration>
                           </execution>
                         </executions>
-                    </plugin>    
+                    </plugin>
                     <plugin>
-                        <!-- To know which version of your application you have deployed on 
+                        <!-- To know which version of your application you have deployed on
                             a machine -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
@@ -228,7 +228,7 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <!-- Creating a fat jar by including all classes required for running 
+                        <!-- Creating a fat jar by including all classes required for running
                             the app -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
@@ -304,7 +304,7 @@
                           </excludes>
                           <workingDirectory>${project.build.directory}</workingDirectory>
                         </configuration>
-                    </plugin>    
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -378,13 +378,13 @@
                             </goals>
                             <configuration>
                               <outputDirectory>src/main/resources/assets</outputDirectory>
-                              <resources>          
+                              <resources>
                                 <resource>
                                   <directory>reaper_ui/build</directory>
                                   <filtering>false</filtering>
                                 </resource>
-                              </resources>              
-                            </configuration>            
+                              </resources>
+                            </configuration>
                           </execution>
                         </executions>
                       </plugin>
@@ -399,7 +399,7 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <!-- To know which version of your application you have deployed on 
+                        <!-- To know which version of your application you have deployed on
                             a machine -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
@@ -413,7 +413,7 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <!-- Creating a fat jar by including all classes required for running 
+                        <!-- Creating a fat jar by including all classes required for running
                             the app -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
@@ -455,5 +455,5 @@
             </build>
         </profile>
     </profiles>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dropwizard.version>1.1.0</dropwizard.version>
         <dropwizard.cassandra.version>4.1.0</dropwizard.cassandra.version>
         <cassandra.version>2.2.7</cassandra.version>
-        <cucumber.version>1.1.5</cucumber.version>
+        <cucumber.version>1.tered 2.5</cucumber.version>
     </properties>
 
     <dependencies>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>21.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>19.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -63,6 +63,12 @@
             <groupId>systems.composable</groupId>
             <artifactId>dropwizard-cassandra</artifactId>
             <version>${dropwizard.cassandra.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cassandra</groupId>

--- a/src/main/java/com/spotify/reaper/ReaperApplication.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplication.java
@@ -33,10 +33,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.spotify.reaper.AppContext;
-import com.spotify.reaper.ReaperApplicationConfiguration;
+
 import com.spotify.reaper.ReaperApplicationConfiguration.JmxCredentials;
-import com.spotify.reaper.ReaperException;
 import com.spotify.reaper.cassandra.JmxConnectionFactory;
 import com.spotify.reaper.resources.ClusterResource;
 import com.spotify.reaper.resources.PingResource;
@@ -139,7 +137,7 @@ public class ReaperApplication extends Application<ReaperApplicationConfiguratio
     }
 
     if(config.useAddressTranslator()) {
-      context.jmxConnectionFactory.setUseAddressTranslator(new EC2MultiRegionAddressTranslator());
+      context.jmxConnectionFactory.setAddressTranslator(new EC2MultiRegionAddressTranslator());
     }
 
     // Enable cross-origin requests for using external GUI applications.

--- a/src/main/java/com/spotify/reaper/ReaperApplication.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplication.java
@@ -27,6 +27,8 @@ import org.flywaydb.core.Flyway;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -134,6 +136,10 @@ public class ReaperApplication extends Application<ReaperApplicationConfiguratio
     if (jmxPorts != null) {
       LOG.debug("using JMX ports mapping: {}", jmxPorts);
       context.jmxConnectionFactory.setJmxPorts(jmxPorts);
+    }
+
+    if(config.useAddressTranslator()) {
+      context.jmxConnectionFactory.setUseAddressTranslator(new EC2MultiRegionAddressTranslator());
     }
 
     // Enable cross-origin requests for using external GUI applications.

--- a/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
@@ -56,6 +56,9 @@ public class ReaperApplicationConfiguration extends Configuration {
   @DefaultValue("7")
   private Integer scheduleDaysBetween;
 
+  @JsonProperty
+  @DefaultValue("false")
+  private Boolean useAddressTranslator;
 
   @JsonProperty
   @NotNull
@@ -212,6 +215,14 @@ public class ReaperApplicationConfiguration extends Configuration {
     return this.enableDynamicSeedList==null?Boolean.TRUE:this.enableDynamicSeedList;
   }
 
+  public void setUseAddressTranslator(Boolean useAddressTranslator) {
+    this.useAddressTranslator = useAddressTranslator;
+  }
+
+  public boolean useAddressTranslator() {
+    return this.useAddressTranslator;
+  }
+
   public static class JmxCredentials {
 
     @JsonProperty
@@ -241,7 +252,6 @@ public class ReaperApplicationConfiguration extends Configuration {
   public void setCassandraFactory(CassandraFactory cassandra) {
       this.cassandra = cassandra;
   }
-
   
   public Boolean getAllowUnreachableNodes() {
     return allowUnreachableNodes;

--- a/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
@@ -58,7 +58,7 @@ public class ReaperApplicationConfiguration extends Configuration {
 
   @JsonProperty
   @DefaultValue("false")
-  private Boolean useAddressTranslator;
+  private boolean useAddressTranslator;
 
   @JsonProperty
   @NotNull

--- a/src/main/java/com/spotify/reaper/cassandra/JmxConnectionFactory.java
+++ b/src/main/java/com/spotify/reaper/cassandra/JmxConnectionFactory.java
@@ -14,6 +14,8 @@
 package com.spotify.reaper.cassandra;
 
 import com.google.common.base.Optional;
+
+import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
 import com.spotify.reaper.ReaperApplicationConfiguration.JmxCredentials;
 import com.spotify.reaper.ReaperException;
 import com.spotify.reaper.core.Cluster;
@@ -34,6 +36,7 @@ public class JmxConnectionFactory {
   private static final Logger LOG = LoggerFactory.getLogger(JmxConnectionFactory.class);
   private Map<String, Integer> jmxPorts;
   private JmxCredentials jmxAuth;
+  private EC2MultiRegionAddressTranslator addressTranslator;
 
   public JmxProxy connect(Optional<RepairStatusHandler> handler, String host)
       throws ReaperException {
@@ -47,7 +50,7 @@ public class JmxConnectionFactory {
       username = jmxAuth.getUsername();
       password = jmxAuth.getPassword();
     }
-    return JmxProxy.connect(handler, host, username, password);
+    return JmxProxy.connect(handler, host, username, password, addressTranslator);
   }
 
   public final JmxProxy connect(String host) throws ReaperException {
@@ -90,5 +93,9 @@ public class JmxConnectionFactory {
 
   public void setJmxAuth(JmxCredentials jmxAuth) {
     this.jmxAuth = jmxAuth;
+  }
+
+  public void setUseAddressTranslator(EC2MultiRegionAddressTranslator addressTranslator) {
+    this.addressTranslator = addressTranslator;
   }
 }

--- a/src/main/java/com/spotify/reaper/cassandra/JmxConnectionFactory.java
+++ b/src/main/java/com/spotify/reaper/cassandra/JmxConnectionFactory.java
@@ -95,7 +95,7 @@ public class JmxConnectionFactory {
     this.jmxAuth = jmxAuth;
   }
 
-  public void setUseAddressTranslator(EC2MultiRegionAddressTranslator addressTranslator) {
+  public void setAddressTranslator(EC2MultiRegionAddressTranslator addressTranslator) {
     this.addressTranslator = addressTranslator;
   }
 }


### PR DESCRIPTION
Enabled the possibility to configure Ec2MultiRegionAddressTranslator for jmx connections.

This is needed for Cassandra Cross AZ deployments where nodes have associated public IPs.

Actually the fix feels a bit hacky but we didn't find any better way without major efforts to make this work. If you have any idea for a better solution let us know.

We basically introduced new property `useAddressTranslator` which is false by default. In order not to instantiate a new instance of the translator each time we are passing one to `JMXConnectionFactory`. 
