### PR TITLE
Fix coordinator node being nulled out by abort() for incremental repairs

### DIFF
--- a/src/main/java/com/spotify/reaper/service/SegmentRunner.java
+++ b/src/main/java/com/spotify/reaper/service/SegmentRunner.java
@@ -120,7 +120,7 @@ public final class SegmentRunner implements RepairStatusHandler, Runnable {
   }
 
   public static void abort(AppContext context, RepairSegment segment, JmxProxy jmxConnection) {
-    postpone(context, segment, Optional.fromNullable((RepairUnit) null));
+    postpone(context, segment, context.storage.getRepairUnit(segment.getRepairUnitId()));
     LOG.info("Aborting repair on segment with id {} on coordinator {}",
         segment.getId(), segment.getCoordinatorHost());
     jmxConnection.cancelAllRepairs();


### PR DESCRIPTION
`SegmentRunner.abort()` was nulling the coordinator node as it didn't provide the repair unit to `postpone()`.
This is a problem for incremental repair as the coordinator node is never recomputed after repair run creation.

The fix provides the RepairUnit which allows postpone() to detect incremental repairs and avoid nulling `coordinator_host`.