### PR TITLE
move into the next development cycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <name>Cassandra Reaper</name>
     <groupId>com.spotify</groupId>
     <artifactId>cassandra-reaper</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
It's healthy to only have non-snapshot versions existing in one git SHA.
That is master should be bumped immediately into SNAPSHOT, after each release, to ensure releases are attached to unique SHA and of the one distribution.

For example, now in master a `mvn install` would overwrite the 0.6.0 release on your local machine.