### PR TITLE
In CassandraStorage implement segments as clustering keys within the repair_run table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.1.0</dropwizard.version>
+        <dropwizard.version>1.0.7</dropwizard.version>
         <dropwizard.cassandra.version>4.1.0</dropwizard.cassandra.version>
         <cassandra.version>2.2.7</cassandra.version>
         <cucumber.version>1.2.5</cucumber.version>

--- a/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
@@ -254,7 +254,7 @@ public class ReaperApplicationConfiguration extends Configuration {
   }
   
   public Boolean getAllowUnreachableNodes() {
-    return allowUnreachableNodes;
+    return allowUnreachableNodes != null ? allowUnreachableNodes : false;
   }
 
   public void setAllowUnreachableNodes(Boolean allow) {

--- a/src/main/java/com/spotify/reaper/service/RepairRunner.java
+++ b/src/main/java/com/spotify/reaper/service/RepairRunner.java
@@ -229,7 +229,7 @@ public class RepairRunner implements Runnable {
 
         // Just checking that no currently running segment runner is stuck.
         RepairSegment supposedlyRunningSegment =
-            context.storage.getRepairSegment(currentlyRunningSegments.get(rangeIndex)).get();
+            context.storage.getRepairSegment(repairRunId, currentlyRunningSegments.get(rangeIndex)).get();
         DateTime startTime = supposedlyRunningSegment.getStartTime();
         if (startTime != null && startTime.isBefore(DateTime.now().minusDays(1))) {
           LOG.warn("Looks like segment #{} has been running more than a day. Start time: {}",
@@ -343,7 +343,8 @@ public class RepairRunner implements Runnable {
 	    }
     } 
     else {
-    	potentialCoordinators = Arrays.asList(context.storage.getRepairSegment(segmentId).get().getCoordinatorHost());
+    	potentialCoordinators 
+                = Arrays.asList(context.storage.getRepairSegment(repairRunId, segmentId).get().getCoordinatorHost());
     }
 
     SegmentRunner segmentRunner = new SegmentRunner(context, segmentId, potentialCoordinators,
@@ -369,7 +370,7 @@ public class RepairRunner implements Runnable {
   }
 
   private void handleResult(UUID segmentId) {
-    RepairSegment segment = context.storage.getRepairSegment(segmentId).get();
+    RepairSegment segment = context.storage.getRepairSegment(repairRunId, segmentId).get();
     RepairSegment.State segmentState = segment.getState();
     LOG.debug("In repair run #{}, triggerRepair on segment {} ended with state {}",
         repairRunId, segmentId, segmentState);

--- a/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -76,16 +76,13 @@ public final class CassandraStorage implements IStorage {
   private PreparedStatement getRepairUnitPrepStmt;
   private PreparedStatement insertRepairSegmentPrepStmt;
   private PreparedStatement getRepairSegmentPrepStmt;
-  private PreparedStatement insertRepairSegmentByRunPrepStmt;
-  private PreparedStatement getRepairSegmentByRunIdPrepStmt;
+  private PreparedStatement getRepairSegmentsByRunIdPrepStmt;
   private PreparedStatement insertRepairSchedulePrepStmt;
   private PreparedStatement getRepairSchedulePrepStmt;
   private PreparedStatement getRepairScheduleByClusterAndKsPrepStmt;
   private PreparedStatement insertRepairScheduleByClusterAndKsPrepStmt;
   private PreparedStatement deleteRepairSchedulePrepStmt;
   private PreparedStatement deleteRepairScheduleByClusterAndKsPrepStmt;
-  private PreparedStatement deleteRepairSegmentPrepStmt;
-  private PreparedStatement deleteRepairSegmentByRunId;
 
   public CassandraStorage(ReaperApplicationConfiguration config, Environment environment) {
     cassandra = config.getCassandraFactory().build(environment).register(QueryLogger.builder().build());
@@ -98,7 +95,7 @@ public final class CassandraStorage implements IStorage {
     MigrationTask migration = new MigrationTask(database, new MigrationRepository("db/cassandra"));
     migration.migrate();
     Migration002.migrate(session);
-        
+
     prepareStatements();
   }
 
@@ -109,23 +106,20 @@ public final class CassandraStorage implements IStorage {
     insertRepairRunPrepStmt = session.prepare("INSERT INTO repair_run(id, cluster_name, repair_unit_id, cause, owner, state, creation_time, start_time, end_time, pause_time, intensity, last_event, segment_count, repair_parallelism) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
     insertRepairRunClusterIndexPrepStmt = session.prepare("INSERT INTO repair_run_by_cluster(cluster_name, id) values(?, ?)");
     insertRepairRunUnitIndexPrepStmt = session.prepare("INSERT INTO repair_run_by_unit(repair_unit_id, id) values(?, ?)");
-    getRepairRunPrepStmt = session.prepare("SELECT * FROM repair_run WHERE id = ?");
+    getRepairRunPrepStmt = session.prepare("SELECT id,cluster_name,repair_unit_id,cause,owner,state,creation_time,start_time,end_time,pause_time,intensity,last_event,segment_count,repair_parallelism FROM repair_run WHERE id = ? LIMIT 1");
     getRepairRunForClusterPrepStmt = session.prepare("SELECT * FROM repair_run_by_cluster WHERE cluster_name = ?");
     getRepairRunForUnitPrepStmt = session.prepare("SELECT * FROM repair_run_by_unit WHERE repair_unit_id = ?");
     deleteRepairRunPrepStmt = session.prepare("DELETE FROM repair_run WHERE id = ?");
     deleteRepairRunByClusterPrepStmt = session.prepare("DELETE FROM repair_run_by_cluster WHERE id = ? and cluster_name = ?");
     deleteRepairRunByUnitPrepStmt = session.prepare("DELETE FROM repair_run_by_unit WHERE id = ? and repair_unit_id= ?");
-    deleteRepairSegmentPrepStmt = session.prepare("DELETE FROM repair_segment WHERE id = ?");
-    deleteRepairSegmentByRunId = session.prepare("DELETE FROM repair_segment_by_run_id WHERE run_id = ?");
     insertRepairUnitPrepStmt = session.prepare("INSERT INTO repair_unit_v1(id, cluster_name, keyspace_name, column_families, incremental_repair) VALUES(?, ?, ?, ?, ?)");
     getRepairUnitPrepStmt = session.prepare("SELECT * FROM repair_unit_v1 WHERE id = ?");
-    insertRepairSegmentPrepStmt = session.prepare("INSERT INTO repair_segment(id, repair_unit_id, run_id, start_token, end_token, state, coordinator_host, start_time, end_time, fail_count) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-    getRepairSegmentPrepStmt = session.prepare("SELECT * FROM repair_segment WHERE id = ?");
-    insertRepairSegmentByRunPrepStmt = session.prepare("INSERT INTO repair_segment_by_run_id(run_id, segment_id) VALUES(?, ?)");
-    getRepairSegmentByRunIdPrepStmt = session.prepare("SELECT * FROM repair_segment_by_run_id WHERE run_id = ?");
+    insertRepairSegmentPrepStmt = session.prepare("INSERT INTO repair_run(id, segment_id, repair_unit_id, start_token, end_token, segment_state, coordinator_host, segment_start_time, segment_end_time, fail_count) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    getRepairSegmentPrepStmt = session.prepare("SELECT id,repair_unit_id,segment_id,start_token,end_token,segment_state,coordinator_host,segment_start_time,segment_end_time,fail_count FROM repair_run WHERE id = ? and segment_id = ?");
+    getRepairSegmentsByRunIdPrepStmt = session.prepare("SELECT id,repair_unit_id,segment_id,start_token,end_token,segment_state,coordinator_host,segment_start_time,segment_end_time,fail_count FROM repair_run WHERE id = ?");
     insertRepairSchedulePrepStmt = session.prepare("INSERT INTO repair_schedule_v1(id, repair_unit_id, state, days_between, next_activation, run_history, segment_count, repair_parallelism, intensity, creation_time, owner, pause_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
     getRepairSchedulePrepStmt = session.prepare("SELECT * FROM repair_schedule_v1 WHERE id = ?");
-    insertRepairScheduleByClusterAndKsPrepStmt = session.prepare("INSERT INTO repair_schedule_by_cluster_and_keyspace(cluster_name, keyspace_name, repair_schedule_id) VALUES(?, ?, ?)"); 
+    insertRepairScheduleByClusterAndKsPrepStmt = session.prepare("INSERT INTO repair_schedule_by_cluster_and_keyspace(cluster_name, keyspace_name, repair_schedule_id) VALUES(?, ?, ?)");
     getRepairScheduleByClusterAndKsPrepStmt = session.prepare("SELECT repair_schedule_id FROM repair_schedule_by_cluster_and_keyspace WHERE cluster_name = ? and keyspace_name = ?");
     deleteRepairSchedulePrepStmt = session.prepare("DELETE FROM repair_schedule_v1 WHERE id = ?");
     deleteRepairScheduleByClusterAndKsPrepStmt = session.prepare("DELETE FROM repair_schedule_by_cluster_and_keyspace WHERE cluster_name = ? and keyspace_name = ? and repair_schedule_id = ?");
@@ -183,25 +177,49 @@ public final class CassandraStorage implements IStorage {
   public RepairRun addRepairRun(Builder repairRun, Collection<RepairSegment.Builder> newSegments) {
     RepairRun newRepairRun = repairRun.build(UUIDs.timeBased());
     BatchStatement batch = new BatchStatement();
-    batch.add(insertRepairRunPrepStmt.bind(newRepairRun.getId(), 
-        newRepairRun.getClusterName(), 
-        newRepairRun.getRepairUnitId(), 
-        newRepairRun.getCause(), 
-        newRepairRun.getOwner(), 
-        newRepairRun.getRunState().toString(),
-        newRepairRun.getCreationTime()==null?null:newRepairRun.getCreationTime(), 
-            newRepairRun.getStartTime()==null?null:newRepairRun.getStartTime(), 
-                newRepairRun.getEndTime()==null?null:newRepairRun.getEndTime(), 
-                    newRepairRun.getPauseTime()==null?null:newRepairRun.getPauseTime(), 
-                        newRepairRun.getIntensity(), 
-                        newRepairRun.getLastEvent(), 
-                        newRepairRun.getSegmentCount(), 
-                        newRepairRun.getRepairParallelism().toString())
-        );
+    BatchStatement repairRunBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
+
+    repairRunBatch.add(insertRepairRunPrepStmt.bind(
+            newRepairRun.getId(),
+            newRepairRun.getClusterName(),
+            newRepairRun.getRepairUnitId(),
+            newRepairRun.getCause(),
+            newRepairRun.getOwner(),
+            newRepairRun.getRunState().toString(),
+            newRepairRun.getCreationTime()==null?null:newRepairRun.getCreationTime(),
+            newRepairRun.getStartTime()==null?null:newRepairRun.getStartTime(),
+            newRepairRun.getEndTime()==null?null:newRepairRun.getEndTime(),
+            newRepairRun.getPauseTime()==null?null:newRepairRun.getPauseTime(),
+            newRepairRun.getIntensity(),
+            newRepairRun.getLastEvent(),
+            newRepairRun.getSegmentCount(),
+            newRepairRun.getRepairParallelism().toString()));
+
     batch.add(insertRepairRunClusterIndexPrepStmt.bind(newRepairRun.getClusterName(), newRepairRun.getId()));
     batch.add(insertRepairRunUnitIndexPrepStmt.bind(newRepairRun.getRepairUnitId(), newRepairRun.getId()));
     session.execute(batch);
-    addRepairSegments(newSegments, newRepairRun.getId());
+
+    for(RepairSegment.Builder builder:newSegments){
+      RepairSegment segment = builder.withRunId(newRepairRun.getId()).build(UUIDs.timeBased());
+
+      repairRunBatch.add(insertRepairSegmentPrepStmt.bind(
+            segment.getRunId(),
+            segment.getId(),
+            segment.getRepairUnitId(),
+            segment.getStartToken(),
+            segment.getEndToken(),
+            segment.getState().ordinal(),
+            segment.getCoordinatorHost(),
+            segment.getStartTime(),
+            segment.getEndTime(),
+            segment.getFailCount()));
+
+      if(100 == repairRunBatch.size()){
+          session.execute(repairRunBatch);
+          repairRunBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
+      }
+    }
+    session.execute(repairRunBatch);
     return newRepairRun;
   }
 
@@ -258,7 +276,7 @@ public final class CassandraStorage implements IStorage {
   /**
    * Create a collection of RepairRun objects out of a list of ResultSetFuture.
    * Used to handle async queries on the repair_run table with a list of ids.
-   * 
+   *
    * @param repairRunFutures
    * @return
    */
@@ -301,21 +319,6 @@ public final class CassandraStorage implements IStorage {
       batch.add(deleteRepairRunByUnitPrepStmt.bind(id, repairRun.get().getRepairUnitId()));
       session.execute(batch);
     }
-
-    // Delete all segments for the run we've deleted
-    List<ResultSetFuture> futures= Lists.newArrayList(); 
-    Collection<RepairSegment> segments = getRepairSegmentsForRun(id);
-    int i=0;
-    final int nbSegments = segments.size();
-    futures.add(session.executeAsync(deleteRepairSegmentByRunId.bind(id)));
-    for(RepairSegment segment:segments){
-      futures.add(session.executeAsync(deleteRepairSegmentPrepStmt.bind(segment.getId())));
-      i++;
-      if(i%100==0 || i==nbSegments-1){
-        futures.stream().forEach(f -> f.getUninterruptibly());
-      }
-    }
-
     return repairRun;
   }
 
@@ -354,60 +357,31 @@ public final class CassandraStorage implements IStorage {
     return Optional.fromNullable(repairUnit);
   }
 
-  private void addRepairSegments(Collection<RepairSegment.Builder> newSegments, UUID runId) {
-    List<ResultSetFuture> insertFutures = Lists.<ResultSetFuture>newArrayList();
-    BatchStatement batch = new BatchStatement();
-    for(RepairSegment.Builder builder:newSegments){
-      RepairSegment segment = builder.withRunId(runId).build(UUIDs.timeBased());
-      insertFutures.add(session.executeAsync(
-              insertRepairSegmentPrepStmt.bind(
-                      segment.getId(),
-                      segment.getRepairUnitId(),
-                      segment.getRunId(),
-                      segment.getStartToken(),
-                      segment.getEndToken(),
-                      segment.getState().ordinal(),
-                      segment.getCoordinatorHost(),
-                      segment.getStartTime(),
-                      segment.getEndTime(),
-                      segment.getFailCount())));
-
-      batch.add(insertRepairSegmentByRunPrepStmt.bind(segment.getRunId(), segment.getId()));
-      if(insertFutures.size()%100==0){
-        // cluster ddos protection
-        session.execute(batch);
-        batch.clear();
-        for(ResultSetFuture insertFuture:insertFutures){
-          insertFuture.getUninterruptibly();
-        }
-        insertFutures = Lists.newArrayList();
-      }
-    }
-
-    // Wait for last queries to ack
-    if(batch.size()>0) {
-      session.execute(batch);
-    }
-    
-    for(ResultSetFuture insertFuture:insertFutures){
-      insertFuture.getUninterruptibly();
-    }
-  }
-
   @Override
   public boolean updateRepairSegment(RepairSegment newRepairSegment) {
     Date startTime = null;
     if (newRepairSegment.getStartTime() != null) {
        startTime = newRepairSegment.getStartTime().toDate();
     }
-    session.executeAsync(insertRepairSegmentPrepStmt.bind(newRepairSegment.getId(), newRepairSegment.getRepairUnitId(), newRepairSegment.getRunId(), newRepairSegment.getStartToken(), newRepairSegment.getEndToken(), newRepairSegment.getState().ordinal(), newRepairSegment.getCoordinatorHost(), startTime, newRepairSegment.getEndTime().toDate(), newRepairSegment.getFailCount()));
+    session.executeAsync(insertRepairSegmentPrepStmt.bind(
+            newRepairSegment.getRunId(),
+            newRepairSegment.getId(),
+            newRepairSegment.getRepairUnitId(),
+            newRepairSegment.getStartToken(),
+            newRepairSegment.getEndToken(),
+            newRepairSegment.getState().ordinal(),
+            newRepairSegment.getCoordinatorHost(),
+            startTime,
+            newRepairSegment.getEndTime().toDate(),
+            newRepairSegment.getFailCount()));
+
     return true;
   }
 
   @Override
-  public Optional<RepairSegment> getRepairSegment(UUID id) {
+  public Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId) {
     RepairSegment segment = null;
-    Row segmentRow = session.execute(getRepairSegmentPrepStmt.bind(id)).one();
+    Row segmentRow = session.execute(getRepairSegmentPrepStmt.bind(runId, segmentId)).one();
     if(segmentRow != null){
       segment = createRepairSegmentFromRow(segmentRow);
     }
@@ -417,53 +391,28 @@ public final class CassandraStorage implements IStorage {
 
   @Override
   public Collection<RepairSegment> getRepairSegmentsForRun(UUID runId) {
-    List<ResultSetFuture> segmentsFuture = Lists.newArrayList();
     Collection<RepairSegment> segments = Lists.newArrayList();
-
     // First gather segments ids
-    ResultSet segmentsIdResultSet = session.execute(getRepairSegmentByRunIdPrepStmt.bind(runId));
-    int i=0;
-    for(Row segmentIdResult:segmentsIdResultSet) {
-      // Then get segments by id
-      segmentsFuture.add(session.executeAsync(getRepairSegmentPrepStmt.bind(segmentIdResult.getUUID("segment_id"))));
-      i++;
-      if(i%100==0 || segmentsIdResultSet.isFullyFetched()) {
-        segments.addAll(fetchRepairSegmentFromFutures(segmentsFuture));
-        segmentsFuture = Lists.newArrayList();
-      }
-    }
-
-    return segments;
-  }
-  
-  private Collection<RepairSegment> fetchRepairSegmentFromFutures(List<ResultSetFuture> segmentsFuture){
-    Collection<RepairSegment> segments = Lists.newArrayList();
-    
-    for(ResultSetFuture segmentResult:segmentsFuture) {
-      Row segmentRow = segmentResult.getUninterruptibly().one();
-      if(segmentRow!=null){
+    ResultSet segmentsIdResultSet = session.execute(getRepairSegmentsByRunIdPrepStmt.bind(runId));
+    for(Row segmentRow : segmentsIdResultSet) {
         segments.add(createRepairSegmentFromRow(segmentRow));
-      }
-    }    
-    
+    }
     return segments;
-    
   }
 
-  private RepairSegment createRepairSegmentFromRow(Row segmentRow){
-    return createRepairSegmentFromRow(segmentRow, segmentRow.getUUID("id"));
-  }
-  private RepairSegment createRepairSegmentFromRow(Row segmentRow, UUID segmentId){
+  private static RepairSegment createRepairSegmentFromRow(Row segmentRow){
     return new RepairSegment.Builder(
-            new RingRange(new BigInteger(segmentRow.getVarint("start_token") +""), new BigInteger(segmentRow.getVarint("end_token")+"")),
+            new RingRange(
+                    new BigInteger(segmentRow.getVarint("start_token") +""),
+                    new BigInteger(segmentRow.getVarint("end_token")+"")),
             segmentRow.getUUID("repair_unit_id"))
-        .withRunId(segmentRow.getUUID("run_id"))
+        .withRunId(segmentRow.getUUID("id"))
         .coordinatorHost(segmentRow.getString("coordinator_host"))
-        .endTime(new DateTime(segmentRow.getTimestamp("end_time")))
+        .endTime(new DateTime(segmentRow.getTimestamp("segment_end_time")))
         .failCount(segmentRow.getInt("fail_count"))
-        .startTime(new DateTime(segmentRow.getTimestamp("start_time")))
-        .state(State.values()[segmentRow.getInt("state")])
-        .build(segmentRow.getUUID("id"));
+        .startTime(new DateTime(segmentRow.getTimestamp("segment_start_time")))
+        .state(State.values()[segmentRow.getInt("segment_state")])
+        .build(segmentRow.getUUID("segment_id"));
   }
 
 
@@ -484,7 +433,7 @@ public final class CassandraStorage implements IStorage {
 
     for(RepairSegment seg:segments){
       if(seg.getState().equals(State.NOT_STARTED) // State condition
-          && ((range.isPresent() && 
+          && ((range.isPresent() &&
               (range.get().getStart().compareTo(seg.getStartToken())>=0 || range.get().getEnd().compareTo(seg.getEndToken())<=0)
               ) || !range.isPresent()) // Token range condition
           ){
@@ -583,13 +532,13 @@ public final class CassandraStorage implements IStorage {
 
   private RepairSchedule createRepairScheduleFromRow(Row repairScheduleRow){
     return new RepairSchedule.Builder(repairScheduleRow.getUUID("repair_unit_id"),
-        RepairSchedule.State.valueOf(repairScheduleRow.getString("state")), 
-        repairScheduleRow.getInt("days_between"), 
-        new DateTime(repairScheduleRow.getTimestamp("next_activation")), 
+        RepairSchedule.State.valueOf(repairScheduleRow.getString("state")),
+        repairScheduleRow.getInt("days_between"),
+        new DateTime(repairScheduleRow.getTimestamp("next_activation")),
         ImmutableList.copyOf(repairScheduleRow.getSet("run_history", UUID.class)),
-        repairScheduleRow.getInt("segment_count"), 
-        RepairParallelism.fromName(repairScheduleRow.getString("repair_parallelism")), 
-        repairScheduleRow.getDouble("intensity"), 
+        repairScheduleRow.getInt("segment_count"),
+        RepairParallelism.fromName(repairScheduleRow.getString("repair_parallelism")),
+        repairScheduleRow.getDouble("intensity"),
         new DateTime(repairScheduleRow.getTimestamp("creation_time")))
         .owner(repairScheduleRow.getString("owner"))
         .pauseTime(new DateTime(repairScheduleRow.getTimestamp("pause_time"))).build(repairScheduleRow.getUUID("id"));
@@ -657,17 +606,17 @@ public final class CassandraStorage implements IStorage {
     final Set<UUID> repairHistory = Sets.newHashSet();
     repairHistory.addAll(newRepairSchedule.getRunHistory());
 
-    batch.add(insertRepairSchedulePrepStmt.bind(newRepairSchedule.getId(), 
-        newRepairSchedule.getRepairUnitId(), 
-        newRepairSchedule.getState().toString(), 
-        newRepairSchedule.getDaysBetween(), 
-        newRepairSchedule.getNextActivation(), 
-        repairHistory, 
+    batch.add(insertRepairSchedulePrepStmt.bind(newRepairSchedule.getId(),
+        newRepairSchedule.getRepairUnitId(),
+        newRepairSchedule.getState().toString(),
+        newRepairSchedule.getDaysBetween(),
+        newRepairSchedule.getNextActivation(),
+        repairHistory,
         newRepairSchedule.getSegmentCount(),
-        newRepairSchedule.getRepairParallelism().toString(), 
-        newRepairSchedule.getIntensity(), 
-        newRepairSchedule.getCreationTime(), 
-        newRepairSchedule.getOwner(), 
+        newRepairSchedule.getRepairParallelism().toString(),
+        newRepairSchedule.getIntensity(),
+        newRepairSchedule.getCreationTime(),
+        newRepairSchedule.getOwner(),
         newRepairSchedule.getPauseTime())
         );
     RepairUnit repairUnit = getRepairUnit(newRepairSchedule.getRepairUnitId()).get();
@@ -702,33 +651,39 @@ public final class CassandraStorage implements IStorage {
     for (RepairRun repairRun:repairRuns){
       Collection<RepairSegment> segments = getRepairSegmentsForRun(repairRun.getId());
       Optional<RepairUnit> repairUnit = getRepairUnit(repairRun.getRepairUnitId());
-      
+
       int segmentsRepaired = (int) segments.stream()
                                       .filter(seg -> seg.getState().equals(RepairSegment.State.DONE))
                                       .count();
-      
+
       repairRunStatuses.add(new RepairRunStatus(repairRun, repairUnit.get(), segmentsRepaired));
     }
-    
+
     return repairRunStatuses;
   }
 
   @Override
   public Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName) {
     Collection<RepairSchedule> repairSchedules = getRepairSchedulesForCluster(clusterName);
-    
+
     Collection<RepairScheduleStatus> repairScheduleStatuses = repairSchedules
             .stream()
             .map(sched -> new RepairScheduleStatus(sched, getRepairUnit(sched.getRepairUnitId()).get()))
             .collect(Collectors.toList());
-   
+
     return repairScheduleStatuses;
   }
 
 
 
   private RepairRun buildRepairRunFromRow(Row repairRunResult, UUID id){
-    return new RepairRun.Builder(repairRunResult.getString("cluster_name"), repairRunResult.getUUID("repair_unit_id"), new DateTime(repairRunResult.getTimestamp("creation_time")), repairRunResult.getDouble("intensity"), repairRunResult.getInt("segment_count"), RepairParallelism.fromName(repairRunResult.getString("repair_parallelism")))
+    return new RepairRun.Builder(
+            repairRunResult.getString("cluster_name"),
+            repairRunResult.getUUID("repair_unit_id"),
+            new DateTime(repairRunResult.getTimestamp("creation_time")),
+            repairRunResult.getDouble("intensity"),
+            repairRunResult.getInt("segment_count"),
+            RepairParallelism.fromName(repairRunResult.getString("repair_parallelism")))
         .cause(repairRunResult.getString("cause"))
         .owner(repairRunResult.getString("owner"))
         .endTime(new DateTime(repairRunResult.getTimestamp("end_time")))

--- a/src/main/java/com/spotify/reaper/storage/IStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/IStorage.java
@@ -94,7 +94,7 @@ public interface IStorage {
 
   boolean updateRepairSegment(RepairSegment newRepairSegment);
 
-  Optional<RepairSegment> getRepairSegment(UUID id);
+  Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId);
 
   Collection<RepairSegment> getRepairSegmentsForRun(UUID runId);
 

--- a/src/main/java/com/spotify/reaper/storage/MemoryStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/MemoryStorage.java
@@ -242,7 +242,7 @@ public final class MemoryStorage implements IStorage {
 
   @Override
   public boolean updateRepairSegment(RepairSegment newRepairSegment) {
-    if (getRepairSegment(newRepairSegment.getId()) == null) {
+    if (getRepairSegment(newRepairSegment.getRunId(), newRepairSegment.getId()) == null) {
       return false;
     } else {
       repairSegments.put(newRepairSegment.getId(), newRepairSegment);
@@ -254,8 +254,8 @@ public final class MemoryStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairSegment> getRepairSegment(UUID id) {
-    return Optional.fromNullable(repairSegments.get(id));
+  public Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId) {
+    return Optional.fromNullable(repairSegments.get(segmentId));
   }
 
   @Override

--- a/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
@@ -310,10 +310,10 @@ public final class PostgresStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairSegment> getRepairSegment(UUID id) {
+  public Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId) {
     RepairSegment result;
     try (Handle h = jdbi.open()) {
-      result = getPostgresStorage(h).getRepairSegment(toSequenceId(id));
+      result = getPostgresStorage(h).getRepairSegment(toSequenceId(segmentId));
     }
     return Optional.fromNullable(result);
   }

--- a/src/test/java/com/spotify/reaper/unit/service/RepairRunnerTest.java
+++ b/src/test/java/com/spotify/reaper/unit/service/RepairRunnerTest.java
@@ -93,7 +93,7 @@ public class RepairRunnerTest {
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegment(run.getId()).get().getId();
 
-    assertEquals(storage.getRepairSegment(SEGMENT_ID).get().getState(),
+    assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(),
                  RepairSegment.State.NOT_STARTED);
     AppContext context = new AppContext();
     context.storage = storage;
@@ -121,7 +121,7 @@ public class RepairRunnerTest {
               @Override
               public Integer answer(InvocationOnMock invocation) throws Throwable {
                 assertEquals(RepairSegment.State.NOT_STARTED,
-                             storage.getRepairSegment(SEGMENT_ID).get().getState());
+                             storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
 
                 final int repairNumber = repairAttempts.getAndIncrement();
                 switch (repairNumber) {
@@ -132,7 +132,7 @@ public class RepairRunnerTest {
                         handler.get()
                             .handle(repairNumber, Optional.of(ActiveRepairService.Status.STARTED), Optional.absent(), null);
                         assertEquals(RepairSegment.State.RUNNING,
-                                     storage.getRepairSegment(SEGMENT_ID).get().getState());
+                                     storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
                       }
                     }.start();
                     break;
@@ -143,11 +143,11 @@ public class RepairRunnerTest {
                         handler.get()
                             .handle(repairNumber, Optional.of(ActiveRepairService.Status.STARTED), Optional.absent(), null);
                         assertEquals(RepairSegment.State.RUNNING,
-                            storage.getRepairSegment(SEGMENT_ID).get().getState());
+                            storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
                         handler.get()
                             .handle(repairNumber, Optional.of(ActiveRepairService.Status.SESSION_SUCCESS), Optional.absent(), null);
                         assertEquals(RepairSegment.State.DONE,
-                            storage.getRepairSegment(SEGMENT_ID).get().getState());
+                            storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
                         handler.get()
                             .handle(repairNumber, Optional.of(ActiveRepairService.Status.FINISHED), Optional.absent(), null);
                         mutex.release();
@@ -196,7 +196,7 @@ public class RepairRunnerTest {
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegment(run.getId()).get().getId();
 
-    assertEquals(storage.getRepairSegment(SEGMENT_ID).get().getState(),
+    assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(),
                  RepairSegment.State.NOT_STARTED);
     AppContext context = new AppContext();
     context.storage = storage;
@@ -225,7 +225,7 @@ public class RepairRunnerTest {
               @Override
               public Integer answer(InvocationOnMock invocation) throws Throwable {
                 assertEquals(RepairSegment.State.NOT_STARTED,
-                             storage.getRepairSegment(SEGMENT_ID).get().getState());
+                             storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
 
                 final int repairNumber = repairAttempts.getAndIncrement();
                 switch (repairNumber) {
@@ -236,7 +236,7 @@ public class RepairRunnerTest {
                         handler.get()
                             .handle(repairNumber, Optional.absent(), Optional.of(ProgressEventType.START), null);
                         assertEquals(RepairSegment.State.RUNNING,
-                                     storage.getRepairSegment(SEGMENT_ID).get().getState());
+                                     storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
                       }
                     }.start();
                     break;
@@ -247,11 +247,11 @@ public class RepairRunnerTest {
                         handler.get()
                             .handle(repairNumber, Optional.absent(), Optional.of(ProgressEventType.START), null);
                         assertEquals(RepairSegment.State.RUNNING,
-                            storage.getRepairSegment(SEGMENT_ID).get().getState());
+                            storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
                         handler.get()
                             .handle(repairNumber, Optional.absent(), Optional.of(ProgressEventType.SUCCESS), null);
                         assertEquals(RepairSegment.State.DONE,
-                            storage.getRepairSegment(SEGMENT_ID).get().getState());
+                            storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
                         handler.get()
                             .handle(repairNumber, Optional.absent(), Optional.of(ProgressEventType.COMPLETE), null);
                         mutex.release();
@@ -308,7 +308,7 @@ public class RepairRunnerTest {
 
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    assertEquals(storage.getRepairSegment(SEGMENT_ID).get().getState(),
+    assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(),
                  RepairSegment.State.NOT_STARTED);
     context.jmxConnectionFactory = new JmxConnectionFactory() {
       @Override
@@ -327,7 +327,7 @@ public class RepairRunnerTest {
               @Override
               public Integer answer(InvocationOnMock invocation) throws Throwable {
                 assertEquals(RepairSegment.State.NOT_STARTED,
-                             storage.getRepairSegment(SEGMENT_ID).get().getState());
+                             storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState());
                 new Thread() {
                   @Override
                   public void run() {

--- a/src/test/resources/cassandra-reaper-cassandra-at.yaml
+++ b/src/test/resources/cassandra-reaper-cassandra-at.yaml
@@ -8,6 +8,7 @@ repairRunThreadCount: 15
 hangingRepairTimeoutMins: 1
 storageType: cassandra
 incrementalRepair: false
+allowUnreachableNodes: true
 
 logging:
   level: DEBUG


### PR DESCRIPTION
Collapses three tables into just one `repair_run`.

Also a change as required in IStorage so to identify a segment both by runId and segmentId.

ref:
 - https://github.com/thelastpickle/cassandra-reaper/issues/94
 - https://github.com/thelastpickle/cassandra-reaper/pull/102