### PR TITLE
Adds integration test to ensure scheduled repairs can initiate repair runs, and maintain history

### DIFF
--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleMapper.java
@@ -34,21 +34,21 @@ public class RepairScheduleMapper implements ResultSetMapper<RepairSchedule> {
     
     UUID[] runHistoryUUIDs = new UUID[0];
     
-    Integer[] runHistory = null;
+    Number[] runHistory = null;
     Array av = r.getArray("run_history");
     if(null != av) {
       Object obj = av.getArray();
-      if(obj instanceof Integer[]) {
-        runHistory = (Integer[])obj;
+      if(obj instanceof Number[]) {
+        runHistory = (Number[])obj;
       } else if(obj instanceof Object[]) {
         Object[] ol = (Object[])obj;
-        runHistory = Arrays.copyOf(ol, ol.length, Integer[].class);
+        runHistory = Arrays.copyOf(ol, ol.length, Number[].class);
       }
       
       if (null != runHistory && runHistory.length > 0) {
         runHistoryUUIDs = new UUID[runHistory.length];
         for (int i = 0; i < runHistory.length; i++) {
-          runHistoryUUIDs[i] = fromSequenceId(runHistory[i]);
+          runHistoryUUIDs[i] = fromSequenceId(runHistory[i].longValue());
         }
       }
     }  

--- a/src/test/resources/com.spotify.reaper.acceptance/integration_reaper_functionality.feature
+++ b/src/test/resources/com.spotify.reaper.acceptance/integration_reaper_functionality.feature
@@ -27,7 +27,26 @@ Feature: Using Reaper to launch repairs and schedule them
     When the last added schedule is deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
- 
+
+  Scenario: Create a cluster and a scheduled repair run with repair run history and delete them
+    Given that we are going to use "127.0.0.1" as cluster seed host
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for the last added cluster
+    When a new daily repair schedule is added for the last added cluster and keyspace "booya" with next repair immediately
+    Then reaper has 1 scheduled repairs for the last added cluster
+    And deleting the last added cluster fails
+    When we wait for a scheduled repair run has started for cluster "test_cluster"
+    And we wait for at least 1 segments to be repaired
+    Then reaper has 1 repairs for the last added cluster
+    When the last added repair is stopped
+    And the last added repair run is deleted
+    And deleting the last added cluster fails
+    When all added schedules are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+
   Scenario: Create a cluster and a repair run and delete them
     Given that we are going to use "127.0.0.1" as cluster seed host
     And reaper has no cluster in storage


### PR DESCRIPTION
Adds integration test to ensure scheduled repairs can initiate repair runs, and maintain history

 This test fails before commit https://github.com/thelastpickle/cassandra-reaper/commit/3d16533fe5be00cd1ce500225349068b33b974bf, and passes with and after it.

 Part of the requirement is that, with assertions enabled, as they are when running tests, the SchedulingManager exits the JVM on errors.
 This is ok, as fail-fast behaviour would be expected when assertions are enabled.

ref:
 - https://github.com/thelastpickle/cassandra-reaper/issues/113 – PostgreSQL exception since the ID changed to UUID
 - https://github.com/thelastpickle/cassandra-reaper/pull/114 – LongCollectionSQLType should hold Longs, not UUIDs 