### PR TITLE
Allow the auto scheduler to honour the incrementalRepair option.

### DIFF
--- a/src/main/java/com/spotify/reaper/service/ClusterRepairScheduler.java
+++ b/src/main/java/com/spotify/reaper/service/ClusterRepairScheduler.java
@@ -71,10 +71,11 @@ public class ClusterRepairScheduler {
 
   private void createRepairSchedule(Cluster cluster, String keyspace, DateTime nextActivationTime) {
     try {
+      Boolean incrementalRepair = context.config.getIncrementalRepair() != null ? context.config.getIncrementalRepair() : Boolean.FALSE;
       RepairSchedule repairSchedule = CommonTools.storeNewRepairSchedule(
           context,
           cluster,
-          CommonTools.getNewOrExistingRepairUnit(context, cluster, keyspace, Collections.emptySet(), Boolean.FALSE),
+          CommonTools.getNewOrExistingRepairUnit(context, cluster, keyspace, Collections.emptySet(), incrementalRepair),
           context.config.getScheduleDaysBetween(),
           nextActivationTime,
           REPAIR_OWNER,


### PR DESCRIPTION
Currently the auto-scheduler will always schedule a full repair, regardless of the incrementalRepair option. This PR will honour that setting, allowing to auto-schedule incremental repairs.