### PR TITLE
Add a query logger to the Cassandra storage

### DIFF
--- a/resource/cassandra-reaper-cassandra.yaml
+++ b/resource/cassandra-reaper-cassandra.yaml
@@ -26,6 +26,14 @@ jmxPorts:
 logging:
   level: INFO
   loggers:
+    com.datastax.driver.core.QueryLogger.NORMAL:
+      level: DEBUG
+      additive: false
+      appenders:
+        - type: file
+          currentLogFilename: query-logger.log
+          archivedLogFilenamePattern: query-logger-%d.log.gz
+          archivedFileCount: 2
     io.dropwizard: WARN
     org.eclipse.jetty: WARN
   appenders:

--- a/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.QueryLogger;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
@@ -86,7 +87,7 @@ public class CassandraStorage implements IStorage {
   private PreparedStatement deleteRepairSegmentByRunId;
 
   public CassandraStorage(ReaperApplicationConfiguration config, Environment environment) {
-    cassandra = config.getCassandraFactory().build(environment);
+    cassandra = config.getCassandraFactory().build(environment).register(QueryLogger.builder().build());
     CodecRegistry codecRegistry = cassandra.getConfiguration().getCodecRegistry();
     codecRegistry.register(new DateTimeCodec());
     session = cassandra.connect(config.getCassandraFactory().getKeyspace());


### PR DESCRIPTION
for debugging and profiling.

Example of logging queries to a separate file found in cassandra-reaper-cassandra.yaml

ref: https://github.com/thelastpickle/cassandra-reaper/issues/85