### PR TITLE
Cassandra performance: Replace sequence ids with time-based UUIDs

### DIFF
--- a/src/main/java/com/spotify/reaper/core/RepairRun.java
+++ b/src/main/java/com/spotify/reaper/core/RepairRun.java
@@ -14,6 +14,7 @@
 package com.spotify.reaper.core;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
@@ -21,7 +22,7 @@ import org.joda.time.DateTimeComparator;
 
 public class RepairRun implements Comparable<RepairRun> {
 
-  private final long id;
+  private final UUID id;
 
   // IDEA: maybe we want to have start and stop token for parallel runners on same repair run?
   //private final long startToken;
@@ -30,7 +31,7 @@ public class RepairRun implements Comparable<RepairRun> {
   private final String cause;
   private final String owner;
   private final String clusterName;
-  private final long repairUnitId;
+  private final UUID repairUnitId;
   private final RunState runState;
   private final DateTime creationTime;
   private final DateTime startTime;
@@ -41,7 +42,7 @@ public class RepairRun implements Comparable<RepairRun> {
   private final int segmentCount;
   private final RepairParallelism repairParallelism;
 
-  private RepairRun(Builder builder, long id) {
+  private RepairRun(Builder builder, UUID id) {
     this.id = id;
     this.clusterName = builder.clusterName;
     this.repairUnitId = builder.repairUnitId;
@@ -58,11 +59,11 @@ public class RepairRun implements Comparable<RepairRun> {
     this.repairParallelism = builder.repairParallelism;
   }
 
-  public long getId() {
+  public UUID getId() {
     return id;
   }
 
-  public long getRepairUnitId() {
+  public UUID getRepairUnitId() {
     return repairUnitId;
   }
 
@@ -174,7 +175,7 @@ public class RepairRun implements Comparable<RepairRun> {
   public static class Builder {
 
     public final String clusterName;
-    public final long repairUnitId;
+    public final UUID repairUnitId;
     private RunState runState;
     private DateTime creationTime;
     private double intensity;
@@ -188,7 +189,7 @@ public class RepairRun implements Comparable<RepairRun> {
     private int segmentCount;
     private RepairParallelism repairParallelism;
 
-    public Builder(String clusterName, long repairUnitId, DateTime creationTime,
+    public Builder(String clusterName, UUID repairUnitId, DateTime creationTime,
                    double intensity, int segmentCount, RepairParallelism repairParallelism) {
       this.clusterName = clusterName;
       this.repairUnitId = repairUnitId;
@@ -270,7 +271,7 @@ public class RepairRun implements Comparable<RepairRun> {
       return this;
     }
 
-    public RepairRun build(long id) {
+    public RepairRun build(UUID id) {
       return new RepairRun(this, id);
     }
   }

--- a/src/main/java/com/spotify/reaper/core/RepairSchedule.java
+++ b/src/main/java/com/spotify/reaper/core/RepairSchedule.java
@@ -16,19 +16,20 @@ package com.spotify.reaper.core;
 import com.google.common.collect.ImmutableList;
 import com.spotify.reaper.core.RepairSegment.State;
 import com.spotify.reaper.storage.postgresql.LongCollectionSQLType;
+import java.util.UUID;
 
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 
 public class RepairSchedule {
 
-  private final long id;
+  private final UUID id;
 
-  private final long repairUnitId;
+  private final UUID repairUnitId;
   private final State state;
   private final int daysBetween;
   private final DateTime nextActivation;
-  private final ImmutableList<Long> runHistory;
+  private final ImmutableList<UUID> runHistory;
   private final int segmentCount;
   private final RepairParallelism repairParallelism;
   private final double intensity;
@@ -36,7 +37,7 @@ public class RepairSchedule {
   private final String owner;
   private final DateTime pauseTime;
 
-  private RepairSchedule(Builder builder, long id) {
+  private RepairSchedule(Builder builder, UUID id) {
     this.id = id;
     this.repairUnitId = builder.repairUnitId;
     this.state = builder.state;
@@ -51,11 +52,11 @@ public class RepairSchedule {
     this.pauseTime = builder.pauseTime;
   }
 
-  public long getId() {
+  public UUID getId() {
     return id;
   }
 
-  public long getRepairUnitId() {
+  public UUID getRepairUnitId() {
     return repairUnitId;
   }
 
@@ -75,7 +76,7 @@ public class RepairSchedule {
     return nextActivation;
   }
 
-  public ImmutableList<Long> getRunHistory() {
+  public ImmutableList<UUID> getRunHistory() {
     return runHistory;
   }
 
@@ -123,11 +124,11 @@ public class RepairSchedule {
 
   public static class Builder {
 
-    public final long repairUnitId;
+    public final UUID repairUnitId;
     private State state;
     private int daysBetween;
     private DateTime nextActivation;
-    private ImmutableList<Long> runHistory;
+    private ImmutableList<UUID> runHistory;
     private int segmentCount;
     private RepairParallelism repairParallelism;
     private double intensity;
@@ -135,8 +136,8 @@ public class RepairSchedule {
     private String owner;
     private DateTime pauseTime;
 
-    public Builder(long repairUnitId, State state, int daysBetween, DateTime nextActivation,
-                   ImmutableList<Long> runHistory, int segmentCount,
+    public Builder(UUID repairUnitId, State state, int daysBetween, DateTime nextActivation,
+                   ImmutableList<UUID> runHistory, int segmentCount,
                    RepairParallelism repairParallelism,
                    double intensity, DateTime creationTime) {
       this.repairUnitId = repairUnitId;
@@ -181,7 +182,7 @@ public class RepairSchedule {
       return this;
     }
 
-    public Builder runHistory(ImmutableList<Long> runHistory) {
+    public Builder runHistory(ImmutableList<UUID> runHistory) {
       this.runHistory = runHistory;
       return this;
     }
@@ -216,7 +217,7 @@ public class RepairSchedule {
       return this;
     }
 
-    public RepairSchedule build(long id) {
+    public RepairSchedule build(UUID id) {
       return new RepairSchedule(this, id);
     }
   }

--- a/src/main/java/com/spotify/reaper/core/RepairSegment.java
+++ b/src/main/java/com/spotify/reaper/core/RepairSegment.java
@@ -18,12 +18,13 @@ import com.spotify.reaper.service.RingRange;
 import org.joda.time.DateTime;
 
 import java.math.BigInteger;
+import java.util.UUID;
 
 public class RepairSegment {
 
-  private final long id;
-  private final long runId;
-  private final long repairUnitId;
+  private final UUID id;
+  private final UUID runId;
+  private final UUID repairUnitId;
   private final RingRange tokenRange;
   private final int failCount;
   private final State state;
@@ -32,7 +33,7 @@ public class RepairSegment {
   private final DateTime startTime;
   private final DateTime endTime;
 
-  private RepairSegment(Builder builder, long id) {
+  private RepairSegment(Builder builder, UUID id) {
     this.id = id;
     this.runId = builder.runId;
     this.repairUnitId = builder.repairUnitId;
@@ -45,15 +46,15 @@ public class RepairSegment {
     this.endTime = builder.endTime;
   }
 
-  public long getId() {
+  public UUID getId() {
     return id;
   }
 
-  public long getRunId() {
+  public UUID getRunId() {
     return runId;
   }
 
-  public long getRepairUnitId() {
+  public UUID getRepairUnitId() {
     return repairUnitId;
   }
 
@@ -105,9 +106,9 @@ public class RepairSegment {
 
   public static class Builder {
 
-    public final long runId;
+    public final UUID runId;
     public final RingRange tokenRange;
-    private final long repairUnitId;
+    private final UUID repairUnitId;
     private int failCount;
     private State state;
     private String coordinatorHost;
@@ -115,7 +116,7 @@ public class RepairSegment {
     private DateTime startTime;
     private DateTime endTime;
 
-    public Builder(long runId, RingRange tokenRange, long repairUnitId) {
+    public Builder(UUID runId, RingRange tokenRange, UUID repairUnitId) {
       this.runId = runId;
       this.repairUnitId = repairUnitId;
       this.tokenRange = tokenRange;
@@ -165,7 +166,7 @@ public class RepairSegment {
       return this;
     }
 
-    public RepairSegment build(long id) {
+    public RepairSegment build(UUID id) {
       return new RepairSegment(this, id);
     }
   }

--- a/src/main/java/com/spotify/reaper/core/RepairUnit.java
+++ b/src/main/java/com/spotify/reaper/core/RepairUnit.java
@@ -14,16 +14,17 @@
 package com.spotify.reaper.core;
 
 import java.util.Set;
+import java.util.UUID;
 
 public class RepairUnit {
 
-  private final long id;
+  private final UUID id;
   private final String clusterName;
   private final String keyspaceName;
   private final Set<String> columnFamilies;
   private final Boolean incrementalRepair;	
 
-  private RepairUnit(Builder builder, long id) {
+  private RepairUnit(Builder builder, UUID id) {
     this.id = id;
     this.clusterName = builder.clusterName;
     this.keyspaceName = builder.keyspaceName;
@@ -31,7 +32,7 @@ public class RepairUnit {
     this.incrementalRepair = builder.incrementalRepair;
   }
 
-  public long getId() {
+  public UUID getId() {
     return id;
   }
 
@@ -76,7 +77,7 @@ public class RepairUnit {
       incrementalRepair = original.incrementalRepair;
     }
 
-    public RepairUnit build(long id) {
+    public RepairUnit build(UUID id) {
       return new RepairUnit(this, id);
     }
   }

--- a/src/main/java/com/spotify/reaper/resources/CommonTools.java
+++ b/src/main/java/com/spotify/reaper/resources/CommonTools.java
@@ -39,6 +39,7 @@ import com.spotify.reaper.core.RepairSegment;
 import com.spotify.reaper.core.RepairUnit;
 import com.spotify.reaper.service.RingRange;
 import com.spotify.reaper.service.SegmentGenerator;
+import java.util.UUID;
 
 public class CommonTools {
 
@@ -257,7 +258,7 @@ public class CommonTools {
       throws ReaperException {
     RepairSchedule.Builder scheduleBuilder =
         new RepairSchedule.Builder(repairUnit.getId(), RepairSchedule.State.ACTIVE, daysBetween,
-                                   nextActivation, ImmutableList.<Long>of(), segments,
+                                   nextActivation, ImmutableList.<UUID>of(), segments,
                                    repairParallelism, intensity,
                                    DateTime.now());
     scheduleBuilder.owner(owner);

--- a/src/main/java/com/spotify/reaper/resources/RepairRunResource.java
+++ b/src/main/java/com/spotify/reaper/resources/RepairRunResource.java
@@ -56,6 +56,7 @@ import com.spotify.reaper.core.RepairRun.RunState;
 import com.spotify.reaper.core.RepairSegment;
 import com.spotify.reaper.core.RepairUnit;
 import com.spotify.reaper.resources.view.RepairRunStatus;
+import java.util.UUID;
 
 @Path("/repair_run")
 @Produces(MediaType.APPLICATION_JSON)
@@ -253,7 +254,7 @@ public class RepairRunResource {
   @Path("/{id}")
   public Response modifyRunState(
       @Context UriInfo uriInfo,
-      @PathParam("id") Long repairRunId,
+      @PathParam("id") UUID repairRunId,
       @QueryParam("state") Optional<String> state) throws ReaperException {
 
     LOG.info("modify repair run state called with: id = {}, state = {}", repairRunId, state);
@@ -282,7 +283,7 @@ public class RepairRunResource {
     Collection<RepairRun> repairRuns = context.storage.getRepairRunsForUnit(repairRun.get().getRepairUnitId());
     
     for(RepairRun run:repairRuns){
-    	if(run.getId()!=repairRunId && run.getRunState().equals(RunState.RUNNING)){
+    	if(!run.getId().equals(repairRunId) && run.getRunState().equals(RunState.RUNNING)){
     		String errMsg = "repair unit already has run " + run.getId() + " in RUNNING state";
 		    LOG.error(errMsg);
 		    return Response.status(Response.Status.CONFLICT).entity(errMsg).build();
@@ -373,7 +374,7 @@ public class RepairRunResource {
    */
   @GET
   @Path("/{id}")
-  public Response getRepairRun(@PathParam("id") Long repairRunId) {
+  public Response getRepairRun(@PathParam("id") UUID repairRunId) {
     LOG.debug("get repair_run called with: id = {}", repairRunId);
     Optional<RepairRun> repairRun = context.storage.getRepairRun(repairRunId);
     if (repairRun.isPresent()) {
@@ -497,7 +498,7 @@ public class RepairRunResource {
    */
   @DELETE
   @Path("/{id}")
-  public Response deleteRepairRun(@PathParam("id") Long runId,
+  public Response deleteRepairRun(@PathParam("id") UUID runId,
                                   @QueryParam("owner") Optional<String> owner) {
     LOG.info("delete repair run called with runId: {}, and owner: {}", runId, owner);
     if (!owner.isPresent()) {

--- a/src/main/java/com/spotify/reaper/resources/RepairScheduleResource.java
+++ b/src/main/java/com/spotify/reaper/resources/RepairScheduleResource.java
@@ -52,6 +52,7 @@ import com.spotify.reaper.core.RepairSchedule;
 import com.spotify.reaper.core.RepairUnit;
 import com.spotify.reaper.resources.view.RepairScheduleStatus;
 import com.spotify.reaper.service.SchedulingManager;
+import java.util.UUID;
 
 @Path("/repair_schedule")
 @Produces(MediaType.APPLICATION_JSON)
@@ -212,7 +213,7 @@ public class RepairScheduleResource {
   @Path("/{id}")
   public Response modifyState(
       @Context UriInfo uriInfo,
-      @PathParam("id") Long repairScheduleId,
+      @PathParam("id") UUID repairScheduleId,
       @QueryParam("state") Optional<String> state) {
 
     LOG.info("modify repair schedule state called with: id = {}, state = {}",
@@ -290,7 +291,7 @@ public class RepairScheduleResource {
    */
   @GET
   @Path("/{id}")
-  public Response getRepairSchedule(@PathParam("id") Long repairScheduleId) {
+  public Response getRepairSchedule(@PathParam("id") UUID repairScheduleId) {
     LOG.debug("get repair_schedule called with: id = {}", repairScheduleId);
     Optional<RepairSchedule> repairSchedule = context.storage.getRepairSchedule(repairScheduleId);
     if (repairSchedule.isPresent()) {
@@ -399,7 +400,7 @@ public class RepairScheduleResource {
    */
   @DELETE
   @Path("/{id}")
-  public Response deleteRepairSchedule(@PathParam("id") Long repairScheduleId,
+  public Response deleteRepairSchedule(@PathParam("id") UUID repairScheduleId,
       @QueryParam("owner") Optional<String> owner) {
     LOG.info("delete repair schedule called with repairScheduleId: {}, and owner: {}",
         repairScheduleId, owner);

--- a/src/main/java/com/spotify/reaper/resources/view/RepairRunStatus.java
+++ b/src/main/java/com/spotify/reaper/resources/view/RepairRunStatus.java
@@ -26,6 +26,7 @@ import org.joda.time.Duration;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * Contains the data to be shown when querying repair run status.
@@ -39,7 +40,7 @@ public class RepairRunStatus {
   private String owner;
 
   @JsonProperty
-  private long id;
+  private UUID id;
 
   @JsonProperty("cluster_name")
   private String clusterName;
@@ -95,7 +96,7 @@ public class RepairRunStatus {
   public RepairRunStatus() {
   }
 
-  public RepairRunStatus(long runId, String clusterName, String keyspaceName,
+  public RepairRunStatus(UUID runId, String clusterName, String keyspaceName,
       Collection<String> columnFamilies, int segmentsRepaired, int totalSegments,
       RepairRun.RunState state, DateTime startTime, DateTime endTime, String cause, String owner,
       String lastEvent, DateTime creationTime, DateTime pauseTime, double intensity, boolean incrementalRepair,
@@ -229,11 +230,11 @@ public class RepairRunStatus {
     this.owner = owner;
   }
 
-  public long getId() {
+  public UUID getId() {
     return id;
   }
 
-  public void setId(long id) {
+  public void setId(UUID id) {
     this.id = id;
   }
 

--- a/src/main/java/com/spotify/reaper/resources/view/RepairScheduleStatus.java
+++ b/src/main/java/com/spotify/reaper/resources/view/RepairScheduleStatus.java
@@ -24,11 +24,12 @@ import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.Collection;
+import java.util.UUID;
 
 public class RepairScheduleStatus {
 
   @JsonProperty
-  private long id;
+  private UUID id;
 
   @JsonProperty
   private String owner;
@@ -75,7 +76,7 @@ public class RepairScheduleStatus {
   public RepairScheduleStatus() {
   }
 
-  public RepairScheduleStatus(long id, String owner, String clusterName, String keyspaceName,
+  public RepairScheduleStatus(UUID id, String owner, String clusterName, String keyspaceName,
       Collection<String> columnFamilies, RepairSchedule.State state,
       DateTime creationTime, DateTime nextActivation,
       DateTime pauseTime, double intensity, boolean incrementalRepair, int segmentCount, RepairParallelism repairParallelism,
@@ -115,11 +116,11 @@ public class RepairScheduleStatus {
     );
   }
 
-  public long getId() {
+  public UUID getId() {
     return id;
   }
 
-  public void setId(long id) {
+  public void setId(UUID id) {
     this.id = id;
   }
 

--- a/src/main/java/com/spotify/reaper/service/RepairManager.java
+++ b/src/main/java/com/spotify/reaper/service/RepairManager.java
@@ -21,6 +21,7 @@ import com.spotify.reaper.ReaperException;
 import com.spotify.reaper.cassandra.JmxProxy;
 import com.spotify.reaper.core.RepairRun;
 import com.spotify.reaper.core.RepairSegment;
+import java.util.UUID;
 
 public class RepairManager {
 
@@ -36,7 +37,7 @@ public class RepairManager {
 
   // Caching all active RepairRunners.
   @VisibleForTesting
-  public Map<Long, RepairRunner> repairRunners = Maps.newConcurrentMap();
+  public Map<UUID, RepairRunner> repairRunners = Maps.newConcurrentMap();
 
   public void initializeThreadPool(int threadAmount, long repairTimeout,
       TimeUnit repairTimeoutTimeUnit, long retryDelay,
@@ -81,7 +82,7 @@ public class RepairManager {
 
   public RepairRun startRepairRun(AppContext context, RepairRun runToBeStarted) throws ReaperException {
     assert null != executor : "you need to initialize the thread pool first";
-    long runId = runToBeStarted.getId();
+    UUID runId = runToBeStarted.getId();
     LOG.info("Starting a run with id #{} with current state '{}'",
         runId, runToBeStarted.getRunState());
     switch (runToBeStarted.getRunState()) {
@@ -128,7 +129,7 @@ public class RepairManager {
     }
   }
 
-  private void startRunner(AppContext context, long runId) {
+  private void startRunner(AppContext context, UUID runId) {
     if (!repairRunners.containsKey(runId)) {
       LOG.info("scheduling repair for repair run #{}", runId);
       try {

--- a/src/main/java/com/spotify/reaper/service/SchedulingManager.java
+++ b/src/main/java/com/spotify/reaper/service/SchedulingManager.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.UUID;
 
 public class SchedulingManager extends TimerTask {
 
@@ -73,7 +74,7 @@ public class SchedulingManager extends TimerTask {
   @Override
   public void run() {
     LOG.debug("Checking for repair schedules...");
-    long lastId = -1;
+    UUID lastId = null;
     try {
       Collection<RepairSchedule> schedules = context.storage.getAllRepairSchedules();
       boolean anyRunStarted = false;
@@ -130,7 +131,7 @@ public class SchedulingManager extends TimerTask {
       if (startNewRun) {
         try {
           RepairRun startedRun = startNewRunForUnit(schedule, repairUnit);
-          ImmutableList<Long> newRunHistory = new ImmutableList.Builder<Long>()
+          ImmutableList<UUID> newRunHistory = new ImmutableList.Builder<UUID>()
               .addAll(schedule.getRunHistory()).add(startedRun.getId()).build();
           context.storage.updateRepairSchedule(schedule.with()
               .runHistory(newRunHistory)

--- a/src/main/java/com/spotify/reaper/service/SegmentRunner.java
+++ b/src/main/java/com/spotify/reaper/service/SegmentRunner.java
@@ -48,6 +48,7 @@ import com.spotify.reaper.core.RepairSegment;
 import com.spotify.reaper.core.RepairUnit;
 import com.spotify.reaper.utils.SimpleCondition;
 import com.sun.management.UnixOperatingSystemMXBean;
+import java.util.UUID;
 
 public final class SegmentRunner implements RepairStatusHandler, Runnable {
 
@@ -59,7 +60,7 @@ public final class SegmentRunner implements RepairStatusHandler, Runnable {
       Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
 
   private final AppContext context;
-  private final long segmentId;
+  private final UUID segmentId;
   private final Condition condition = new SimpleCondition();
   private final Collection<String> potentialCoordinators;
   private final long timeoutMillis;
@@ -73,9 +74,9 @@ public final class SegmentRunner implements RepairStatusHandler, Runnable {
 
   // Caching all active SegmentRunners.
   @VisibleForTesting
-  public static Map<Long, SegmentRunner> segmentRunners = Maps.newConcurrentMap();
+  public static Map<UUID, SegmentRunner> segmentRunners = Maps.newConcurrentMap();
 
-  public SegmentRunner(AppContext context, long segmentId, Collection<String> potentialCoordinators,
+  public SegmentRunner(AppContext context, UUID segmentId, Collection<String> potentialCoordinators,
       long timeoutMillis, double intensity, RepairParallelism validationParallelism,
       String clusterName, RepairUnit repairUnit, RepairRunner repairRunner) {
     this.context = context;
@@ -209,7 +210,7 @@ public final class SegmentRunner implements RepairStatusHandler, Runnable {
             .coordinatorHost(coordinator.getHost())
             .repairCommandId(commandId)
             .build(segmentId));
-        String eventMsg = String.format("Triggered repair of segment %d via host %s",
+        String eventMsg = String.format("Triggered repair of segment %s via host %s",
             segment.getId(), coordinator.getHost());
         repairRunner.updateLastEvent(eventMsg);
         LOG.info("Repair for segment {} started, status wait will timeout in {} millis", segmentId,
@@ -354,7 +355,7 @@ public final class SegmentRunner implements RepairStatusHandler, Runnable {
     
   }
 
-  private boolean repairHasSegmentRunning(long repairRunId) {
+  private boolean repairHasSegmentRunning(UUID repairRunId) {
 	  Collection<RepairSegment> segments = context.storage.getRepairSegmentsForRun(repairRunId);
 	  for(RepairSegment segment:segments) {
 		  if(segment.getState() == RepairSegment.State.RUNNING) {

--- a/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -9,8 +9,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -24,6 +22,7 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
@@ -44,6 +43,7 @@ import com.spotify.reaper.resources.view.RepairScheduleStatus;
 import com.spotify.reaper.service.RepairParameters;
 import com.spotify.reaper.service.RingRange;
 import com.spotify.reaper.storage.cassandra.DateTimeCodec;
+import com.spotify.reaper.storage.cassandra.Migration003;
 
 import org.apache.cassandra.repair.RepairParallelism;
 import org.cognitor.cassandra.migration.Database;
@@ -57,10 +57,6 @@ public class CassandraStorage implements IStorage {
   private static final Logger LOG = LoggerFactory.getLogger(CassandraStorage.class);
   com.datastax.driver.core.Cluster cassandra = null;
   Session session;
-
-  /** simple cache of repair_id.
-   * not accurate, only provides a floor value to shortcut looking for next appropriate id */
-  private final ConcurrentMap<String,Long> repairIds = new ConcurrentHashMap<>();
 
   /* Simple statements */
   private final String getClustersStmt = "SELECT * FROM cluster";
@@ -92,9 +88,6 @@ public class CassandraStorage implements IStorage {
   private PreparedStatement deleteRepairScheduleByClusterAndKsPrepStmt;
   private PreparedStatement deleteRepairSegmentPrepStmt;
   private PreparedStatement deleteRepairSegmentByRunId;
-  private PreparedStatement insertRepairId;
-  private PreparedStatement selectRepairId;
-  private PreparedStatement updateRepairId;
 
   public CassandraStorage(ReaperApplicationConfiguration config, Environment environment) {
     cassandra = config.getCassandraFactory().build(environment).register(QueryLogger.builder().build());
@@ -106,6 +99,7 @@ public class CassandraStorage implements IStorage {
     Database database = new Database(cassandra, config.getCassandraFactory().getKeyspace());
     MigrationTask migration = new MigrationTask(database, new MigrationRepository("db/cassandra"));
     migration.migrate();
+    Migration003.migrate(session);
         
     prepareStatements();
   }
@@ -125,21 +119,18 @@ public class CassandraStorage implements IStorage {
     deleteRepairRunByUnitPrepStmt = session.prepare("DELETE FROM repair_run_by_unit WHERE id = ? and repair_unit_id= ?");
     deleteRepairSegmentPrepStmt = session.prepare("DELETE FROM repair_segment WHERE id = ?");
     deleteRepairSegmentByRunId = session.prepare("DELETE FROM repair_segment_by_run_id WHERE run_id = ?");
-    insertRepairUnitPrepStmt = session.prepare("INSERT INTO repair_unit(id, cluster_name, keyspace_name, column_families, incremental_repair) VALUES(?, ?, ?, ?, ?)");
-    getRepairUnitPrepStmt = session.prepare("SELECT * FROM repair_unit WHERE id = ?");
+    insertRepairUnitPrepStmt = session.prepare("INSERT INTO repair_unit_v1(id, cluster_name, keyspace_name, column_families, incremental_repair) VALUES(?, ?, ?, ?, ?)");
+    getRepairUnitPrepStmt = session.prepare("SELECT * FROM repair_unit_v1 WHERE id = ?");
     insertRepairSegmentPrepStmt = session.prepare("INSERT INTO repair_segment(id, repair_unit_id, run_id, start_token, end_token, state, coordinator_host, start_time, end_time, fail_count) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
     getRepairSegmentPrepStmt = session.prepare("SELECT * FROM repair_segment WHERE id = ?");
     insertRepairSegmentByRunPrepStmt = session.prepare("INSERT INTO repair_segment_by_run_id(run_id, segment_id) VALUES(?, ?)");
     getRepairSegmentByRunIdPrepStmt = session.prepare("SELECT * FROM repair_segment_by_run_id WHERE run_id = ?");
-    insertRepairSchedulePrepStmt = session.prepare("INSERT INTO repair_schedule(id, repair_unit_id, state, days_between, next_activation, run_history, segment_count, repair_parallelism, intensity, creation_time, owner, pause_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-    getRepairSchedulePrepStmt = session.prepare("SELECT * FROM repair_schedule WHERE id = ?");
+    insertRepairSchedulePrepStmt = session.prepare("INSERT INTO repair_schedule_v1(id, repair_unit_id, state, days_between, next_activation, run_history, segment_count, repair_parallelism, intensity, creation_time, owner, pause_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    getRepairSchedulePrepStmt = session.prepare("SELECT * FROM repair_schedule_v1 WHERE id = ?");
     insertRepairScheduleByClusterAndKsPrepStmt = session.prepare("INSERT INTO repair_schedule_by_cluster_and_keyspace(cluster_name, keyspace_name, repair_schedule_id) VALUES(?, ?, ?)"); 
     getRepairScheduleByClusterAndKsPrepStmt = session.prepare("SELECT repair_schedule_id FROM repair_schedule_by_cluster_and_keyspace WHERE cluster_name = ? and keyspace_name = ?");
-    deleteRepairSchedulePrepStmt = session.prepare("DELETE FROM repair_schedule WHERE id = ?");
+    deleteRepairSchedulePrepStmt = session.prepare("DELETE FROM repair_schedule_v1 WHERE id = ?");
     deleteRepairScheduleByClusterAndKsPrepStmt = session.prepare("DELETE FROM repair_schedule_by_cluster_and_keyspace WHERE cluster_name = ? and keyspace_name = ? and repair_schedule_id = ?");
-    insertRepairId = session.prepare("INSERT INTO repair_id (id_type, id) VALUES(?, 0) IF NOT EXISTS");
-    selectRepairId = session.prepare("SELECT id FROM repair_id WHERE id_type = ?");
-    updateRepairId = session.prepare("UPDATE repair_id SET id=? WHERE id_type =? IF id = ?");
   }
 
   @Override
@@ -192,7 +183,7 @@ public class CassandraStorage implements IStorage {
 
   @Override
   public RepairRun addRepairRun(Builder repairRun) {
-    RepairRun newRepairRun = repairRun.build(getNewRepairId("repair_run"));
+    RepairRun newRepairRun = repairRun.build(UUIDs.timeBased());
     BatchStatement batch = new BatchStatement();
     batch.add(insertRepairRunPrepStmt.bind(newRepairRun.getId(), 
         newRepairRun.getClusterName(), 
@@ -222,7 +213,7 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairRun> getRepairRun(long id) {
+  public Optional<RepairRun> getRepairRun(UUID id) {
     RepairRun repairRun = null;
     Row repairRunResult = session.execute(getRepairRunPrepStmt.bind(id)).one();
     if(repairRunResult != null){
@@ -237,9 +228,9 @@ public class CassandraStorage implements IStorage {
     List<ResultSetFuture> repairRunFutures = Lists.<ResultSetFuture>newArrayList();
 
     // Grab all ids for the given cluster name
-    Collection<Long> repairRunIds = getRepairRunIdsForCluster(clusterName);
+    Collection<UUID> repairRunIds = getRepairRunIdsForCluster(clusterName);
     // Grab repair runs asynchronously for all the ids returned by the index table
-    for(Long repairRunId:repairRunIds){
+    for(UUID repairRunId:repairRunIds){
       repairRunFutures.add(session.executeAsync(getRepairRunPrepStmt.bind(repairRunId)));
     }
 
@@ -247,7 +238,7 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public Collection<RepairRun> getRepairRunsForUnit(long repairUnitId) {
+  public Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId) {
     Collection<RepairRun> repairRuns = Lists.<RepairRun>newArrayList();
     List<ResultSetFuture> repairRunFutures = Lists.<ResultSetFuture>newArrayList();
 
@@ -256,7 +247,7 @@ public class CassandraStorage implements IStorage {
 
     // Grab repair runs asynchronously for all the ids returned by the index table
     for(Row repairRunId:repairRunIds){
-      repairRunFutures.add(session.executeAsync(getRepairRunPrepStmt.bind(repairRunId.getLong("id"))));
+      repairRunFutures.add(session.executeAsync(getRepairRunPrepStmt.bind(repairRunId.getUUID("id"))));
     }
 
     repairRuns = getRepairRunsAsync(repairRunFutures);
@@ -278,7 +269,7 @@ public class CassandraStorage implements IStorage {
     for(ResultSetFuture repairRunFuture:repairRunFutures){
       Row repairRunResult = repairRunFuture.getUninterruptibly().one();
       if(repairRunResult != null){
-        RepairRun repairRun = buildRepairRunFromRow(repairRunResult, repairRunResult.getLong("id"));
+        RepairRun repairRun = buildRepairRunFromRow(repairRunResult, repairRunResult.getUUID("id"));
         repairRuns.add(repairRun);
       }
     }
@@ -294,7 +285,7 @@ public class CassandraStorage implements IStorage {
     ResultSet repairRunResults = session.execute("SELECT * FROM repair_run");
     for(Row repairRun:repairRunResults){
       if(RunState.valueOf(repairRun.getString("state")).equals(runState)){
-        repairRuns.add(buildRepairRunFromRow(repairRun, repairRun.getLong("id")));
+        repairRuns.add(buildRepairRunFromRow(repairRun, repairRun.getUUID("id")));
       }
     }
 
@@ -302,7 +293,7 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairRun> deleteRepairRun(long id) {
+  public Optional<RepairRun> deleteRepairRun(UUID id) {
     Optional<RepairRun> repairRun = getRepairRun(id);
     if(repairRun.isPresent()){
       BatchStatement batch = new BatchStatement();
@@ -330,14 +321,14 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public RepairUnit addRepairUnit(com.spotify.reaper.core.RepairUnit.Builder newRepairUnit) {
-    RepairUnit repairUnit = newRepairUnit.build(getNewRepairId("repair_unit"));
+  public RepairUnit addRepairUnit(RepairUnit.Builder newRepairUnit) {
+    RepairUnit repairUnit = newRepairUnit.build(UUIDs.timeBased());
     session.execute(insertRepairUnitPrepStmt.bind(repairUnit.getId(), repairUnit.getClusterName(), repairUnit.getKeyspaceName(), repairUnit.getColumnFamilies(), repairUnit.getIncrementalRepair()));
     return repairUnit;
   }
 
   @Override
-  public Optional<RepairUnit> getRepairUnit(long id) {
+  public Optional<RepairUnit> getRepairUnit(UUID id) {
     RepairUnit repairUnit = null;
     Row repairUnitRow = session.execute(getRepairUnitPrepStmt.bind(id)).one();
     if(repairUnitRow!=null){
@@ -350,12 +341,12 @@ public class CassandraStorage implements IStorage {
   public Optional<RepairUnit> getRepairUnit(String cluster, String keyspace, Set<String> columnFamilyNames) {
     // brute force again
     RepairUnit repairUnit=null;
-    ResultSet results = session.execute("SELECT * FROM repair_unit");		
+    ResultSet results = session.execute("SELECT * FROM repair_unit_v1");
     for(Row repairUnitRow:results){
       if(repairUnitRow.getString("cluster_name").equals(cluster)
           && repairUnitRow.getString("keyspace_name").equals(keyspace)
           && repairUnitRow.getSet("column_families", String.class).equals(columnFamilyNames)){
-        repairUnit = new RepairUnit.Builder(repairUnitRow.getString("cluster_name"), repairUnitRow.getString("keyspace_name"), repairUnitRow.getSet("column_families", String.class), repairUnitRow.getBool("incremental_repair")).build(repairUnitRow.getLong("id"));
+        repairUnit = new RepairUnit.Builder(repairUnitRow.getString("cluster_name"), repairUnitRow.getString("keyspace_name"), repairUnitRow.getSet("column_families", String.class), repairUnitRow.getBool("incremental_repair")).build(repairUnitRow.getUUID("id"));
         // exit the loop once we find a match
         break;
       }
@@ -365,11 +356,11 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public void addRepairSegments(Collection<com.spotify.reaper.core.RepairSegment.Builder> newSegments, long runId) {
+  public void addRepairSegments(Collection<RepairSegment.Builder> newSegments, UUID runId) {
     List<ResultSetFuture> insertFutures = Lists.<ResultSetFuture>newArrayList();
     BatchStatement batch = new BatchStatement();
     for(com.spotify.reaper.core.RepairSegment.Builder builder:newSegments){
-      RepairSegment segment = builder.build(getNewRepairId("repair_segment"));
+      RepairSegment segment = builder.build(UUIDs.timeBased());
       insertFutures.add(session.executeAsync(insertRepairSegmentPrepStmt.bind(segment.getId(), segment.getRepairUnitId(), segment.getRunId(), segment.getStartToken(), segment.getEndToken(), segment.getState().ordinal(), segment.getCoordinatorHost(), segment.getStartTime(), segment.getEndTime(), segment.getFailCount())));
       batch.add(insertRepairSegmentByRunPrepStmt.bind(segment.getRunId(), segment.getId()));
       if(insertFutures.size()%100==0){
@@ -404,7 +395,7 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairSegment> getRepairSegment(long id) {
+  public Optional<RepairSegment> getRepairSegment(UUID id) {
     RepairSegment segment = null;
     Row segmentRow = session.execute(getRepairSegmentPrepStmt.bind(id)).one();
     if(segmentRow != null){
@@ -415,7 +406,7 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public Collection<RepairSegment> getRepairSegmentsForRun(long runId) {
+  public Collection<RepairSegment> getRepairSegmentsForRun(UUID runId) {
     List<ResultSetFuture> segmentsFuture = Lists.newArrayList();
     Collection<RepairSegment> segments = Lists.newArrayList();
 
@@ -424,7 +415,7 @@ public class CassandraStorage implements IStorage {
     int i=0;
     for(Row segmentIdResult:segmentsIdResultSet) {
       // Then get segments by id
-      segmentsFuture.add(session.executeAsync(getRepairSegmentPrepStmt.bind(segmentIdResult.getLong("segment_id"))));
+      segmentsFuture.add(session.executeAsync(getRepairSegmentPrepStmt.bind(segmentIdResult.getUUID("segment_id"))));
       i++;
       if(i%100==0 || segmentsIdResultSet.isFullyFetched()) {
         segments.addAll(fetchRepairSegmentFromFutures(segmentsFuture));
@@ -450,20 +441,23 @@ public class CassandraStorage implements IStorage {
   }
 
   private RepairSegment createRepairSegmentFromRow(Row segmentRow){
-    return createRepairSegmentFromRow(segmentRow, segmentRow.getLong("id"));
+    return createRepairSegmentFromRow(segmentRow, segmentRow.getUUID("id"));
   }
-  private RepairSegment createRepairSegmentFromRow(Row segmentRow, long segmentId){
-    return new RepairSegment.Builder(segmentRow.getLong("run_id"), new RingRange(new BigInteger(segmentRow.getVarint("start_token") +""), new BigInteger(segmentRow.getVarint("end_token")+"")), segmentRow.getLong("repair_unit_id"))
+  private RepairSegment createRepairSegmentFromRow(Row segmentRow, UUID segmentId){
+    return new RepairSegment.Builder(
+            segmentRow.getUUID("run_id"),
+            new RingRange(new BigInteger(segmentRow.getVarint("start_token") +""), new BigInteger(segmentRow.getVarint("end_token")+"")),
+            segmentRow.getUUID("repair_unit_id"))
         .coordinatorHost(segmentRow.getString("coordinator_host"))
         .endTime(new DateTime(segmentRow.getTimestamp("end_time")))
         .failCount(segmentRow.getInt("fail_count"))
         .startTime(new DateTime(segmentRow.getTimestamp("start_time")))
         .state(State.values()[segmentRow.getInt("state")])
-        .build(segmentRow.getLong("id"));
+        .build(segmentRow.getUUID("id"));
   }
 
 
-  public Optional<RepairSegment> getSegment(long runId, Optional<RingRange> range){
+  public Optional<RepairSegment> getSegment(UUID runId, Optional<RingRange> range){
     RepairSegment segment = null;
     List<RepairSegment> segments = Lists.<RepairSegment>newArrayList();
     segments.addAll(getRepairSegmentsForRun(runId));
@@ -492,17 +486,17 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairSegment> getNextFreeSegment(long runId) {
+  public Optional<RepairSegment> getNextFreeSegment(UUID runId) {
     return getSegment(runId, Optional.<RingRange>absent());
   }
 
   @Override
-  public Optional<RepairSegment> getNextFreeSegmentInRange(long runId, RingRange range) {
+  public Optional<RepairSegment> getNextFreeSegmentInRange(UUID runId, RingRange range) {
     return getSegment(runId, Optional.fromNullable(range));
   }
 
   @Override
-  public Collection<RepairSegment> getSegmentsWithState(long runId, State segmentState) {
+  public Collection<RepairSegment> getSegmentsWithState(UUID runId, State segmentState) {
     Collection<RepairSegment> foundSegments = Lists.<RepairSegment>newArrayList();
     List<RepairSegment> segments = Lists.<RepairSegment>newArrayList();
 
@@ -537,29 +531,29 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public Collection<Long> getRepairRunIdsForCluster(String clusterName) {
-    Collection<Long> repairRunIds = Lists.<Long>newArrayList();
+  public Collection<UUID> getRepairRunIdsForCluster(String clusterName) {
+    Collection<UUID> repairRunIds = Lists.<UUID>newArrayList();
     ResultSet results = session.execute(getRepairRunForClusterPrepStmt.bind(clusterName));
     for(Row result:results){
-      repairRunIds.add(result.getLong("id"));
+      repairRunIds.add(result.getUUID("id"));
     }
     return repairRunIds;
   }
 
   @Override
-  public int getSegmentAmountForRepairRun(long runId) {
+  public int getSegmentAmountForRepairRun(UUID runId) {
     return getRepairSegmentsForRun(runId).size();
 
   }
 
   @Override
-  public int getSegmentAmountForRepairRunWithState(long runId, State state) {
+  public int getSegmentAmountForRepairRunWithState(UUID runId, State state) {
     return getSegmentsWithState(runId, state).size();
   }
 
   @Override
   public RepairSchedule addRepairSchedule(com.spotify.reaper.core.RepairSchedule.Builder repairSchedule) {
-    RepairSchedule schedule = repairSchedule.build(getNewRepairId("repairSchedule"));
+    RepairSchedule schedule = repairSchedule.build(UUIDs.timeBased());
     updateRepairSchedule(schedule);
 
     return schedule;
@@ -568,7 +562,7 @@ public class CassandraStorage implements IStorage {
 
 
   @Override
-  public Optional<RepairSchedule> getRepairSchedule(long repairScheduleId) {
+  public Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId) {
     RepairSchedule schedule = null;
     Row sched = session.execute(getRepairSchedulePrepStmt.bind(repairScheduleId)).one();
     if(sched!=null){
@@ -578,17 +572,17 @@ public class CassandraStorage implements IStorage {
   }
 
   private RepairSchedule createRepairScheduleFromRow(Row repairScheduleRow){
-    return new RepairSchedule.Builder(repairScheduleRow.getLong("repair_unit_id"), 
+    return new RepairSchedule.Builder(repairScheduleRow.getUUID("repair_unit_id"),
         RepairSchedule.State.valueOf(repairScheduleRow.getString("state")), 
         repairScheduleRow.getInt("days_between"), 
         new DateTime(repairScheduleRow.getTimestamp("next_activation")), 
-        ImmutableList.copyOf(repairScheduleRow.getSet("run_history", Long.class)), 
+        ImmutableList.copyOf(repairScheduleRow.getSet("run_history", UUID.class)),
         repairScheduleRow.getInt("segment_count"), 
         RepairParallelism.fromName(repairScheduleRow.getString("repair_parallelism")), 
         repairScheduleRow.getDouble("intensity"), 
         new DateTime(repairScheduleRow.getTimestamp("creation_time")))
         .owner(repairScheduleRow.getString("owner"))
-        .pauseTime(new DateTime(repairScheduleRow.getTimestamp("pause_time"))).build(repairScheduleRow.getLong("id"));
+        .pauseTime(new DateTime(repairScheduleRow.getTimestamp("pause_time"))).build(repairScheduleRow.getUUID("id"));
 
 
   }
@@ -598,7 +592,7 @@ public class CassandraStorage implements IStorage {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
     ResultSet scheduleIds = session.execute(getRepairScheduleByClusterAndKsPrepStmt.bind(clusterName, " "));
     for(Row scheduleId:scheduleIds){
-      Optional<RepairSchedule> schedule = getRepairSchedule(scheduleId.getLong("repair_schedule_id"));
+      Optional<RepairSchedule> schedule = getRepairSchedule(scheduleId.getUUID("repair_schedule_id"));
       if(schedule.isPresent()){
         schedules.add(schedule.get());
       }
@@ -612,7 +606,7 @@ public class CassandraStorage implements IStorage {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
     ResultSet scheduleIds = session.execute(getRepairScheduleByClusterAndKsPrepStmt.bind(" ", keyspaceName));
     for(Row scheduleId:scheduleIds){
-      Optional<RepairSchedule> schedule = getRepairSchedule(scheduleId.getLong("repair_schedule_id"));
+      Optional<RepairSchedule> schedule = getRepairSchedule(scheduleId.getUUID("repair_schedule_id"));
       if(schedule.isPresent()){
         schedules.add(schedule.get());
       }
@@ -626,7 +620,7 @@ public class CassandraStorage implements IStorage {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
     ResultSet scheduleIds = session.execute(getRepairScheduleByClusterAndKsPrepStmt.bind(clusterName, keyspaceName));
     for(Row scheduleId:scheduleIds){
-      Optional<RepairSchedule> schedule = getRepairSchedule(scheduleId.getLong("repair_schedule_id"));
+      Optional<RepairSchedule> schedule = getRepairSchedule(scheduleId.getUUID("repair_schedule_id"));
       if(schedule.isPresent()){
         schedules.add(schedule.get());
       }
@@ -638,7 +632,7 @@ public class CassandraStorage implements IStorage {
   @Override
   public Collection<RepairSchedule> getAllRepairSchedules() {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
-    ResultSet scheduleResults = session.execute("SELECT * FROM repair_schedule");
+    ResultSet scheduleResults = session.execute("SELECT * FROM repair_schedule_v1");
     for(Row scheduleRow:scheduleResults){
       schedules.add(createRepairScheduleFromRow(scheduleRow));
 
@@ -650,7 +644,7 @@ public class CassandraStorage implements IStorage {
   @Override
   public boolean updateRepairSchedule(RepairSchedule newRepairSchedule) {
     BatchStatement batch = new BatchStatement();
-    final Set<Long> repairHistory = Sets.newHashSet();
+    final Set<UUID> repairHistory = Sets.newHashSet();
     repairHistory.addAll(newRepairSchedule.getRunHistory());
 
     batch.add(insertRepairSchedulePrepStmt.bind(newRepairSchedule.getId(), 
@@ -676,7 +670,7 @@ public class CassandraStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairSchedule> deleteRepairSchedule(long id) {
+  public Optional<RepairSchedule> deleteRepairSchedule(UUID id) {
     Optional<RepairSchedule> repairSchedule = getRepairSchedule(id);
     if(repairSchedule.isPresent()){
       RepairUnit repairUnit = getRepairUnit(repairSchedule.get().getRepairUnitId()).get();
@@ -713,43 +707,18 @@ public class CassandraStorage implements IStorage {
   public Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName) {
     Collection<RepairSchedule> repairSchedules = getRepairSchedulesForCluster(clusterName);
     
-    Collection<RepairScheduleStatus> repairScheduleStatuses = repairSchedules.stream()
-                                                                             .map(sched -> new RepairScheduleStatus(sched, getRepairUnit(sched.getRepairUnitId()).get()))
-                                                                             .collect(Collectors.toList());
+    Collection<RepairScheduleStatus> repairScheduleStatuses = repairSchedules
+            .stream()
+            .map(sched -> new RepairScheduleStatus(sched, getRepairUnit(sched.getRepairUnitId()).get()))
+            .collect(Collectors.toList());
    
     return repairScheduleStatuses;
   }
 
-  public long getNewRepairId(String idType){
-    if (!repairIds.containsKey(idType)){
-        repairIds.putIfAbsent(idType, 0L);
-        // Create id counter if it doesn't exist yet
-        session.execute(insertRepairId.bind(idType));
-    }
-    long idValue = repairIds.get(idType);
-    int attempts = 0;
 
-    // Increment and perform CAS, if it fails then fetch current value of the counter and repeat
-    while(true){
-      idValue++;
-      ResultSet casResult = session.execute(updateRepairId.bind(idValue, idType, (idValue-1)));
-      if(casResult.wasApplied()){
-          break;
-      }else{
-          idValue = session.execute(selectRepairId.bind(idType)).one().getLong("id");
-          Preconditions.checkState(idValue < Long.MAX_VALUE);
-          attempts++;
-          if(10 <= attempts && 0 == attempts % 10){
-              LOG.warn("still cant find a new repairId after " + attempts + " attempts");
-          }
-      }
-    }
-    repairIds.put(idType, Math.max(idValue, repairIds.get(idType)));
-    return idValue;
-  }
 
-  private RepairRun buildRepairRunFromRow(Row repairRunResult, long id){
-    return new RepairRun.Builder(repairRunResult.getString("cluster_name"), repairRunResult.getLong("repair_unit_id"), new DateTime(repairRunResult.getTimestamp("creation_time")), repairRunResult.getDouble("intensity"), repairRunResult.getInt("segment_count"), RepairParallelism.fromName(repairRunResult.getString("repair_parallelism")))
+  private RepairRun buildRepairRunFromRow(Row repairRunResult, UUID id){
+    return new RepairRun.Builder(repairRunResult.getString("cluster_name"), repairRunResult.getUUID("repair_unit_id"), new DateTime(repairRunResult.getTimestamp("creation_time")), repairRunResult.getDouble("intensity"), repairRunResult.getInt("segment_count"), RepairParallelism.fromName(repairRunResult.getString("repair_parallelism")))
         .cause(repairRunResult.getString("cause"))
         .owner(repairRunResult.getString("owner"))
         .endTime(new DateTime(repairRunResult.getTimestamp("end_time")))

--- a/src/main/java/com/spotify/reaper/storage/IStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/IStorage.java
@@ -27,6 +27,7 @@ import com.spotify.reaper.service.RingRange;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.validation.constraints.NotNull;
 
@@ -58,11 +59,11 @@ public interface IStorage {
 
   boolean updateRepairRun(RepairRun repairRun);
 
-  Optional<RepairRun> getRepairRun(long id);
+  Optional<RepairRun> getRepairRun(UUID id);
 
   Collection<RepairRun> getRepairRunsForCluster(String clusterName);
 
-  Collection<RepairRun> getRepairRunsForUnit(long repairUnitId);
+  Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId);
 
   Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState);
 
@@ -73,11 +74,11 @@ public interface IStorage {
    * @param id The id of the RepairRun instance to delete, and all segments for it.
    * @return The deleted RepairRun instance, if delete succeeds, with state set to DELETED.
    */
-  Optional<RepairRun> deleteRepairRun(long id);
+  Optional<RepairRun> deleteRepairRun(UUID id);
 
   RepairUnit addRepairUnit(RepairUnit.Builder newRepairUnit);
 
-  Optional<RepairUnit> getRepairUnit(long id);
+  Optional<RepairUnit> getRepairUnit(UUID id);
 
   /**
    * Get a stored RepairUnit targeting the given tables in the given keyspace.
@@ -90,15 +91,15 @@ public interface IStorage {
   Optional<RepairUnit> getRepairUnit(String cluster, String keyspace,
       Set<String> columnFamilyNames);
 
-  void addRepairSegments(Collection<RepairSegment.Builder> newSegments, long runId);
+  void addRepairSegments(Collection<RepairSegment.Builder> newSegments, UUID runId);
 
   boolean updateRepairSegment(RepairSegment newRepairSegment);
 
-  Optional<RepairSegment> getRepairSegment(long id);
+  Optional<RepairSegment> getRepairSegment(UUID id);
 
-  Collection<RepairSegment> getRepairSegmentsForRun(long runId);
+  Collection<RepairSegment> getRepairSegmentsForRun(UUID runId);
 
-  Optional<RepairSegment> getNextFreeSegment(long runId);
+  Optional<RepairSegment> getNextFreeSegment(UUID runId);
 
   /**
    * @param runId the run id that the segment belongs to.
@@ -107,21 +108,21 @@ public interface IStorage {
    *              that covers the whole ring.
    * @return a segment enclosed by the range with state NOT_STARTED, or nothing.
    */
-  Optional<RepairSegment> getNextFreeSegmentInRange(long runId, RingRange range);
+  Optional<RepairSegment> getNextFreeSegmentInRange(UUID runId, RingRange range);
 
-  Collection<RepairSegment> getSegmentsWithState(long runId, RepairSegment.State segmentState);
+  Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState);
 
   Collection<RepairParameters> getOngoingRepairsInCluster(String clusterName);
 
-  Collection<Long> getRepairRunIdsForCluster(String clusterName);
+  Collection<UUID> getRepairRunIdsForCluster(String clusterName);
 
-  int getSegmentAmountForRepairRun(long runId);
+  int getSegmentAmountForRepairRun(UUID runId);
 
-  int getSegmentAmountForRepairRunWithState(long runId, RepairSegment.State state);
+  int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state);
 
   RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule);
 
-  Optional<RepairSchedule> getRepairSchedule(long repairScheduleId);
+  Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId);
 
   Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName);
 
@@ -141,7 +142,7 @@ public interface IStorage {
    * @param id The id of the RepairSchedule instance to delete.
    * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
    */
-  Optional<RepairSchedule> deleteRepairSchedule(long id);
+  Optional<RepairSchedule> deleteRepairSchedule(UUID id);
 
   @NotNull
   Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit);

--- a/src/main/java/com/spotify/reaper/storage/cassandra/Migration003.java
+++ b/src/main/java/com/spotify/reaper/storage/cassandra/Migration003.java
@@ -1,0 +1,93 @@
+
+package com.spotify.reaper.storage.cassandra;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.utils.UUIDs;
+import com.spotify.reaper.storage.CassandraStorage;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Migration003 {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Migration003.class);
+
+    /** migrate over the repair_schedule table **/
+    public static void migrate(Session session) {
+        KeyspaceMetadata metadata = session.getCluster().getMetadata().getKeyspace(session.getLoggedKeyspace());
+        if(null != metadata.getTable("repair_unit")) {
+
+            LOG.warn("Migrating repair_unit and repair_schedule tables. This may take some minutes…");
+
+            PreparedStatement insertRprUnit = session.prepare(
+                    "INSERT INTO repair_unit_v1 (id, cluster_name, keyspace_name, column_families, incremental_repair) VALUES(?, ?, ?, ?, ?)");
+
+            PreparedStatement insertRprSched = session.prepare(
+                    "INSERT INTO repair_schedule_v1 (id, repair_unit_id, state, days_between, next_activation, run_history, segment_count, repair_parallelism, intensity, creation_time, owner, pause_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+
+            PreparedStatement insertRprSchedIdx = session.prepare(
+                    "INSERT INTO repair_schedule_by_cluster_and_keyspace(cluster_name, keyspace_name, repair_schedule_id) VALUES(?, ?, ?)");
+
+            Map<Long,UUID> repairUnitIds = new HashMap<>();
+            Map<Long,String> repairUnitClusters = new HashMap<>();
+            Map<Long,String> repairUnitKeyspaces = new HashMap<>();
+
+            for(Row row : session.execute(QueryBuilder.select().from("repair_unit"))) {
+                UUID uuid = UUIDs.timeBased();
+                repairUnitIds.put(row.getLong("id"), uuid);
+                repairUnitClusters.put(row.getLong("id"), row.getString("cluster_name"));
+                repairUnitKeyspaces.put(row.getLong("id"), row.getString("keyspace_name"));
+
+                session.execute(
+                        insertRprUnit.bind(
+                                uuid,
+                                row.getString("cluster_name"),
+                                row.getString("keyspace_name"),
+                                row.getSet("column_families", String.class),
+                                row.getBool("incremental_repair")));
+            }
+            session.executeAsync("DROP TABLE repair_unit");
+
+            for(Row row : session.execute(QueryBuilder.select().from("repair_schedule"))) {
+                UUID uuid = UUIDs.timeBased();
+                long repairUnitId = row.getLong("repair_unit_id");
+                
+                session.execute(
+                        insertRprSched.bind(
+                            uuid,
+                            repairUnitIds.get(repairUnitId),
+                            row.getString("state"),
+                            row.getInt("days_between"),
+                            row.getTimestamp("next_activation"),
+                            Collections.emptySet(),
+                            row.getInt("segment_count"),
+                            row.getString("repair_parallelism"),
+                            row.getDouble("intensity"),
+                            row.getTimestamp("creation_time"),
+                            row.getString("owner"),
+                            row.getTimestamp("pause_time")));
+
+
+                session.executeAsync(insertRprSchedIdx
+                        .bind(repairUnitClusters.get(repairUnitId), repairUnitKeyspaces.get(repairUnitId), uuid));
+                
+                session.executeAsync(insertRprSchedIdx.bind(repairUnitClusters.get(repairUnitId), " ", uuid));
+                session.executeAsync(insertRprSchedIdx.bind(" ", repairUnitKeyspaces.get(repairUnitId), uuid));
+            }
+
+            session.executeAsync("DROP TABLE repair_unit");
+            session.executeAsync("DROP TABLE repair_schedule");
+
+            LOG.warn("Migration of repair_unit and repair_schedule tables completed.");
+        }
+    }
+
+    private void Migration003(){}
+}

--- a/src/main/java/com/spotify/reaper/storage/postgresql/LongCollectionSQLType.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/LongCollectionSQLType.java
@@ -3,19 +3,20 @@ package com.spotify.reaper.storage.postgresql;
 import com.google.common.collect.Lists;
 
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * This is required to be able to map in generic manner into Postgres array types through JDBI.
  */
 public class LongCollectionSQLType {
 
-  private Collection<Long> collection;
+  private Collection<UUID> collection;
 
-  public LongCollectionSQLType(Collection<Long> collection) {
+  public LongCollectionSQLType(Collection<UUID> collection) {
     this.collection = collection;
   }
 
-  public Collection<Long> getValue() {
+  public Collection<UUID> getValue() {
     if (this.collection == null) {
       return Lists.newArrayList();
     } else {

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunMapper.java
@@ -13,6 +13,7 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.spotify.reaper.core.RepairRun;
 
 import org.apache.cassandra.repair.RepairParallelism;
@@ -23,6 +24,7 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.UUID;
 
 public class RepairRunMapper implements ResultSetMapper<RepairRun> {
 
@@ -41,7 +43,7 @@ public class RepairRunMapper implements ResultSetMapper<RepairRun> {
         RepairParallelism.fromName(r.getString("repair_parallelism"));
     RepairRun.Builder repairRunBuilder =
         new RepairRun.Builder(r.getString("cluster_name"),
-                              r.getLong("repair_unit_id"),
+                              fromSequenceId(r.getLong("repair_unit_id")),
                               getDateTimeOrNull(r, "creation_time"),
                               r.getFloat("intensity"),
                               r.getInt("segment_count"),
@@ -54,7 +56,10 @@ public class RepairRunMapper implements ResultSetMapper<RepairRun> {
         .endTime(getDateTimeOrNull(r, "end_time"))
         .pauseTime(getDateTimeOrNull(r, "pause_time"))
         .lastEvent(r.getString("last_event"))
-        .build(r.getLong("id"));
+        .build(fromSequenceId(r.getLong("id")));
   }
 
+  private static UUID fromSequenceId(long insertedId) {
+    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
+  }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
@@ -1,5 +1,6 @@
 package com.spotify.reaper.storage.postgresql;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.ImmutableSet;
 
 import com.spotify.reaper.core.RepairRun;
@@ -13,6 +14,7 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.UUID;
 
 public class RepairRunStatusMapper implements ResultSetMapper<RepairRunStatus> {
 
@@ -42,8 +44,12 @@ public class RepairRunStatusMapper implements ResultSetMapper<RepairRunStatus> {
     }
     RepairParallelism repairParallelism = RepairParallelism.fromName(repairParallelismStr);
 
-    return new RepairRunStatus(runId, clusterName, keyspaceName, columnFamilies, segmentsRepaired,
+    return new RepairRunStatus(fromSequenceId(runId), clusterName, keyspaceName, columnFamilies, segmentsRepaired,
         totalSegments, state, startTime, endTime, cause, owner, lastEvent,
         creationTime, pauseTime, intensity, incrementalRepair, repairParallelism);
+  }
+
+  private static UUID fromSequenceId(long insertedId) {
+    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -13,6 +13,7 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.ImmutableSet;
 
 import com.spotify.reaper.core.RepairSchedule;
@@ -25,6 +26,7 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.UUID;
 
 public class RepairScheduleStatusMapper implements ResultSetMapper<RepairScheduleStatus> {
 
@@ -40,7 +42,7 @@ public class RepairScheduleStatusMapper implements ResultSetMapper<RepairSchedul
     RepairParallelism repairParallelism = RepairParallelism.fromName(repairParallelismStr);
 
     return new RepairScheduleStatus(
-        r.getLong("id"),
+        fromSequenceId(r.getLong("id")),
         r.getString("owner"),
         r.getString("cluster_name"),
         r.getString("keyspace_name"),
@@ -55,5 +57,9 @@ public class RepairScheduleStatusMapper implements ResultSetMapper<RepairSchedul
         repairParallelism,
         r.getInt("days_between")
     );
+  }
+
+  private static UUID fromSequenceId(long insertedId) {
+    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairUnitMapper.java
@@ -13,6 +13,7 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.Sets;
 import com.spotify.reaper.core.RepairUnit;
 
@@ -22,6 +23,7 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.UUID;
 
 public class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
 
@@ -39,7 +41,11 @@ public class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
                                                         r.getString("keyspace_name"),
                                                         Sets.newHashSet(columnFamilies),
                                                         r.getBoolean("incremental_repair"));
-    return builder.build(r.getLong("id"));
+    return builder.build(fromSequenceId(r.getLong("id")));
   }
 
+
+  private static UUID fromSequenceId(long insertedId) {
+    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
+  }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/UuidArgumentFactory.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/UuidArgumentFactory.java
@@ -1,0 +1,27 @@
+package com.spotify.reaper.storage.postgresql;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.Argument;
+import org.skife.jdbi.v2.tweak.ArgumentFactory;
+
+import java.util.UUID;
+
+/**
+ * Provides JDBI a method to map UUID value to a long (most sig bits) value in database.
+ */
+public final class UuidArgumentFactory implements ArgumentFactory<UUID> {
+
+  @Override
+  public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
+    return value instanceof UUID;
+  }
+
+  @Override
+  public Argument build(Class<?> expectedType, final UUID value, StatementContext ctx) {
+    return (pos, stmt, sc) -> stmt.setLong(pos, toSequenceId(value));
+  }
+
+  private static long toSequenceId(UUID id) {
+    return id.getMostSignificantBits();
+  }
+}

--- a/src/main/resources/db/cassandra/003_switch_to_uuids.cql
+++ b/src/main/resources/db/cassandra/003_switch_to_uuids.cql
@@ -1,0 +1,134 @@
+--
+-- Cassandra schema for cassandra-reaper database
+
+-- CREATE KEYSPACE IF NOT EXISTS reaper_db WITH REPLICATION={'class':'SimpleStrategy', 'replication_factor':3};
+
+-- use reaper_db;
+
+ALTER TABLE cluster
+  WITH compaction = {'class': 'LeveledCompactionStrategy'}
+  AND caching = {'rows_per_partition': 'ALL'};
+
+-- Repair unit is basically a keyspace with a set of column families.
+-- Cassandra supports repairing multiple column families in one go.
+
+CREATE TABLE IF NOT EXISTS repair_unit_v1 (
+  id              timeuuid PRIMARY KEY,
+  cluster_name    text,
+  keyspace_name   text,
+  column_families set<text>,
+  incremental_repair boolean
+)
+  WITH compaction = {'class': 'LeveledCompactionStrategy'};
+
+DROP TABLE IF EXISTS repair_run;
+
+CREATE TABLE IF NOT EXISTS repair_run (
+  id                 timeuuid,
+  cluster_name       text      STATIC,
+  repair_unit_id     timeuuid    STATIC,
+  cause              text      STATIC,
+  owner              text      STATIC,
+  state              text      STATIC,
+  creation_time      timestamp STATIC,
+  start_time         timestamp STATIC,
+  end_time           timestamp STATIC,
+  pause_time         timestamp STATIC,
+  intensity          double    STATIC,
+  last_event         text      STATIC,
+  segment_count      int       STATIC,
+  repair_parallelism text      STATIC,
+  segment_id         timeuuid,
+  start_token        varint,
+  end_token          varint,
+  segment_state      int,
+  coordinator_host   text,
+  segment_start_time timestamp,
+  segment_end_time   timestamp,
+  fail_count         int,
+  PRIMARY KEY (id, segment_id)
+)
+  WITH compaction = {'class': 'LeveledCompactionStrategy'}
+  AND caching = {'rows_per_partition': 10};
+
+
+DROP TABLE IF EXISTS repair_run_by_cluster;
+
+CREATE TABLE IF NOT EXISTS repair_run_by_cluster (
+  cluster_name text,
+  id           timeuuid,
+  PRIMARY KEY(cluster_name, id)
+)
+  WITH compaction = {'class': 'LeveledCompactionStrategy'}
+  AND caching = {'rows_per_partition': 10};
+
+
+DROP TABLE IF EXISTS repair_run_by_unit;
+
+CREATE TABLE IF NOT EXISTS repair_run_by_unit (
+  repair_unit_id timeuuid,
+  id             timeuuid,
+  PRIMARY KEY(repair_unit_id, id)
+)
+  WITH compaction = {'class': 'LeveledCompactionStrategy'}
+  AND caching = {'rows_per_partition': 10};
+
+
+DROP TABLE IF EXISTS repair_segment;
+
+CREATE TABLE IF NOT EXISTS repair_segment (
+  id               timeuuid PRIMARY KEY,
+  repair_unit_id   timeuuid,
+  run_id           timeuuid,
+  start_token      varint,
+  end_token        varint,
+  state            int   ,
+  coordinator_host text,
+  start_time       timestamp,
+  end_time         timestamp,
+  fail_count       INT
+)
+  WITH compaction = {'class': 'LeveledCompactionStrategy'}
+  AND caching = {'rows_per_partition': 10};
+
+
+DROP TABLE IF EXISTS repair_segment_by_run_id;
+
+CREATE TABLE IF NOT EXISTS repair_segment_by_run_id (
+  run_id           timeuuid,
+  segment_id       timeuuid,
+  PRIMARY KEY(run_id, segment_id)
+)
+  WITH compaction = {'class': 'LeveledCompactionStrategy'}
+  AND caching = {'rows_per_partition': 10};
+
+
+CREATE TABLE IF NOT EXISTS repair_schedule_v1 (
+  id                 timeuuid PRIMARY KEY,
+  repair_unit_id     timeuuid,
+  state              text                    ,
+  days_between       int                ,
+  next_activation    timestamp,
+  run_history        set<timeuuid>,
+  segment_count      int                     ,
+  repair_parallelism text                    ,
+  intensity          double                    ,
+  creation_time      timestamp,
+  owner              text                    ,
+  pause_time         timestamp
+)
+  WITH compaction = {'class': 'LeveledCompactionStrategy'};
+
+
+DROP TABLE IF EXISTS repair_schedule_by_cluster_and_keyspace;
+
+CREATE TABLE IF NOT EXISTS repair_schedule_by_cluster_and_keyspace (
+  cluster_name text,
+  keyspace_name text,
+  repair_schedule_id timeuuid,
+  PRIMARY KEY((cluster_name, keyspace_name), repair_schedule_id)
+)
+  WITH compaction = {'class': 'LeveledCompactionStrategy'}
+  AND caching = {'rows_per_partition': 10};
+
+DROP TABLE IF EXISTS repair_id;

--- a/src/test/java/com/spotify/reaper/AssertionTest.java
+++ b/src/test/java/com/spotify/reaper/AssertionTest.java
@@ -1,0 +1,22 @@
+
+package com.spotify.reaper;
+
+import org.junit.Test;
+
+
+public final class AssertionTest{
+
+    @Test
+    public void test_assertions_enabled(){
+        boolean asserted = false;
+        try{
+            assert false;
+        }catch (AssertionError error){
+            asserted = true;
+        }
+        if (!asserted){
+            throw new AssertionError("assertions are not enabled");
+        }
+    }
+
+}

--- a/src/test/java/com/spotify/reaper/acceptance/ReaperCassandraIT.java
+++ b/src/test/java/com/spotify/reaper/acceptance/ReaperCassandraIT.java
@@ -57,7 +57,14 @@ public class ReaperCassandraIT {
   public static void initSchema() throws IOException{
     Cluster cluster = Cluster.builder().addContactPoint("127.0.0.1").build();
     Session tmpSession = cluster.connect();
-    tmpSession.execute("DROP KEYSPACE IF EXISTS reaper_db");
+    while(true){
+        try{
+            tmpSession.execute("DROP KEYSPACE IF EXISTS reaper_db");
+            break;
+        }catch(Exception ex){
+            LOG.warn("error dropping keyspace", ex);
+        }
+    }
     tmpSession.execute("CREATE KEYSPACE IF NOT EXISTS reaper_db WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}");
     tmpSession.close();
   }

--- a/src/test/java/com/spotify/reaper/acceptance/TestContext.java
+++ b/src/test/java/com/spotify/reaper/acceptance/TestContext.java
@@ -3,6 +3,7 @@ package com.spotify.reaper.acceptance;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Helper class for holding acceptance test scenario state.
@@ -15,7 +16,7 @@ public class TestContext {
   public static String TEST_CLUSTER;
 
   /* Used for targeting an object accessed in last test step. */
-  public static Long LAST_MODIFIED_ID;
+  public static UUID LAST_MODIFIED_ID;
 
   /* Testing cluster seed host mapped to cluster name. */
   public static Map<String, String> TEST_CLUSTER_SEED_HOSTS = new HashMap<>();

--- a/src/test/java/com/spotify/reaper/resources/view/RepairScheduleStatusTest.java
+++ b/src/test/java/com/spotify/reaper/resources/view/RepairScheduleStatusTest.java
@@ -1,5 +1,6 @@
 package com.spotify.reaper.resources.view;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.Lists;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -26,7 +27,7 @@ public class RepairScheduleStatusTest {
     data.setColumnFamilies(Lists.<String>newArrayList());
     data.setCreationTime(DateTime.now().withMillis(0));
     data.setDaysBetween(2);
-    data.setId(1);
+    data.setId(UUIDs.timeBased());
     data.setIntensity(0.75);
     data.setIncrementalRepair(false);
     data.setKeyspaceName("testKeyspace");

--- a/src/test/java/com/spotify/reaper/unit/resources/RepairRunResourceTest.java
+++ b/src/test/java/com/spotify/reaper/unit/resources/RepairRunResourceTest.java
@@ -1,5 +1,6 @@
 package com.spotify.reaper.unit.resources;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -30,6 +31,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.Response;
@@ -149,7 +151,7 @@ public class RepairRunResourceTest {
     assertEquals(1, context.storage.getClusters().size());
     assertEquals(1, context.storage.getRepairRunsForCluster(CLUSTER_NAME).size());
     assertEquals(1, context.storage.getRepairRunIdsForCluster(CLUSTER_NAME).size());
-    Long runId = context.storage.getRepairRunIdsForCluster(CLUSTER_NAME).iterator().next();
+    UUID runId = context.storage.getRepairRunIdsForCluster(CLUSTER_NAME).iterator().next();
     RepairRun run = context.storage.getRepairRun(runId).get();
     assertEquals(RepairRun.RunState.NOT_STARTED, run.getRunState());
     assertEquals(TIME_CREATE, run.getCreationTime().getMillis());
@@ -175,7 +177,7 @@ public class RepairRunResourceTest {
   public void testTriggerNotExistingRun() throws ReaperException {
     RepairRunResource resource = new RepairRunResource(context);
     Optional<String> newState = Optional.of(RepairRun.RunState.RUNNING.toString());
-    Response response = resource.modifyRunState(uriInfo, 42l, newState);
+    Response response = resource.modifyRunState(uriInfo, UUIDs.timeBased(), newState);
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     assertTrue(response.getEntity() instanceof String);
     assertTrue(response.getEntity().toString().contains("not found"));
@@ -189,7 +191,7 @@ public class RepairRunResourceTest {
     RepairRunResource resource = new RepairRunResource(context);
     Response response = addDefaultRepairRun(resource);
     RepairRunStatus repairRunStatus = (RepairRunStatus) response.getEntity();
-    long runId = repairRunStatus.getId();
+    UUID runId = repairRunStatus.getId();
 
     DateTimeUtils.setCurrentMillisFixed(TIME_START);
     Optional<String> newState = Optional.of(RepairRun.RunState.RUNNING.toString());
@@ -207,7 +209,7 @@ public class RepairRunResourceTest {
     RepairRunResource resource = new RepairRunResource(context);
     Response response = addDefaultRepairRun(resource);
     RepairRunStatus repairRunStatus = (RepairRunStatus) response.getEntity();
-    long runId = repairRunStatus.getId();
+    UUID runId = repairRunStatus.getId();
 
     DateTimeUtils.setCurrentMillisFixed(TIME_START);
     Optional<String> newState = Optional.of(RepairRun.RunState.RUNNING.toString());
@@ -220,7 +222,7 @@ public class RepairRunResourceTest {
     RepairRunResource newResource = new RepairRunResource(context);
     Response newResponse = addDefaultRepairRun(newResource);
     RepairRunStatus newRepairRunStatus = (RepairRunStatus) newResponse.getEntity();
-    long newRunId = newRepairRunStatus.getId();
+    UUID newRunId = newRepairRunStatus.getId();
 
     DateTimeUtils.setCurrentMillisFixed(TIME_START);
     Optional<String> newRunState = Optional.of(RepairRun.RunState.RUNNING.toString());
@@ -268,7 +270,7 @@ public class RepairRunResourceTest {
     RepairRunResource resource = new RepairRunResource(context);
     Response response = addDefaultRepairRun(resource);
     RepairRunStatus repairRunStatus = (RepairRunStatus) response.getEntity();
-    long runId = repairRunStatus.getId();
+    UUID runId = repairRunStatus.getId();
 
     response = resource.modifyRunState(uriInfo, runId,
                                        Optional.of(RepairRun.RunState.PAUSED.toString()));
@@ -287,7 +289,7 @@ public class RepairRunResourceTest {
   @Test
   public void testPauseNotExistingRun() throws InterruptedException, ReaperException {
     RepairRunResource resource = new RepairRunResource(context);
-    Response response = resource.modifyRunState(uriInfo, 42l,
+    Response response = resource.modifyRunState(uriInfo, UUIDs.timeBased(),
                                                 Optional.of(RepairRun.RunState.PAUSED.toString()));
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     assertEquals(0, context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING).size());

--- a/src/test/java/com/spotify/reaper/unit/service/RepairRunnerTest.java
+++ b/src/test/java/com/spotify/reaper/unit/service/RepairRunnerTest.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,8 +93,8 @@ public class RepairRunnerTest {
     storage.addRepairSegments(Collections.singleton(
         new RepairSegment.Builder(run.getId(), new RingRange(BigInteger.ZERO, BigInteger.ONE),
                                   cf.getId())), run.getId());
-    final long RUN_ID = run.getId();
-    final long SEGMENT_ID = storage.getNextFreeSegment(run.getId()).get().getId();
+    final UUID RUN_ID = run.getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegment(run.getId()).get().getId();
 
     assertEquals(storage.getRepairSegment(SEGMENT_ID).get().getState(),
                  RepairSegment.State.NOT_STARTED);
@@ -198,8 +199,8 @@ public class RepairRunnerTest {
     storage.addRepairSegments(Collections.singleton(
         new RepairSegment.Builder(run.getId(), new RingRange(BigInteger.ZERO, BigInteger.ONE),
                                   cf.getId())), run.getId());
-    final long RUN_ID = run.getId();
-    final long SEGMENT_ID = storage.getNextFreeSegment(run.getId()).get().getId();
+    final UUID RUN_ID = run.getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegment(run.getId()).get().getId();
 
     assertEquals(storage.getRepairSegment(SEGMENT_ID).get().getState(),
                  RepairSegment.State.NOT_STARTED);
@@ -298,7 +299,7 @@ public class RepairRunnerTest {
     context.repairManager = new RepairManager();
 
     storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton(null)));
-    long cf = storage.addRepairUnit(
+    UUID cf = storage.addRepairUnit(
         new RepairUnit.Builder(CLUSTER_NAME, KS_NAME, CF_NAMES, INCREMENTAL_REPAIR)).getId();
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
     RepairRun run = storage.addRepairRun(
@@ -310,8 +311,8 @@ public class RepairRunnerTest {
             .repairCommandId(1337),
         new RepairSegment.Builder(run.getId(), new RingRange(BigInteger.ONE, BigInteger.ZERO), cf)
     ), run.getId());
-    final long RUN_ID = run.getId();
-    final long SEGMENT_ID = storage.getNextFreeSegment(run.getId()).get().getId();
+    final UUID RUN_ID = run.getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegment(run.getId()).get().getId();
 
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 

--- a/src/test/java/com/spotify/reaper/unit/service/SegmentRunnerTest.java
+++ b/src/test/java/com/spotify/reaper/unit/service/SegmentRunnerTest.java
@@ -43,6 +43,7 @@ import org.mockito.stubbing.Answer;
 
 import java.math.BigInteger;
 import java.util.Collections;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -75,7 +76,7 @@ public class SegmentRunnerTest {
     context.storage.addRepairSegments(Collections.singleton(
         new RepairSegment.Builder(run.getId(), new RingRange(BigInteger.ONE, BigInteger.ZERO),
                                   cf.getId())), run.getId());
-    final long segmentId = context.storage.getNextFreeSegment(run.getId()).get().getId();
+    final UUID segmentId = context.storage.getNextFreeSegment(run.getId()).get().getId();
 
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final MutableObject<Future<?>> future = new MutableObject<>();
@@ -136,7 +137,7 @@ public class SegmentRunnerTest {
     storage.addRepairSegments(Collections.singleton(
         new RepairSegment.Builder(run.getId(), new RingRange(BigInteger.ONE, BigInteger.ZERO),
                                   cf.getId())), run.getId());
-    final long segmentId = storage.getNextFreeSegment(run.getId()).get().getId();
+    final UUID segmentId = storage.getNextFreeSegment(run.getId()).get().getId();
 
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final MutableObject<Future<?>> future = new MutableObject<>();
@@ -210,7 +211,7 @@ public class SegmentRunnerTest {
     storage.addRepairSegments(Collections.singleton(
         new RepairSegment.Builder(run.getId(), new RingRange(BigInteger.ONE, BigInteger.ZERO),
                                   cf.getId())), run.getId());
-    final long segmentId = storage.getNextFreeSegment(run.getId()).get().getId();
+    final UUID segmentId = storage.getNextFreeSegment(run.getId()).get().getId();
 
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final MutableObject<Future<?>> future = new MutableObject<>();

--- a/src/test/resources/cassandra-reaper-cassandra-at.yaml
+++ b/src/test/resources/cassandra-reaper-cassandra-at.yaml
@@ -14,6 +14,7 @@ logging:
   loggers:
     io.dropwizard: INFO
     org.eclipse.jetty: INFO
+    com.datastax.driver.core.QueryLogger.NORMAL: INFO
   appenders:
     - type: console
 


### PR DESCRIPTION
The sequence number was a postgresql (sql) optimisation that imposed itself upon the code's design.
But there is no constraint in the codebase that IDs are to be a sequential sequence, nor even ordered.

By replacing all IDs in the codebase with UUIDs, we:
 - isolate sequence generation to postgresql as an internal implementation detail, and
 - permit C* to generate and use time-based UUIDs.

This reduces those 14k cql requests to even even lower number as the repair_id table doesn't exist now.

ref: https://github.com/thelastpickle/cassandra-reaper/issues/94

Previous, to improve C* performance, the statements against `repair_id` has been made into prepared statements and the floor value for the sequence cached. Caching and transactions are nearly always a bad idea, and in this example, given a little thought, it's become clear the Correct Design™ is without caching, transactions, or any in-process state.