### PR TITLE
Fix number of parallel repair computation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.1.0</dropwizard.version>
+        <dropwizard.version>1.0.7</dropwizard.version>
         <dropwizard.cassandra.version>4.1.0</dropwizard.cassandra.version>
         <cassandra.version>2.2.7</cassandra.version>
         <cucumber.version>1.2.5</cucumber.version>

--- a/resource/cassandra-reaper-cassandra-ssl.yaml
+++ b/resource/cassandra-reaper-cassandra-ssl.yaml
@@ -12,6 +12,7 @@ enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
 enableDynamicSeedList: true
+repairManagerSchedulingIntervalSeconds: 30
 
 jmxPorts:
   127.0.0.1: 7198

--- a/resource/cassandra-reaper-cassandra.yaml
+++ b/resource/cassandra-reaper-cassandra.yaml
@@ -12,6 +12,7 @@ enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
 enableDynamicSeedList: true
+repairManagerSchedulingIntervalSeconds: 30
 
 jmxPorts:
   127.0.0.1: 7100

--- a/resource/cassandra-reaper-h2.yaml
+++ b/resource/cassandra-reaper-h2.yaml
@@ -12,6 +12,7 @@ enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
 enableDynamicSeedList: true
+repairManagerSchedulingIntervalSeconds: 30
 
 jmxPorts:
   127.0.0.1: 7100

--- a/resource/cassandra-reaper-memory.yaml
+++ b/resource/cassandra-reaper-memory.yaml
@@ -12,6 +12,7 @@ enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
 enableDynamicSeedList: true
+repairManagerSchedulingIntervalSeconds: 30
 
 jmxPorts:
   127.0.0.1: 7100

--- a/resource/cassandra-reaper-postgres.yaml
+++ b/resource/cassandra-reaper-postgres.yaml
@@ -12,6 +12,7 @@ enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
 enableDynamicSeedList: true
+repairManagerSchedulingIntervalSeconds: 30
 
 jmxPorts:
   127.0.0.1: 7100

--- a/resource/cassandra-reaper.yaml
+++ b/resource/cassandra-reaper.yaml
@@ -12,6 +12,7 @@ enableCrossOrigin: true
 incrementalRepair: false
 allowUnreachableNodes: false
 enableDynamicSeedList: true
+repairManagerSchedulingIntervalSeconds: 30
 
 jmxPorts:
   127.0.0.1: 7100

--- a/src/main/java/com/spotify/reaper/ReaperApplication.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplication.java
@@ -122,7 +122,7 @@ public class ReaperApplication extends Application<ReaperApplicationConfiguratio
     context.repairManager.initializeThreadPool(
         config.getRepairRunThreadCount(),
         config.getHangingRepairTimeoutMins(), TimeUnit.MINUTES,
-        30, TimeUnit.SECONDS);
+        config.getRepairManagerSchedulingIntervalSeconds(), TimeUnit.SECONDS);
 
     if (context.storage == null) {
       LOG.info("initializing storage of type: {}", config.getStorageType());

--- a/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
+++ b/src/main/java/com/spotify/reaper/ReaperApplicationConfiguration.java
@@ -93,6 +93,9 @@ public class ReaperApplicationConfiguration extends Configuration {
   @JsonProperty
   @DefaultValue("true")
   private Boolean enableDynamicSeedList;
+  
+  @JsonProperty
+  private Integer repairManagerSchedulingIntervalSeconds;
 
   public int getSegmentCount() {
     return segmentCount;
@@ -170,13 +173,13 @@ public class ReaperApplicationConfiguration extends Configuration {
     this.database = database;
   }
 
-  public int getHangingRepairTimeoutMins() {
-    return hangingRepairTimeoutMins;
+  public int getRepairManagerSchedulingIntervalSeconds() {
+    return this.repairManagerSchedulingIntervalSeconds==null?30:this.repairManagerSchedulingIntervalSeconds;
   }
 
   @JsonProperty
-  public void setHangingRepairTimeoutMins(int hangingRepairTimeoutMins) {
-    this.hangingRepairTimeoutMins = hangingRepairTimeoutMins;
+  public void setRepairManagerSchedulingIntervalSeconds(int repairManagerSchedulingIntervalSeconds) {
+    this.repairManagerSchedulingIntervalSeconds = repairManagerSchedulingIntervalSeconds;
   }
 
   public Map<String, Integer> getJmxPorts() {
@@ -259,6 +262,15 @@ public class ReaperApplicationConfiguration extends Configuration {
 
   public void setAllowUnreachableNodes(Boolean allow) {
     this.allowUnreachableNodes = allow;
+  }
+  
+  public int getHangingRepairTimeoutMins() {
+    return hangingRepairTimeoutMins;
+  }
+
+  @JsonProperty
+  public void setHangingRepairTimeoutMins(int hangingRepairTimeoutMins) {
+    this.hangingRepairTimeoutMins = hangingRepairTimeoutMins;
   }
   
   public static class AutoSchedulingConfiguration {

--- a/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
+++ b/src/main/java/com/spotify/reaper/cassandra/JmxProxy.java
@@ -236,6 +236,18 @@ public class JmxProxy implements NotificationListener, AutoCloseable {
   }
 
   /**
+   * @return all hosts in the ring with their host id
+   */
+  @NotNull
+  public Map<String, String> getEndpointToHostId() {
+    checkNotNull(ssProxy, "Looks like the proxy is not connected");
+    Map<String, String> hosts =
+        ((StorageServiceMBean) ssProxy).getEndpointToHostId();
+    
+    return hosts;
+  }
+
+  /**
    * @return full class name of Cassandra's partitioner.
    */
   public String getPartitioner() {

--- a/src/test/java/com/spotify/reaper/unit/service/RepairRunnerTest.java
+++ b/src/test/java/com/spotify/reaper/unit/service/RepairRunnerTest.java
@@ -362,10 +362,12 @@ public class RepairRunnerTest {
   @Test
   public void getPossibleParallelRepairsTest() throws Exception {
     Map<List<String>, List<String>> map = RepairRunnerTest.threeNodeCluster();
-    assertEquals(1, RepairRunner.getPossibleParallelRepairsCount(map));
+    Map<String, String> endpointsThreeNodes = RepairRunnerTest.threeNodeClusterEndpoint();
+    assertEquals(1, RepairRunner.getPossibleParallelRepairsCount(map, endpointsThreeNodes));
 
     map = RepairRunnerTest.sixNodeCluster();
-    assertEquals(2, RepairRunner.getPossibleParallelRepairsCount(map));
+    Map<String, String> endpointsSixNodes = RepairRunnerTest.sixNodeClusterEndpoint();
+    assertEquals(2, RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes));
   }
 
   @Test
@@ -384,8 +386,37 @@ public class RepairRunnerTest {
     List<RingRange> segments = generator.generateSegments(32, tokens, Boolean.FALSE);
 
     Map<List<String>, List<String>> map = RepairRunnerTest.sixNodeCluster();
+    Map<String, String> endpointsSixNodes = RepairRunnerTest.sixNodeClusterEndpoint();
     List<RingRange> ranges = RepairRunner.getParallelRanges(
-        RepairRunner.getPossibleParallelRepairsCount(map),
+        RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes),
+        segments
+    );
+    assertEquals(2, ranges.size());
+    assertEquals(  "0", ranges.get(0).getStart().toString());
+    assertEquals("150", ranges.get(0).getEnd().toString());
+    assertEquals("150", ranges.get(1).getStart().toString());
+    assertEquals(  "0", ranges.get(1).getEnd().toString());
+  }
+  
+  @Test
+  public void getParallelSegmentsTest2() throws ReaperException {
+    List<BigInteger> tokens = Lists.transform(
+        Lists.newArrayList("0", "25", "50", "75", "100", "125", "150", "175", "200", "225", "250"),
+        new Function<String, BigInteger>() {
+          @Nullable
+          @Override
+          public BigInteger apply(String s) {
+            return new BigInteger(s);
+          }
+        }
+    );
+    SegmentGenerator generator = new SegmentGenerator(new BigInteger("0"), new BigInteger("299"));
+    List<RingRange> segments = generator.generateSegments(32, tokens, Boolean.FALSE);
+
+    Map<List<String>, List<String>> map = RepairRunnerTest.sixNodeCluster();
+    Map<String, String> endpointsSixNodes = RepairRunnerTest.sixNodeClusterEndpoint();
+    List<RingRange> ranges = RepairRunner.getParallelRanges(
+        RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes),
         segments
     );
     assertEquals(2, ranges.size());
@@ -413,6 +444,26 @@ public class RepairRunnerTest {
     map = addRangeToMap(map, "250",   "0", "a6", "a1", "a2");
     return map;
   }
+  
+  public static Map<String, String> threeNodeClusterEndpoint() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put("host1", "hostId1");
+    map.put("host2", "hostId2");
+    map.put("host3", "hostId3");
+    return map;
+  }
+
+  public static Map<String, String> sixNodeClusterEndpoint() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put("host1", "hostId1");
+    map.put("host2", "hostId2");
+    map.put("host3", "hostId3");
+    map.put("host4", "hostId4");
+    map.put("host5", "hostId5");
+    map.put("host6", "hostId6");
+    return map;
+  }
+
 
   private static Map<List<String>, List<String>> addRangeToMap(Map<List<String>, List<String>> map,
       String rStart, String rEnd, String... hosts) {


### PR DESCRIPTION
Fix computation of the number of parallel repairs by using the number of nodes instead of the number of tokens.
Add local caching for repair segments.
Downgrade to Dropwizard 1.0.7 and Guava 19.0 to fix dependency issues.
Make repair manager schedule cycle configurable (was 30s hardcoded).