### PR TITLE
Add docker-build process.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,10 @@ bin/
 .settings/
 .project
 build/
+packages/
 *.deb
+*.rpm
 
 # frontend dev stuffs.
 reaper_ui/bower_components/
 reaper_ui/node_modules/
-

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 # Using mvn:
-VERSION := $(shell mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\[')
+VERSION := `mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`
 
 # Using python:
-#VERSION := $(shell python -c "import xml.etree.ElementTree as ET; print(ET.parse(open('pom.xml')).getroot().find('{http://maven.apache.org/POM/4.0.0}version').text)")
+# VERSION := `python -c "import xml.etree.ElementTree as ET; print(ET.parse(open('pom.xml')).getroot().find('{http://maven.apache.org/POM/4.0.0}version').text)"`
 
 package:
 	mvn package
 
 prepare:
+	echo "$(VERSION)..."
 	mkdir -p build/usr/share/cassandra-reaper
 	mkdir -p build/usr/local/bin
 	mkdir -p build/etc/init.d
@@ -19,14 +20,14 @@ prepare:
 	chmod 755 build/etc/init.d/cassandra-reaper
 
 deb: prepare
-	rm -f reaper_*.deb
+	rm -f reaper*.deb
 	fpm -s dir -t deb -n reaper -v $(VERSION) --pre-install debian/preinstall.sh -C build .
 
 rpm: prepare
-	rm -f reaper_*.rpm
+	rm -f reaper*.rpm
 	fpm -s dir -t rpm -n reaper -v $(VERSION) --pre-install debian/preinstall.sh -C build .
 
-all: package deb
+all: package deb rpm
 
 clean:
 	rm -rf reaper_*.deb reaper_*.rpm

--- a/README.md
+++ b/README.md
@@ -65,8 +65,15 @@ Run the tool with *-h* or *--help* option to see usage instructions.
 
 ### Debian and RPM Packages
 
-Notice that you can also build Debian and RPM packages from this project by using *Make*, for example:
-`make all`.
+#### Make
+
+Debian and RPM packages can be built from this project using Make, for example:
+
+```bash
+make all
+```
+
+#### Docker
 
 A [Docker](https://docs.docker.com/engine/installation/) build environment is
 also provided to build the entire project and can be run by using

--- a/README.md
+++ b/README.md
@@ -63,8 +63,23 @@ use the provided CLI tool in *bin/spreaper* to call the service.
 
 Run the tool with *-h* or *--help* option to see usage instructions.
 
-Notice that you can also build a Debian package from this project by using *debuild*, for example:
-`debuild -uc -us -b`
+### Debian and RPM Packages
+
+Notice that you can also build Debian and RPM packages from this project by using *Make*, for example:
+`make all`.
+
+A [Docker](https://docs.docker.com/engine/installation/) build environment is
+also provided to build the entire project and can be run by using
+[Docker Compose](https://docs.docker.com/compose/install/):
+
+```bash
+docker-compose -f docker-build/docker-compose.yml build \
+    && docker-compose -f docker-build/docker-compose.yml run build
+```
+
+The final packages will be located within:
+
+```./packages/```
 
 
 Configuration
@@ -381,6 +396,6 @@ After modifying the `resource/cassandra-reaper.yaml` config file, Reaper can be 
 
 ```java -jar target/cassandra-reaper-X.X.X.jar server resource/cassandra-reaper.yaml```
 
-Once started, the UI can be accessed through : `http://127.0.0.1:8080/webui/`
+Once started, the UI can be accessed through : http://127.0.0.1:8080/webui/
 
 Reaper can also be accessed using the REST API exposed on port 8080, or using the command line tool `bin/spreaper`

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:16.04
+
+# use a common app path, copied from python-onbuild:latest
+ENV WORKDIR /usr/src/app
+RUN mkdir -p ${WORKDIR}
+WORKDIR ${WORKDIR}
+
+# install dependencies
+RUN apt-get update \
+    && apt-get install -y \
+        curl \
+    && curl -sL https://deb.nodesource.com/setup_6.x -o nodesource_setup.sh \
+    && bash nodesource_setup.sh \
+    && apt-get update \
+    && apt-get install -y \
+        build-essential \
+        git \
+        maven \
+        nodejs \
+        openjdk-8-jdk \
+        rpm \
+        ruby-dev \
+    && mvn --version \
+    && gem install fpm \
+    && npm install -g bower
+
+# cache maven dependencies, useful during Dockerfile testing
+COPY pom.xml /tmp
+COPY reaper_ui/*.json reaper_ui/*.js /tmp/reaper_ui/
+WORKDIR /tmp
+RUN mvn clean package \
+    && mvn clean package -Pbuild-ui
+WORKDIR ${WORKDIR}
+
+# Add entrypoint script
+COPY docker-build/docker-entrypoint.sh ${WORKDIR}
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/docker-build/docker-compose.yml
+++ b/docker-build/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  build:
+    build:
+      context: ..
+      dockerfile: docker-build/Dockerfile
+    volumes:
+      - ..:/usr/src/app/cassandra-reaper
+      - ../packages:/usr/src/app/packages

--- a/docker-build/docker-entrypoint.sh
+++ b/docker-build/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# build jar
+# build web UI
+# build Debian and RPM packages
+# copy built packages into a mounted volume
+cd ${WORKDIR}/cassandra-reaper
+mvn clean package -Pbuild-ui \
+    && make all \
+    && mv *.deb *.rpm ${WORKDIR}/packages \
+    && cp target/cassandra-*SNAPSHOT.jar ${WORKDIR}/packages
+
+# execute any provided command
+$@

--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,7 @@
                                     <executable>bower</executable>
                                     <workingDirectory>reaper_ui</workingDirectory>
                                     <arguments>
+                                        <argument>--allow-root</argument>
                                         <argument>install</argument>
                                     </arguments>
                                 </configuration>

--- a/reaper_ui/bower.json
+++ b/reaper_ui/bower.json
@@ -20,7 +20,7 @@
   ],
   "devDependencies": {
     "jquery": "~2.1.3",
-    "startbootstrap-sb-admin-2": "git://github.com/BlackrockDigital/startbootstrap-sb-admin-2#v1.0.5",
+    "startbootstrap-sb-admin-2": "https://github.com/BlackrockDigital/startbootstrap-sb-admin-2.git#v1.0.5",
     "rxjs": "~2.4.6",
     "moment": "~2.9.0"
   }


### PR DESCRIPTION
This is the first pull request in an attempt to resolve #46, which has partially, and more accurately, been taken care of through #76.

The bulk of these changes appear in the README.

The intent of these files is to build the RPM and Debian packages without any system dependencies other than Docker.