### PR TITLE
Bump aborted runs down in cluster run summary

### DIFF
--- a/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
@@ -203,7 +203,7 @@ public interface IStoragePostgreSQL {
           + "FROM repair_run "
           + "JOIN repair_unit ON repair_unit_id = repair_unit.id "
           + "WHERE repair_unit.cluster_name = :clusterName "
-          + "ORDER BY end_time DESC, start_time DESC "
+          + "ORDER BY COALESCE(end_time, start_time) DESC, start_time DESC "
           + "LIMIT :limit";
 
   static final String SQL_CLUSTER_SCHEDULE_OVERVIEW =


### PR DESCRIPTION
Null fields put old aborted runs high in the sort order for repair
runs history of a cluster. This moves those down to an appropriate
position.

(Port of https://github.com/spotify/cassandra-reaper/pull/151)