### PR TITLE
Docker compose environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ packages/
 # frontend dev stuffs.
 reaper_ui/bower_components/
 reaper_ui/node_modules/
+
+# Docker Compose persistent storage directory
+data/

--- a/README.md
+++ b/README.md
@@ -431,9 +431,13 @@ node's status:
 
 Once the Cassandra node is online and accepting CQL connections,
 create the required `reaper_db` Cassandra keyspace to allow Reaper to save
-its cluster and scheduling data:
+its cluster and scheduling data.
 
-```docker-compose run initialize-reaper_db```
+By default, the `reaper_db` keyspace is created using a replication factor
+of 1. To change this replication factor, provide the intended replication
+factor as an optional argument:
+
+```docker-compose run initialize-reaper_db [$REPLICATION_FACTOR]```
 
 Wait a few moments for the `reaper_db` schema change to propagate,
 then start Reaper:

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Source code for all the REST resources can be found from package com.spotify.rea
     Delete all the related repair runs before calling this endpoint.
 
 
-Building and running Reaper
+Building and Running Reaper
 ------------------------------------
 
 To build Reaper without rebuilding the UI, run the following command : 
@@ -406,3 +406,55 @@ After modifying the `resource/cassandra-reaper.yaml` config file, Reaper can be 
 Once started, the UI can be accessed through : http://127.0.0.1:8080/webui/
 
 Reaper can also be accessed using the REST API exposed on port 8080, or using the command line tool `bin/spreaper`
+
+
+Running a Dockerized Reaper Example
+-----------------------------------
+
+### Build Reaper Docker Image
+
+First, build the Docker image and add it to your local image cache using the
+`cassandra-reaper:latest` tag:
+
+```mvn clean package docker:build```
+
+### Start Docker Environment
+
+First, start the Cassandra cluster:
+
+```docker-compose up cassandra```
+
+You can use the `nodetool` Docker Compose service to check on the Cassandra
+node's status:
+
+```docker-compose run nodetool status```
+
+Once the Cassandra node is online and accepting CQL connections,
+create the required `reaper_db` Cassandra keyspace to allow Reaper to save
+its scheduling data:
+
+```docker-compose run initialize-reaper_db```
+
+Wait a few moments for the `reaper_db` schema change to propagate,
+then start Reaper:
+
+```docker-compose up reaper```
+
+### Access The Environment
+
+Once started, the UI can be accessed through: http://127.0.0.1:8080/webui/
+
+The helper `cqlsh` Docker Compose service has also been included:
+
+```docker-compose run cqlsh```
+
+### Destroying the Docker Environment
+
+When terminating the infrastructure, use the following command to stop
+all related Docker Compose services:
+
+```docker-compose down```
+
+To completely clean up all persistent data, delete the `./data/` directory:
+
+```rm -rf ./data/```

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ node's status:
 
 Once the Cassandra node is online and accepting CQL connections,
 create the required `reaper_db` Cassandra keyspace to allow Reaper to save
-its scheduling data:
+its cluster and scheduling data:
 
 ```docker-compose run initialize-reaper_db```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
     mem_limit: 4g
     memswap_limit: 4g
     mem_swappiness: 0
+    ports:
+      - "7000:7000"
+      - "7001:7001"
+      - "7199:7199"
+      - "9042:9042"
     volumes:
       - ./data/cassandra:/var/lib/cassandra
       - ./docker/cassandra/jmxremote.access:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/management/jmxremote.access

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '2.2'
+
+services:
+  cassandra:
+    image: cassandra:3.11
+    env_file:
+      - docker/cassandra/cassandra.env
+    mem_limit: 4g
+    memswap_limit: 4g
+    mem_swappiness: 0
+    volumes:
+      - ./data/cassandra:/var/lib/cassandra
+      - ./docker/cassandra/jmxremote.access:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/management/jmxremote.access
+      - ./docker/cassandra/jmxremote.password:/etc/cassandra/jmxremote.password
+
+  cqlsh:
+    image: cassandra:3.11
+    command: cqlsh cassandra
+    links:
+      - cassandra
+
+  nodetool:
+    image: cassandra:3.11
+    entrypoint: nodetool --host cassandra --username reaperUser --password reaperPass
+    links:
+      - cassandra
+
+  initialize-reaper_db:
+    build: ./docker/initialize-reaper_db
+    links:
+      - cassandra
+
+  reaper:
+    image: cassandra-reaper:latest
+    env_file:
+      - docker/reaper/reaper.env
+    links:
+      - cassandra
+    ports:
+      - "8080:8080"
+      - "8081:8081"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,119 @@
+# Dockerized Reaper Example
+
+This directory, as well as the root directory's `docker-compose.yml`, compose
+the repo's Dockerized environment.
+
+Instructions for running this Dockerized environment appear in the main
+[README](../#running-a-dockerized-reaper-example).
+
+Simply put, the following actions are needed:
+
+* Use `mvn` to build the `cassandra-reaper:latest` Docker image.
+* Start a Cassandra node to act as:
+    * Reaper's backend database.
+    * The Cassandra node that Reaper will manage repairs for.
+* Create the `reaper_db` keyspace to store Reaper's cluster and scheduling data.
+* Start Reaper.
+
+Within this README, we will discuss the individual components that simplify the
+entire setup.
+
+## Docker Compose
+
+While the Docker Compose prerequisite is not necessary for running a Dockerized Reaper
+environment, it simplifies all the options that would normally go into the
+command-line when running `docker` into a clean `docker-compose.yml`. These
+options can later be duplicated using the Docker provisioning service of your
+choice.
+
+### Cassandra
+
+The Cassandra options are set to use a `mem_limit` and `memswap_limit` both set
+to `4g`. Equivalent settings for both `mem_limit` and `memswap_limit`,
+along with `mem_swappiness: 0`, will
+[disable swapping](https://docs.docker.com/engine/reference/run/#user-memory-constraints)
+which is ideal for Cassandra.
+
+The [`env_file`](cassandra/cassandra.env), uses the `cassandra`
+Docker Compose service name/container's hostname and sets both the
+`$CASSANDRA_LISTEN_ADDRESS` and `$CASSANDRA_SEEDS` to `cassandra`. The
+`env_file` also sets `LOCAL_JMX=no` to allow JMX to bind to the `cassandra`
+hostname instead of `localhost` allowing Reaper to communicate with the
+Cassandra node. All other settings are simply for demonstration purposes.
+
+The [jmxremote.access](cassandra/jmxremote.access) and
+[jmxremote.password](cassandra/jmxremote.password) files define the JMX
+user/pass combination to be `reaperUser`/`reaperPass`. They are mounted using
+the locations defined in the `services:cassandra:volumes` section of the
+`docker-compose.yml`.
+
+Through the inclusion of the `ports` settings within the `docker-compose.yml`'s
+`cassandra` service, accessing the Cassandra node from outside of this
+Docker Compose setup should also be immediately possible when providing the
+`cassandra` service's IP address as defined by:
+`docker-compose exec cassandra hostname -i`.
+
+#### Cassandra Utilities
+
+The `docker-compose.yml` also provides helper services to quickly use `cqlsh`
+and `nodetool` without having to configure the necessary information.
+
+The `cqlsh` service already comes preconfigured to use the `cassandra` hostname.
+
+The `nodetool` service comes preconfigured to use the `cassandra` hostname as
+well as the preconfigured JMX username and password as defined within
+[jmxremote.access](cassandra/jmxremote.access) and
+[jmxremote.password](cassandra/jmxremote.password).
+
+### Reaper
+
+Before the `reaper` service is started, the `initialize-reaper_db` service must
+be run at least once in order to create the `reaper_db`
+[keyspace](initialize-reaper_db/Dockerfile).
+As long as the `./data/` directory is not removed the Cassandra data will be
+persisted and thus the `reaper_db` keyspace, related tables, and data will all
+appear once the `cassandra` service is started again.
+
+The `reaper` service simply uses the pre-built images provided by running the
+command: `mvn clean package docker:build`.
+
+The [`env_file`](reaper/reaper.env) provides Reaper with the
+preconfigured JMX username and password as defined within
+[jmxremote.access](cassandra/jmxremote.access) and
+[jmxremote.password](cassandra/jmxremote.password) in order to contact
+the Cassandra nodes Reaper will be managing repairs for. The `env_file` also
+sets the Reaper storage backend to use the same Cassandra node that is started
+through the `cassandra` service.
+
+## Using Dockerized Reaper in Production
+
+In order to use Dockerized Reaper in production environments, you can use
+the following Docker Compose service definition:
+
+```yaml
+version: '2.2'
+
+services:
+  reaper:
+    image: cassandra-reaper:latest
+    env_file:
+      - path/to/reaper.env
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+```
+
+The above definition can be used on any machine that has built
+the Reaper Docker image using `mvn clean package docker:build`.
+
+The `env_file` environmental variable choices are defined within
+[src/main/docker/cassandra-reaper.yml](../src/main/docker/cassandra-reaper.yml) and
+[src/main/docker/append-persistence.sh](../src/main/docker/append-persistence.sh).
+The default values can be seen within [src/main/docker/Dockerfile](../src/main/docker/Dockerfile).
+
+The `ports` parameters will expose and map the `8080` and `8181` ports from the
+container onto the host. This allows you to access the Reaper UI using:
+`http://hostname:8080`.
+
+To start the service, run the container in `detached` mode by including the
+`-d` parameter: `docker-compose up -d reaper`.

--- a/docker/cassandra/cassandra.env
+++ b/docker/cassandra/cassandra.env
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# use a non-localhost listen address that matches the Docker Compose hostname
+CASSANDRA_LISTEN_ADDRESS=cassandra
+CASSANDRA_SEEDS=cassandra
+
+# leave blank to auto configure
+CASSANDRA_BROADCAST_ADDRESS
+CASSANDRA_RPC_ADDRESS
+
+# name of this Cassandra cluster
+CASSANDRA_CLUSTER_NAME='reaper-cluster'
+
+# use the TLP-recommended number of vnodes
+CASSANDRA_NUM_TOKENS=32
+
+# snitch information
+CASSANDRA_DC=docker-compose-1
+CASSANDRA_RACK=rack1
+CASSANDRA_ENDPOINT_SNITCH=GossipingPropertyFileSnitch
+
+# open JMX port for access by Reaper
+# WARNING: this is unsafe in production without proper firewall settings
+LOCAL_JMX=no

--- a/docker/cassandra/jmxremote.access
+++ b/docker/cassandra/jmxremote.access
@@ -1,0 +1,1 @@
+reaperUser readwrite

--- a/docker/cassandra/jmxremote.password
+++ b/docker/cassandra/jmxremote.password
@@ -1,0 +1,1 @@
+reaperUser reaperPass

--- a/docker/initialize-reaper_db/Dockerfile
+++ b/docker/initialize-reaper_db/Dockerfile
@@ -1,6 +1,8 @@
 FROM cassandra:3.11
 
-# create the required reaper_db keyspace to allow Reaper to store scheduling data
-CMD set -x \
-    && cqlsh cassandra -e \
-    "CREATE KEYSPACE IF NOT EXISTS reaper_db WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };"
+# create the reaper_db keyspace
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# use a default replication factor of 1
+CMD ["1"]

--- a/docker/initialize-reaper_db/Dockerfile
+++ b/docker/initialize-reaper_db/Dockerfile
@@ -1,0 +1,6 @@
+FROM cassandra:3.11
+
+# create the required reaper_db keyspace to allow Reaper to store scheduling data
+CMD set -x \
+    && cqlsh cassandra -e \
+    "CREATE KEYSPACE IF NOT EXISTS reaper_db WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };"

--- a/docker/initialize-reaper_db/docker-entrypoint.sh
+++ b/docker/initialize-reaper_db/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x
+
+REPLICATION_FACTOR=$1
+
+# create the required reaper_db keyspace to allow Reaper to store scheduling data
+cqlsh cassandra -e \
+    "CREATE KEYSPACE IF NOT EXISTS reaper_db \
+    WITH replication = {'class': 'SimpleStrategy', \
+                        'replication_factor': $REPLICATION_FACTOR };"

--- a/docker/reaper/reaper.env
+++ b/docker/reaper/reaper.env
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# use the credentials that match the ./docker/cassandra/jmxremote.* configurations
+REAPER_JMX_USERNAME=reaperUser
+REAPER_JMX_PASSWORD=reaperPass
+
+# define the Dockerized Cassandra node to serve as the Reaper backend
+# while using the reaper_db keyspace
+REAPER_STORAGE_TYPE=cassandra
+REAPER_CASS_CLUSTER_NAME="reaper-cluster"
+REAPER_CASS_CONTACT_POINTS=["cassandra"]
+REAPER_CASS_KEYSPACE=reaper_db

--- a/src/main/docker/entrypoint.sh
+++ b/src/main/docker/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$1" = 'cassandra-reaper' ]; then
+    set -x
     su-exec reaper /usr/local/bin/append-persistence.sh
     exec su-exec reaper java -jar ${JAVA_OPTS} \
         /usr/local/lib/cassandra-reaper.jar server /etc/cassandra-reaper.yml


### PR DESCRIPTION
This PR is dependent on #135.

This is the last PR in an effort to to deprecate #46.

This adds a sample Cassandra node, including all the required settings and Docker Compose services in order to run Reaper in a clean and isolated environment with the only dependencies being Docker and Docker Compose.

I've also included a semi-lengthy, in-depth view of Docker Compose infrastructure within `./docker/README.md`. At the end of this README, are instructions for how to run Dockerized Reaper within production environments.