### PR TITLE
Make UUIDs returned from PostgresStorage deterministic to reduce confusion

### DIFF
--- a/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
@@ -13,7 +13,6 @@
  */
 package com.spotify.reaper.storage;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
@@ -496,11 +495,11 @@ public final class PostgresStorage implements IStorage {
     }
   }
 
-  private static UUID fromSequenceId(long insertedId) {
+  public static UUID fromSequenceId(long insertedId) {
     return new UUID(insertedId, 0L);
   }
 
-  private static long toSequenceId(UUID id) {
+  public static long toSequenceId(UUID id) {
     return id.getMostSignificantBits();
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
+++ b/src/main/java/com/spotify/reaper/storage/PostgresStorage.java
@@ -497,7 +497,7 @@ public final class PostgresStorage implements IStorage {
   }
 
   private static UUID fromSequenceId(long insertedId) {
-    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
+    return new UUID(insertedId, 0L);
   }
 
   private static long toSequenceId(UUID id) {

--- a/src/main/java/com/spotify/reaper/storage/postgresql/PostgresUtils.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/PostgresUtils.java
@@ -1,0 +1,13 @@
+package com.spotify.reaper.storage.postgresql;
+
+import java.util.UUID;
+
+public class PostgresUtils {
+  public static UUID fromSequenceId(long insertedId) {
+    return new UUID(insertedId, 0L);
+  }
+
+  public static long toSequenceId(UUID id) {
+    return id.getMostSignificantBits();
+  }
+}

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunMapper.java
@@ -15,7 +15,6 @@ package com.spotify.reaper.storage.postgresql;
 
 import com.spotify.reaper.core.RepairRun;
 
-import com.spotify.reaper.storage.PostgresStorage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
@@ -42,7 +41,7 @@ public class RepairRunMapper implements ResultSetMapper<RepairRun> {
         RepairParallelism.fromName(r.getString("repair_parallelism").toLowerCase().replace("datacenter_aware", "dc_parallel"));
     RepairRun.Builder repairRunBuilder =
         new RepairRun.Builder(r.getString("cluster_name"),
-                              PostgresStorage.fromSequenceId(r.getLong("repair_unit_id")),
+                              PostgresUtils.fromSequenceId(r.getLong("repair_unit_id")),
                               getDateTimeOrNull(r, "creation_time"),
                               r.getFloat("intensity"),
                               r.getInt("segment_count"),
@@ -55,6 +54,6 @@ public class RepairRunMapper implements ResultSetMapper<RepairRun> {
         .endTime(getDateTimeOrNull(r, "end_time"))
         .pauseTime(getDateTimeOrNull(r, "pause_time"))
         .lastEvent(r.getString("last_event"))
-        .build(PostgresStorage.fromSequenceId(r.getLong("id")));
+        .build(PostgresUtils.fromSequenceId(r.getLong("id")));
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunMapper.java
@@ -13,9 +13,9 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.spotify.reaper.core.RepairRun;
 
+import com.spotify.reaper.storage.PostgresStorage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
@@ -24,7 +24,6 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.UUID;
 
 public class RepairRunMapper implements ResultSetMapper<RepairRun> {
 
@@ -43,7 +42,7 @@ public class RepairRunMapper implements ResultSetMapper<RepairRun> {
         RepairParallelism.fromName(r.getString("repair_parallelism").toLowerCase().replace("datacenter_aware", "dc_parallel"));
     RepairRun.Builder repairRunBuilder =
         new RepairRun.Builder(r.getString("cluster_name"),
-                              fromSequenceId(r.getLong("repair_unit_id")),
+                              PostgresStorage.fromSequenceId(r.getLong("repair_unit_id")),
                               getDateTimeOrNull(r, "creation_time"),
                               r.getFloat("intensity"),
                               r.getInt("segment_count"),
@@ -56,10 +55,6 @@ public class RepairRunMapper implements ResultSetMapper<RepairRun> {
         .endTime(getDateTimeOrNull(r, "end_time"))
         .pauseTime(getDateTimeOrNull(r, "pause_time"))
         .lastEvent(r.getString("last_event"))
-        .build(fromSequenceId(r.getLong("id")));
-  }
-
-  private static UUID fromSequenceId(long insertedId) {
-    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
+        .build(PostgresStorage.fromSequenceId(r.getLong("id")));
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableSet;
 import com.spotify.reaper.core.RepairRun;
 import com.spotify.reaper.resources.view.RepairRunStatus;
 
-import com.spotify.reaper.storage.PostgresStorage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
@@ -39,7 +38,7 @@ public class RepairRunStatusMapper implements ResultSetMapper<RepairRunStatus> {
     RepairParallelism repairParallelism =
         RepairParallelism.fromName(r.getString("repair_parallelism").toLowerCase().replace("datacenter_aware", "dc_parallel"));
 
-    return new RepairRunStatus(PostgresStorage.fromSequenceId(runId), clusterName, keyspaceName, columnFamilies, segmentsRepaired,
+    return new RepairRunStatus(PostgresUtils.fromSequenceId(runId), clusterName, keyspaceName, columnFamilies, segmentsRepaired,
         totalSegments, state, startTime, endTime, cause, owner, lastEvent,
         creationTime, pauseTime, intensity, incrementalRepair, repairParallelism);
   }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairRunStatusMapper.java
@@ -1,11 +1,11 @@
 package com.spotify.reaper.storage.postgresql;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.ImmutableSet;
 
 import com.spotify.reaper.core.RepairRun;
 import com.spotify.reaper.resources.view.RepairRunStatus;
 
+import com.spotify.reaper.storage.PostgresStorage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.skife.jdbi.v2.StatementContext;
@@ -14,7 +14,6 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.UUID;
 
 public class RepairRunStatusMapper implements ResultSetMapper<RepairRunStatus> {
 
@@ -40,12 +39,8 @@ public class RepairRunStatusMapper implements ResultSetMapper<RepairRunStatus> {
     RepairParallelism repairParallelism =
         RepairParallelism.fromName(r.getString("repair_parallelism").toLowerCase().replace("datacenter_aware", "dc_parallel"));
 
-    return new RepairRunStatus(fromSequenceId(runId), clusterName, keyspaceName, columnFamilies, segmentsRepaired,
+    return new RepairRunStatus(PostgresStorage.fromSequenceId(runId), clusterName, keyspaceName, columnFamilies, segmentsRepaired,
         totalSegments, state, startTime, endTime, cause, owner, lastEvent,
         creationTime, pauseTime, intensity, incrementalRepair, repairParallelism);
-  }
-
-  private static UUID fromSequenceId(long insertedId) {
-    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleMapper.java
@@ -13,10 +13,10 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.ImmutableList;
 import com.spotify.reaper.core.RepairSchedule;
 
+import com.spotify.reaper.storage.PostgresStorage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
@@ -48,7 +48,7 @@ public class RepairScheduleMapper implements ResultSetMapper<RepairSchedule> {
       if (null != runHistory && runHistory.length > 0) {
         runHistoryUUIDs = new UUID[runHistory.length];
         for (int i = 0; i < runHistory.length; i++) {
-          runHistoryUUIDs[i] = fromSequenceId(runHistory[i].longValue());
+          runHistoryUUIDs[i] = PostgresStorage.fromSequenceId(runHistory[i].longValue());
         }
       }
     }  
@@ -61,7 +61,7 @@ public class RepairScheduleMapper implements ResultSetMapper<RepairSchedule> {
 
     RepairSchedule.State scheduleState = RepairSchedule.State.valueOf(stateStr);
     return new RepairSchedule.Builder(
-        fromSequenceId(r.getLong("repair_unit_id")),
+        PostgresStorage.fromSequenceId(r.getLong("repair_unit_id")),
         scheduleState,
         r.getInt("days_between"),
         RepairRunMapper.getDateTimeOrNull(r, "next_activation"),
@@ -72,10 +72,6 @@ public class RepairScheduleMapper implements ResultSetMapper<RepairSchedule> {
         RepairRunMapper.getDateTimeOrNull(r, "creation_time"))
         .owner(r.getString("owner"))
         .pauseTime(RepairRunMapper.getDateTimeOrNull(r, "pause_time"))
-        .build(fromSequenceId(r.getLong("id")));
-  }
-
-  private static UUID fromSequenceId(long insertedId) {
-    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
+        .build(PostgresStorage.fromSequenceId(r.getLong("id")));
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleMapper.java
@@ -16,7 +16,6 @@ package com.spotify.reaper.storage.postgresql;
 import com.google.common.collect.ImmutableList;
 import com.spotify.reaper.core.RepairSchedule;
 
-import com.spotify.reaper.storage.PostgresStorage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
@@ -48,7 +47,7 @@ public class RepairScheduleMapper implements ResultSetMapper<RepairSchedule> {
       if (null != runHistory && runHistory.length > 0) {
         runHistoryUUIDs = new UUID[runHistory.length];
         for (int i = 0; i < runHistory.length; i++) {
-          runHistoryUUIDs[i] = PostgresStorage.fromSequenceId(runHistory[i].longValue());
+          runHistoryUUIDs[i] = PostgresUtils.fromSequenceId(runHistory[i].longValue());
         }
       }
     }  
@@ -61,7 +60,7 @@ public class RepairScheduleMapper implements ResultSetMapper<RepairSchedule> {
 
     RepairSchedule.State scheduleState = RepairSchedule.State.valueOf(stateStr);
     return new RepairSchedule.Builder(
-        PostgresStorage.fromSequenceId(r.getLong("repair_unit_id")),
+        PostgresUtils.fromSequenceId(r.getLong("repair_unit_id")),
         scheduleState,
         r.getInt("days_between"),
         RepairRunMapper.getDateTimeOrNull(r, "next_activation"),
@@ -72,6 +71,6 @@ public class RepairScheduleMapper implements ResultSetMapper<RepairSchedule> {
         RepairRunMapper.getDateTimeOrNull(r, "creation_time"))
         .owner(r.getString("owner"))
         .pauseTime(RepairRunMapper.getDateTimeOrNull(r, "pause_time"))
-        .build(PostgresStorage.fromSequenceId(r.getLong("id")));
+        .build(PostgresUtils.fromSequenceId(r.getLong("id")));
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -16,10 +16,8 @@ package com.spotify.reaper.storage.postgresql;
 import com.google.common.collect.ImmutableSet;
 
 import com.spotify.reaper.core.RepairSchedule;
-import com.spotify.reaper.core.RepairUnit;
 import com.spotify.reaper.resources.view.RepairScheduleStatus;
 
-import com.spotify.reaper.storage.PostgresStorage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
@@ -34,7 +32,7 @@ public class RepairScheduleStatusMapper implements ResultSetMapper<RepairSchedul
       throws SQLException {
 
     return new RepairScheduleStatus(
-        PostgresStorage.fromSequenceId(r.getLong("id")),
+        PostgresUtils.fromSequenceId(r.getLong("id")),
         r.getString("owner"),
         r.getString("cluster_name"),
         r.getString("keyspace_name"),

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -13,20 +13,19 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.ImmutableSet;
 
 import com.spotify.reaper.core.RepairSchedule;
 import com.spotify.reaper.core.RepairUnit;
 import com.spotify.reaper.resources.view.RepairScheduleStatus;
 
+import com.spotify.reaper.storage.PostgresStorage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.UUID;
 
 public class RepairScheduleStatusMapper implements ResultSetMapper<RepairScheduleStatus> {
 
@@ -35,7 +34,7 @@ public class RepairScheduleStatusMapper implements ResultSetMapper<RepairSchedul
       throws SQLException {
 
     return new RepairScheduleStatus(
-        fromSequenceId(r.getLong("id")),
+        PostgresStorage.fromSequenceId(r.getLong("id")),
         r.getString("owner"),
         r.getString("cluster_name"),
         r.getString("keyspace_name"),
@@ -50,9 +49,5 @@ public class RepairScheduleStatusMapper implements ResultSetMapper<RepairSchedul
         RepairParallelism.fromName(r.getString("repair_parallelism").toLowerCase().replace("datacenter_aware", "dc_parallel")),
         r.getInt("days_between")
     );
-  }
-
-  private static UUID fromSequenceId(long insertedId) {
-    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairSegmentMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairSegmentMapper.java
@@ -17,6 +17,7 @@ import com.datastax.driver.core.utils.UUIDs;
 import com.spotify.reaper.core.RepairSegment;
 import com.spotify.reaper.service.RingRange;
 
+import com.spotify.reaper.storage.PostgresStorage;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
@@ -30,17 +31,13 @@ public class RepairSegmentMapper implements ResultSetMapper<RepairSegment> {
     RingRange range = new RingRange(r.getBigDecimal("start_token").toBigInteger(),
                                     r.getBigDecimal("end_token").toBigInteger());
     return
-        new RepairSegment.Builder(range, fromSequenceId(r.getLong("repair_unit_id")))
-                .withRunId(fromSequenceId(r.getLong("run_id")))
+        new RepairSegment.Builder(range, PostgresStorage.fromSequenceId(r.getLong("repair_unit_id")))
+                .withRunId(PostgresStorage.fromSequenceId(r.getLong("run_id")))
                 .state(RepairSegment.State.values()[r.getInt("state")])
                 .coordinatorHost(r.getString("coordinator_host"))
                 .startTime(RepairRunMapper.getDateTimeOrNull(r, "start_time"))
                 .endTime(RepairRunMapper.getDateTimeOrNull(r, "end_time"))
                 .failCount(r.getInt("fail_count"))
-                .build(fromSequenceId(r.getLong("id")));
-  }
-
-  private static UUID fromSequenceId(long insertedId) {
-    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
+                .build(PostgresStorage.fromSequenceId(r.getLong("id")));
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairSegmentMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairSegmentMapper.java
@@ -13,17 +13,14 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.spotify.reaper.core.RepairSegment;
 import com.spotify.reaper.service.RingRange;
 
-import com.spotify.reaper.storage.PostgresStorage;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.UUID;
 
 public class RepairSegmentMapper implements ResultSetMapper<RepairSegment> {
 
@@ -31,13 +28,13 @@ public class RepairSegmentMapper implements ResultSetMapper<RepairSegment> {
     RingRange range = new RingRange(r.getBigDecimal("start_token").toBigInteger(),
                                     r.getBigDecimal("end_token").toBigInteger());
     return
-        new RepairSegment.Builder(range, PostgresStorage.fromSequenceId(r.getLong("repair_unit_id")))
-                .withRunId(PostgresStorage.fromSequenceId(r.getLong("run_id")))
+        new RepairSegment.Builder(range, PostgresUtils.fromSequenceId(r.getLong("repair_unit_id")))
+                .withRunId(PostgresUtils.fromSequenceId(r.getLong("run_id")))
                 .state(RepairSegment.State.values()[r.getInt("state")])
                 .coordinatorHost(r.getString("coordinator_host"))
                 .startTime(RepairRunMapper.getDateTimeOrNull(r, "start_time"))
                 .endTime(RepairRunMapper.getDateTimeOrNull(r, "end_time"))
                 .failCount(r.getInt("fail_count"))
-                .build(PostgresStorage.fromSequenceId(r.getLong("id")));
+                .build(PostgresUtils.fromSequenceId(r.getLong("id")));
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairUnitMapper.java
@@ -17,6 +17,7 @@ import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.Sets;
 import com.spotify.reaper.core.RepairUnit;
 
+import com.spotify.reaper.storage.PostgresStorage;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
@@ -41,11 +42,6 @@ public class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
                                                         r.getString("keyspace_name"),
                                                         Sets.newHashSet(columnFamilies),
                                                         r.getBoolean("incremental_repair"));
-    return builder.build(fromSequenceId(r.getLong("id")));
-  }
-
-
-  private static UUID fromSequenceId(long insertedId) {
-    return new UUID(insertedId, UUIDs.timeBased().getLeastSignificantBits());
+    return builder.build(PostgresStorage.fromSequenceId(r.getLong("id")));
   }
 }

--- a/src/main/java/com/spotify/reaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/main/java/com/spotify/reaper/storage/postgresql/RepairUnitMapper.java
@@ -13,18 +13,15 @@
  */
 package com.spotify.reaper.storage.postgresql;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.Sets;
 import com.spotify.reaper.core.RepairUnit;
 
-import com.spotify.reaper.storage.PostgresStorage;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.UUID;
 
 public class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
 
@@ -42,6 +39,6 @@ public class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
                                                         r.getString("keyspace_name"),
                                                         Sets.newHashSet(columnFamilies),
                                                         r.getBoolean("incremental_repair"));
-    return builder.build(PostgresStorage.fromSequenceId(r.getLong("id")));
+    return builder.build(PostgresUtils.fromSequenceId(r.getLong("id")));
   }
 }


### PR DESCRIPTION
I'm not sure if there was a particular reason that that least significant 64 bits were taken from a time-based UUID. It led to surprising behavior, like all of the UUIDs (returned from various endpoints) changing every time Reaper got restarted.

Perhaps `toSequenceId` should also require the least significant 64 bits to be 0, so that only the reported UUID can be used for commands like spreaper's pause-schedule.