### PR TITLE
In CassandraStorage remove batch statements

### DIFF
--- a/resource/cassandra-reaper-cassandra.yaml
+++ b/resource/cassandra-reaper-cassandra.yaml
@@ -59,9 +59,6 @@ cassandra:
   clusterName: "test"
   contactPoints: ["127.0.0.1"]
   keyspace: reaper_db
-  queryOptions:
-    consistencyLevel: LOCAL_QUORUM
-    serialConsistencyLevel: SERIAL
 
 autoScheduling:
   enabled: false

--- a/resource/cassandra-reaper-cassandra2.yaml
+++ b/resource/cassandra-reaper-cassandra2.yaml
@@ -57,9 +57,6 @@ cassandra:
   clusterName: "test"
   contactPoints: ["127.0.0.1"]
   keyspace: reaper_db
-  queryOptions:
-    consistencyLevel: LOCAL_QUORUM
-    serialConsistencyLevel: SERIAL
 
 autoScheduling:
   enabled: false

--- a/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -204,7 +204,6 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   @Override
   public RepairRun addRepairRun(Builder repairRun, Collection<RepairSegment.Builder> newSegments) {
     RepairRun newRepairRun = repairRun.build(UUIDs.timeBased());
-    BatchStatement batch = new BatchStatement();
     BatchStatement repairRunBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
 
     repairRunBatch.add(insertRepairRunPrepStmt.bind(
@@ -214,18 +213,17 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
             newRepairRun.getCause(),
             newRepairRun.getOwner(),
             newRepairRun.getRunState().toString(),
-            newRepairRun.getCreationTime()==null?null:newRepairRun.getCreationTime(),
-            newRepairRun.getStartTime()==null?null:newRepairRun.getStartTime(),
-            newRepairRun.getEndTime()==null?null:newRepairRun.getEndTime(),
-            newRepairRun.getPauseTime()==null?null:newRepairRun.getPauseTime(),
+            newRepairRun.getCreationTime(),
+            newRepairRun.getStartTime(),
+            newRepairRun.getEndTime(),
+            newRepairRun.getPauseTime(),
             newRepairRun.getIntensity(),
             newRepairRun.getLastEvent(),
             newRepairRun.getSegmentCount(),
             newRepairRun.getRepairParallelism().toString()));
 
-    batch.add(insertRepairRunClusterIndexPrepStmt.bind(newRepairRun.getClusterName(), newRepairRun.getId()));
-    batch.add(insertRepairRunUnitIndexPrepStmt.bind(newRepairRun.getRepairUnitId(), newRepairRun.getId()));
-    session.execute(batch);
+    session.execute(insertRepairRunClusterIndexPrepStmt.bind(newRepairRun.getClusterName(), newRepairRun.getId()));
+    session.execute(insertRepairRunUnitIndexPrepStmt.bind(newRepairRun.getRepairUnitId(), newRepairRun.getId()));
 
     for(RepairSegment.Builder builder:newSegments){
       RepairSegment segment = builder.withRunId(newRepairRun.getId()).build(UUIDs.timeBased());
@@ -345,11 +343,9 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   public Optional<RepairRun> deleteRepairRun(UUID id) {
     Optional<RepairRun> repairRun = getRepairRun(id);
     if(repairRun.isPresent()){
-      BatchStatement batch = new BatchStatement();
-      batch.add(deleteRepairRunPrepStmt.bind(id));
-      batch.add(deleteRepairRunByClusterPrepStmt.bind(id, repairRun.get().getClusterName()));
-      batch.add(deleteRepairRunByUnitPrepStmt.bind(id, repairRun.get().getRepairUnitId()));
-      session.execute(batch);
+      session.execute(deleteRepairRunPrepStmt.bind(id));
+      session.execute(deleteRepairRunByClusterPrepStmt.bind(id, repairRun.get().getClusterName()));
+      session.execute(deleteRepairRunByUnitPrepStmt.bind(id, repairRun.get().getRepairUnitId()));
     }
     return repairRun;
   }
@@ -637,11 +633,10 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   @Override
   public boolean updateRepairSchedule(RepairSchedule newRepairSchedule) {
-    BatchStatement batch = new BatchStatement();
     final Set<UUID> repairHistory = Sets.newHashSet();
     repairHistory.addAll(newRepairSchedule.getRunHistory());
 
-    batch.add(insertRepairSchedulePrepStmt.bind(newRepairSchedule.getId(),
+    session.execute(insertRepairSchedulePrepStmt.bind(newRepairSchedule.getId(),
         newRepairSchedule.getRepairUnitId(),
         newRepairSchedule.getState().toString(),
         newRepairSchedule.getDaysBetween(),
@@ -655,10 +650,15 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
         newRepairSchedule.getPauseTime())
         );
     RepairUnit repairUnit = getRepairUnit(newRepairSchedule.getRepairUnitId()).get();
-    batch.add(insertRepairScheduleByClusterAndKsPrepStmt.bind(repairUnit.getClusterName(), repairUnit.getKeyspaceName(), newRepairSchedule.getId()));
-    batch.add(insertRepairScheduleByClusterAndKsPrepStmt.bind(repairUnit.getClusterName(), " ", newRepairSchedule.getId()));
-    batch.add(insertRepairScheduleByClusterAndKsPrepStmt.bind(" ", repairUnit.getKeyspaceName(), newRepairSchedule.getId()));
-    session.execute(batch);
+
+    session.execute(insertRepairScheduleByClusterAndKsPrepStmt
+            .bind(repairUnit.getClusterName(), repairUnit.getKeyspaceName(), newRepairSchedule.getId()));
+
+    session.execute(insertRepairScheduleByClusterAndKsPrepStmt
+            .bind(repairUnit.getClusterName(), " ", newRepairSchedule.getId()));
+
+    session.execute(insertRepairScheduleByClusterAndKsPrepStmt
+            .bind(" ", repairUnit.getKeyspaceName(), newRepairSchedule.getId()));
 
     return true;
   }
@@ -668,12 +668,16 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     Optional<RepairSchedule> repairSchedule = getRepairSchedule(id);
     if(repairSchedule.isPresent()){
       RepairUnit repairUnit = getRepairUnit(repairSchedule.get().getRepairUnitId()).get();
-      BatchStatement batch = new BatchStatement();
-      batch.add(deleteRepairSchedulePrepStmt.bind(repairSchedule.get().getId()));
-      batch.add(deleteRepairScheduleByClusterAndKsPrepStmt.bind(repairUnit.getClusterName(), repairUnit.getKeyspaceName(), repairSchedule.get().getId()));
-      batch.add(deleteRepairScheduleByClusterAndKsPrepStmt.bind(repairUnit.getClusterName(), " ", repairSchedule.get().getId()));
-      batch.add(deleteRepairScheduleByClusterAndKsPrepStmt.bind(" ", repairUnit.getKeyspaceName(), repairSchedule.get().getId()));
-      session.execute(batch);
+      session.execute(deleteRepairSchedulePrepStmt.bind(repairSchedule.get().getId()));
+
+      session.execute(deleteRepairScheduleByClusterAndKsPrepStmt
+              .bind(repairUnit.getClusterName(), repairUnit.getKeyspaceName(), repairSchedule.get().getId()));
+
+      session.execute(deleteRepairScheduleByClusterAndKsPrepStmt
+              .bind(repairUnit.getClusterName(), " ", repairSchedule.get().getId()));
+
+      session.execute(deleteRepairScheduleByClusterAndKsPrepStmt
+              .bind(" ", repairUnit.getKeyspaceName(), repairSchedule.get().getId()));
     }
 
     return repairSchedule;

--- a/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -3,15 +3,12 @@ package com.spotify.reaper.storage;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.CodecRegistry;
@@ -23,13 +20,12 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
-import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Optional;
-import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Futures;
 import com.spotify.reaper.ReaperApplication;
 import com.spotify.reaper.ReaperApplicationConfiguration;
 import com.spotify.reaper.core.Cluster;
@@ -47,14 +43,15 @@ import com.spotify.reaper.service.RepairParameters;
 import com.spotify.reaper.service.RingRange;
 import com.spotify.reaper.storage.cassandra.DateTimeCodec;
 import com.spotify.reaper.storage.cassandra.Migration003;
-
+import io.dropwizard.setup.Environment;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.cognitor.cassandra.migration.Database;
 import org.cognitor.cassandra.migration.MigrationRepository;
 import org.cognitor.cassandra.migration.MigrationTask;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import io.dropwizard.setup.Environment;
 import systems.composable.dropwizard.cassandra.CassandraFactory;
 
 public final class CassandraStorage implements IStorage, IDistributedStorage {
@@ -103,10 +100,10 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     CassandraFactory cassandraFactory = config.getCassandraFactory();
     // all INSERT and DELETE statement prepared in this class are idempotent
     cassandraFactory.setQueryOptions(java.util.Optional.of(new QueryOptions().setDefaultIdempotence(true)));
-    cassandra = config.getCassandraFactory().build(environment);
-
+    cassandra = cassandraFactory.build(environment);
     if(config.getActivateQueryLogger())
       cassandra.register(QueryLogger.builder().build());
+    
     CodecRegistry codecRegistry = cassandra.getConfiguration().getCodecRegistry();
     codecRegistry.register(new DateTimeCodec());
     session = cassandra.connect(config.getCassandraFactory().getKeyspace());
@@ -171,12 +168,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   @Override
   public boolean addCluster(Cluster cluster) {
-    try {
-      session.execute(insertClusterPrepStmt.bind(cluster.getName(), cluster.getPartitioner(), cluster.getSeedHosts()));
-    } catch (Exception e) {
-      LOG.warn("failed inserting cluster with name: {}", cluster.getName(), e);
-      return false;
-    }
+    session.execute(insertClusterPrepStmt.bind(cluster.getName(), cluster.getPartitioner(), cluster.getSeedHosts()));
     return true;
   }
 
@@ -187,17 +179,17 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   @Override
   public Optional<Cluster> getCluster(String clusterName) {
-    Cluster cluster = null;
-    for(Row clusterRow : session.execute(getClusterPrepStmt.bind(clusterName))){
-      cluster = new Cluster(clusterRow.getString("name"), clusterRow.getString("partitioner"), clusterRow.getSet("seed_hosts", String.class));
-    }
-
-    return Optional.fromNullable(cluster);
+    Row r = session.execute(getClusterPrepStmt.bind(clusterName)).one();
+    
+    return r != null
+            ? Optional.fromNullable(
+                new Cluster(r.getString("name"), r.getString("partitioner"), r.getSet("seed_hosts", String.class)))
+            : Optional.absent();
   }
 
   @Override
   public Optional<Cluster> deleteCluster(String clusterName) {
-    session.execute(deleteClusterPrepStmt.bind(clusterName));
+    session.executeAsync(deleteClusterPrepStmt.bind(clusterName));
     return Optional.fromNullable(new Cluster(clusterName, null, null));
   }
 
@@ -222,9 +214,6 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
             newRepairRun.getSegmentCount(),
             newRepairRun.getRepairParallelism().toString()));
 
-    session.execute(insertRepairRunClusterIndexPrepStmt.bind(newRepairRun.getClusterName(), newRepairRun.getId()));
-    session.execute(insertRepairRunUnitIndexPrepStmt.bind(newRepairRun.getRepairUnitId(), newRepairRun.getId()));
-
     for(RepairSegment.Builder builder:newSegments){
       RepairSegment segment = builder.withRunId(newRepairRun.getId()).build(UUIDs.timeBased());
 
@@ -241,17 +230,33 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
             segment.getFailCount()));
 
       if(100 == repairRunBatch.size()){
-          session.execute(repairRunBatch);
+          session.executeAsync(repairRunBatch);
           repairRunBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
       }
     }
-    session.execute(repairRunBatch);
+    session.executeAsync(repairRunBatch);
+    session.executeAsync(insertRepairRunClusterIndexPrepStmt.bind(newRepairRun.getClusterName(), newRepairRun.getId()));
+    session.executeAsync(insertRepairRunUnitIndexPrepStmt.bind(newRepairRun.getRepairUnitId(), newRepairRun.getId()));
     return newRepairRun;
   }
 
   @Override
   public boolean updateRepairRun(RepairRun repairRun) {
-    session.execute(insertRepairRunPrepStmt.bind(repairRun.getId(), repairRun.getClusterName(), repairRun.getRepairUnitId(), repairRun.getCause(), repairRun.getOwner(), repairRun.getRunState().toString(), repairRun.getCreationTime(), repairRun.getStartTime(), repairRun.getEndTime(), repairRun.getPauseTime(), repairRun.getIntensity(), repairRun.getLastEvent(), repairRun.getSegmentCount(), repairRun.getRepairParallelism().toString()));
+    session.executeAsync(insertRepairRunPrepStmt.bind(
+            repairRun.getId(), 
+            repairRun.getClusterName(), 
+            repairRun.getRepairUnitId(), 
+            repairRun.getCause(), 
+            repairRun.getOwner(), 
+            repairRun.getRunState().toString(), 
+            repairRun.getCreationTime(), 
+            repairRun.getStartTime(), 
+            repairRun.getEndTime(), 
+            repairRun.getPauseTime(), 
+            repairRun.getIntensity(), 
+            repairRun.getLastEvent(), 
+            repairRun.getSegmentCount(), 
+            repairRun.getRepairParallelism().toString()));
     return true;
   }
 
@@ -343,9 +348,9 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   public Optional<RepairRun> deleteRepairRun(UUID id) {
     Optional<RepairRun> repairRun = getRepairRun(id);
     if(repairRun.isPresent()){
-      session.execute(deleteRepairRunPrepStmt.bind(id));
-      session.execute(deleteRepairRunByClusterPrepStmt.bind(id, repairRun.get().getClusterName()));
-      session.execute(deleteRepairRunByUnitPrepStmt.bind(id, repairRun.get().getRepairUnitId()));
+      session.executeAsync(deleteRepairRunByUnitPrepStmt.bind(id, repairRun.get().getRepairUnitId()));
+      session.executeAsync(deleteRepairRunByClusterPrepStmt.bind(id, repairRun.get().getClusterName()));
+      session.executeAsync(deleteRepairRunPrepStmt.bind(id));
     }
     return repairRun;
   }
@@ -553,12 +558,11 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   @Override
   public Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId) {
-    RepairSchedule schedule = null;
     Row sched = session.execute(getRepairSchedulePrepStmt.bind(repairScheduleId)).one();
-    if(sched!=null){
-      schedule = createRepairScheduleFromRow(sched);
-    }
-    return Optional.fromNullable(schedule);
+
+    return sched != null
+            ? Optional.fromNullable(createRepairScheduleFromRow(sched))
+            : Optional.absent();
   }
 
   private RepairSchedule createRepairScheduleFromRow(Row repairScheduleRow){
@@ -625,9 +629,8 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     ResultSet scheduleResults = session.execute("SELECT * FROM repair_schedule_v1");
     for(Row scheduleRow:scheduleResults){
       schedules.add(createRepairScheduleFromRow(scheduleRow));
-
     }
-
+    
     return schedules;
   }
 
@@ -635,8 +638,10 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   public boolean updateRepairSchedule(RepairSchedule newRepairSchedule) {
     final Set<UUID> repairHistory = Sets.newHashSet();
     repairHistory.addAll(newRepairSchedule.getRunHistory());
+    RepairUnit repairUnit = getRepairUnit(newRepairSchedule.getRepairUnitId()).get();
+    List<ResultSetFuture> futures = Lists.newArrayList();
 
-    session.execute(insertRepairSchedulePrepStmt.bind(newRepairSchedule.getId(),
+    futures.add(session.executeAsync(insertRepairSchedulePrepStmt.bind(newRepairSchedule.getId(),
         newRepairSchedule.getRepairUnitId(),
         newRepairSchedule.getState().toString(),
         newRepairSchedule.getDaysBetween(),
@@ -647,18 +652,22 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
         newRepairSchedule.getIntensity(),
         newRepairSchedule.getCreationTime(),
         newRepairSchedule.getOwner(),
-        newRepairSchedule.getPauseTime())
-        );
-    RepairUnit repairUnit = getRepairUnit(newRepairSchedule.getRepairUnitId()).get();
+        newRepairSchedule.getPauseTime())));
 
-    session.execute(insertRepairScheduleByClusterAndKsPrepStmt
-            .bind(repairUnit.getClusterName(), repairUnit.getKeyspaceName(), newRepairSchedule.getId()));
+    futures.add(session.executeAsync(insertRepairScheduleByClusterAndKsPrepStmt
+            .bind(repairUnit.getClusterName(), repairUnit.getKeyspaceName(), newRepairSchedule.getId())));
 
-    session.execute(insertRepairScheduleByClusterAndKsPrepStmt
-            .bind(repairUnit.getClusterName(), " ", newRepairSchedule.getId()));
+    futures.add(session.executeAsync(insertRepairScheduleByClusterAndKsPrepStmt
+            .bind(repairUnit.getClusterName(), " ", newRepairSchedule.getId())));
 
-    session.execute(insertRepairScheduleByClusterAndKsPrepStmt
-            .bind(" ", repairUnit.getKeyspaceName(), newRepairSchedule.getId()));
+    futures.add(session.executeAsync(insertRepairScheduleByClusterAndKsPrepStmt
+            .bind(" ", repairUnit.getKeyspaceName(), newRepairSchedule.getId())));
+
+    try {
+        Futures.allAsList(futures).get();
+    } catch (InterruptedException | ExecutionException ex) {
+        LOG.error("failed to quorum update repair schedule " + newRepairSchedule.getId(), ex);
+    }
 
     return true;
   }
@@ -668,16 +677,17 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     Optional<RepairSchedule> repairSchedule = getRepairSchedule(id);
     if(repairSchedule.isPresent()){
       RepairUnit repairUnit = getRepairUnit(repairSchedule.get().getRepairUnitId()).get();
-      session.execute(deleteRepairSchedulePrepStmt.bind(repairSchedule.get().getId()));
 
-      session.execute(deleteRepairScheduleByClusterAndKsPrepStmt
+      session.executeAsync(deleteRepairScheduleByClusterAndKsPrepStmt
               .bind(repairUnit.getClusterName(), repairUnit.getKeyspaceName(), repairSchedule.get().getId()));
 
-      session.execute(deleteRepairScheduleByClusterAndKsPrepStmt
+      session.executeAsync(deleteRepairScheduleByClusterAndKsPrepStmt
               .bind(repairUnit.getClusterName(), " ", repairSchedule.get().getId()));
 
-      session.execute(deleteRepairScheduleByClusterAndKsPrepStmt
+      session.executeAsync(deleteRepairScheduleByClusterAndKsPrepStmt
               .bind(" ", repairUnit.getKeyspaceName(), repairSchedule.get().getId()));
+      
+      session.executeAsync(deleteRepairSchedulePrepStmt.bind(repairSchedule.get().getId()));
     }
 
     return repairSchedule;

--- a/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -60,7 +60,9 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   Session session;
 
   /* Simple statements */
-  private final String getClustersStmt = "SELECT * FROM cluster";
+  private static final String SELECT_CLUSTER = "SELECT * FROM cluster";
+  private static final String SELECT_REPAIR_SCHEDULE = "SELECT * FROM repair_schedule_v1";
+  private static final String SELECT_REPAIR_UNIT = "SELECT * FROM repair_unit_v1";
 
   /* prepared statements */
   private PreparedStatement insertClusterPrepStmt;
@@ -158,7 +160,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   @Override
   public Collection<Cluster> getClusters() {
     Collection<Cluster> clusters = Lists.<Cluster>newArrayList();
-    ResultSet clusterResults = session.execute(getClustersStmt);
+    ResultSet clusterResults = session.execute(SELECT_CLUSTER);
     for(Row cluster:clusterResults){
       clusters.add(new Cluster(cluster.getString("name"), cluster.getString("partitioner"), cluster.getSet("seed_hosts", String.class)));
     }
@@ -376,7 +378,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   public Optional<RepairUnit> getRepairUnit(String cluster, String keyspace, Set<String> columnFamilyNames) {
     // brute force again
     RepairUnit repairUnit=null;
-    ResultSet results = session.execute("SELECT * FROM repair_unit_v1");
+    ResultSet results = session.execute(SELECT_REPAIR_UNIT);
     for(Row repairUnitRow:results){
       if(repairUnitRow.getString("cluster_name").equals(cluster)
           && repairUnitRow.getString("keyspace_name").equals(keyspace)
@@ -626,7 +628,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   @Override
   public Collection<RepairSchedule> getAllRepairSchedules() {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
-    ResultSet scheduleResults = session.execute("SELECT * FROM repair_schedule_v1");
+    ResultSet scheduleResults = session.execute(SELECT_REPAIR_SCHEDULE);
     for(Row scheduleRow:scheduleResults){
       schedules.add(createRepairScheduleFromRow(scheduleRow));
     }

--- a/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -20,6 +20,11 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.WriteType;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.policies.DefaultRetryPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -53,18 +58,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import systems.composable.dropwizard.cassandra.CassandraFactory;
+import systems.composable.dropwizard.cassandra.retry.RetryPolicyFactory;
 
 public final class CassandraStorage implements IStorage, IDistributedStorage {
   private static final Logger LOG = LoggerFactory.getLogger(CassandraStorage.class);
   com.datastax.driver.core.Cluster cassandra = null;
   Session session;
 
-  /* Simple statements */
+  /* Simple stmts */
   private static final String SELECT_CLUSTER = "SELECT * FROM cluster";
   private static final String SELECT_REPAIR_SCHEDULE = "SELECT * FROM repair_schedule_v1";
   private static final String SELECT_REPAIR_UNIT = "SELECT * FROM repair_unit_v1";
 
-  /* prepared statements */
+  /* prepared stmts */
   private PreparedStatement insertClusterPrepStmt;
   private PreparedStatement getClusterPrepStmt;
   private PreparedStatement deleteClusterPrepStmt;
@@ -100,8 +106,16 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   public CassandraStorage(ReaperApplicationConfiguration config, Environment environment) {
     CassandraFactory cassandraFactory = config.getCassandraFactory();
-    // all INSERT and DELETE statement prepared in this class are idempotent
+    // all INSERT and DELETE stmt prepared in this class are idempotent
+    if (cassandraFactory.getQueryOptions().isPresent()
+            && ConsistencyLevel.LOCAL_ONE != cassandraFactory.getQueryOptions().get().getConsistencyLevel()) {
+        LOG.warn("Customization of cassandra's queryOptions is not supported and will be overridden");
+    }
     cassandraFactory.setQueryOptions(java.util.Optional.of(new QueryOptions().setDefaultIdempotence(true)));
+    if (cassandraFactory.getRetryPolicy().isPresent()) {
+        LOG.warn("Customization of cassandra's retry policy is not supported and will be overridden");
+    }
+    cassandraFactory.setRetryPolicy(java.util.Optional.of((RetryPolicyFactory) () -> new RetryPolicyImpl()));
     cassandra = cassandraFactory.build(environment);
     if(config.getActivateQueryLogger())
       cassandra.register(QueryLogger.builder().build());
@@ -143,13 +157,13 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     getRepairScheduleByClusterAndKsPrepStmt = session.prepare("SELECT repair_schedule_id FROM repair_schedule_by_cluster_and_keyspace WHERE cluster_name = ? and keyspace_name = ?");
     deleteRepairSchedulePrepStmt = session.prepare("DELETE FROM repair_schedule_v1 WHERE id = ?");
     deleteRepairScheduleByClusterAndKsPrepStmt = session.prepare("DELETE FROM repair_schedule_by_cluster_and_keyspace WHERE cluster_name = ? and keyspace_name = ? and repair_schedule_id = ?");
-    getLeadOnSegmentPrepStmt = session.prepare("INSERT INTO segment_leader(segment_id, reaper_instance_id, reaper_instance_host, last_heartbeat) VALUES(?, ?, ?, dateof(now())) IF NOT EXISTS");
-    renewLeadOnSegmentPrepStmt = session.prepare("UPDATE segment_leader SET reaper_instance_id = ?, reaper_instance_host = ?, last_heartbeat = dateof(now()) WHERE segment_id = ? IF reaper_instance_id = ?");
+    getLeadOnSegmentPrepStmt = session.prepare("INSERT INTO segment_leader(segment_id, reaper_instance_id, reaper_instance_host, last_heartbeat) VALUES(?, ?, ?, dateof(now())) IF NOT EXISTS").setIdempotent(false);
+    renewLeadOnSegmentPrepStmt = session.prepare("UPDATE segment_leader SET reaper_instance_id = ?, reaper_instance_host = ?, last_heartbeat = dateof(now()) WHERE segment_id = ? IF reaper_instance_id = ?").setIdempotent(false);
     releaseLeadOnSegmentPrepStmt = session.prepare("DELETE FROM segment_leader WHERE segment_id = ? IF reaper_instance_id = ?");
-    storeHostMetricsPrepStmt = session.prepare("INSERT INTO host_metrics (host_address, ts, pending_compactions, has_repair_running, active_anticompactions) VALUES(?, dateof(now()), ?, ?, ?)");
+    storeHostMetricsPrepStmt = session.prepare("INSERT INTO host_metrics (host_address, ts, pending_compactions, has_repair_running, active_anticompactions) VALUES(?, dateof(now()), ?, ?, ?)").setIdempotent(false);
     getHostMetricsPrepStmt = session.prepare("SELECT * FROM host_metrics WHERE host_address = ?");
     getRunningReapersCountPrepStmt = session.prepare("SELECT count(*) as nb_reapers FROM running_reapers");
-    saveHeartbeatPrepStmt = session.prepare("INSERT INTO running_reapers(reaper_instance_id, reaper_instance_host, last_heartbeat) VALUES(?,?,dateof(now()))");
+    saveHeartbeatPrepStmt = session.prepare("INSERT INTO running_reapers(reaper_instance_id, reaper_instance_host, last_heartbeat) VALUES(?,?,dateof(now()))").setIdempotent(false);
   }
 
   @Override
@@ -833,5 +847,55 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   private static boolean withinRange(RepairSegment segment, Optional<RingRange> range) {
     return !range.isPresent() || segmentIsWithinRange(segment, range.get());
+  }
+
+  /**
+   * Retry all statements.
+   *
+   * All reaper statements are idempotent.
+   * Reaper generates few read and writes requests, so it's ok to keep retrying.
+   *
+   * Sleep 100 milliseconds in between subsequent read retries.
+   * Fail after the tenth read retry.
+   *
+   * Writes keep retrying forever.
+   */
+  private static class RetryPolicyImpl implements RetryPolicy {
+
+    @Override
+    public RetryDecision onReadTimeout(Statement stmt, ConsistencyLevel cl, int required, int received, boolean retrieved, int retry) {
+        if (retry > 1) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ex) {}
+        }
+        return stmt.isIdempotent()
+                ? retry < 10 ? RetryDecision.retry(cl) : RetryDecision.rethrow()
+                : DefaultRetryPolicy.INSTANCE.onReadTimeout(stmt, cl, required, received, retrieved, retry);
+    }
+
+    @Override
+    public RetryDecision onWriteTimeout(Statement stmt, ConsistencyLevel cl, WriteType type , int required, int received, int retry) {
+        return stmt.isIdempotent()
+                ? RetryDecision.retry(cl)
+                : DefaultRetryPolicy.INSTANCE.onWriteTimeout(stmt, cl, type, required, received, retry);
+    }
+
+    @Override
+    public RetryDecision onUnavailable(Statement stmt, ConsistencyLevel cl, int required, int aliveReplica, int retry) {
+        return DefaultRetryPolicy.INSTANCE
+                .onUnavailable(stmt, cl, required, aliveReplica, retry == 1 ? 0 : retry);
+    }
+
+    @Override
+    public RetryDecision onRequestError(Statement stmt, ConsistencyLevel cl, DriverException e, int nbRetry) {
+        return DefaultRetryPolicy.INSTANCE.onRequestError(stmt, cl, e, nbRetry);
+    }
+
+    @Override
+    public void init(com.datastax.driver.core.Cluster cluster) {}
+
+    @Override
+    public void close() {}
   }
 }


### PR DESCRIPTION
The three commits make the CassandraStorage an eventually consistent model.

This makes it possible to run Reaper with ConsistencyLevel ONE. Previously Reaper had to use QUORUM in any RF>1 environment.

Of course, eventual consistency also means that the reaper keyspace can be increased to RF=N where N is the number of nodes in the cluster. This makes sense when the reaper data-set remains so small and we want to be able to co-locate a reaper instance with each Cassandra node.

