### PR TITLE
Move contextual fields from ReaperApplication to AppContext

### DIFF
--- a/src/server/src/main/java/com/spotify/reaper/AppContext.java
+++ b/src/server/src/main/java/com/spotify/reaper/AppContext.java
@@ -4,6 +4,12 @@ import com.codahale.metrics.MetricRegistry;
 import com.spotify.reaper.cassandra.JmxConnectionFactory;
 import com.spotify.reaper.service.RepairManager;
 import com.spotify.reaper.storage.IStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -12,6 +18,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class AppContext {
 
+  public static final UUID REAPER_INSTANCE_ID = UUID.randomUUID();
+  private static final String DEFAULT_INSTANCE_ADDRESS = "127.0.0.1";
+  private static final Logger LOG = LoggerFactory.getLogger(AppContext.class);
+
+  public static final String REAPER_INSTANCE_ADDRESS = initialiseInstanceAddress();
   public final AtomicBoolean isRunning = new AtomicBoolean(true);
   public IStorage storage;
   public RepairManager repairManager;
@@ -19,4 +30,14 @@ public final class AppContext {
   public ReaperApplicationConfiguration config;
   public MetricRegistry metricRegistry = new MetricRegistry();
 
+  private static String initialiseInstanceAddress() {
+    String reaperInstanceAddress;
+    try {
+      reaperInstanceAddress = InetAddress.getLocalHost().getHostAddress();
+    } catch(UnknownHostException e) {
+      LOG.warn("Cannot get instance address", e);
+     reaperInstanceAddress = DEFAULT_INSTANCE_ADDRESS;
+    }
+    return reaperInstanceAddress;
+  }
 }

--- a/src/server/src/main/java/com/spotify/reaper/ReaperApplication.java
+++ b/src/server/src/main/java/com/spotify/reaper/ReaperApplication.java
@@ -13,11 +13,9 @@
  */
 package com.spotify.reaper;
 
-import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -69,21 +67,17 @@ import io.prometheus.client.exporter.MetricsServlet;
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
-public class ReaperApplication extends Application<ReaperApplicationConfiguration> {
+public final class ReaperApplication extends Application<ReaperApplicationConfiguration> {
 
-  static final Logger LOG = LoggerFactory.getLogger(ReaperApplication.class);
-  public static final UUID REAPER_INSTANCE_ID = UUID.randomUUID();
-  private static String reaperInstanceAddress;
+  private static final Logger LOG = LoggerFactory.getLogger(ReaperApplication.class);
   private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-  private static final String DEFAULT_INSTANCE_ADDRESS = "127.0.0.1";
   
-  private AppContext context;
+  private final AppContext context;
 
   public ReaperApplication() {
     super();
     LOG.info("default ReaperApplication constructor called");
     this.context = new AppContext();
-    setInstanceAddress();
   }
 
   @VisibleForTesting
@@ -91,26 +85,12 @@ public class ReaperApplication extends Application<ReaperApplicationConfiguratio
     super();
     LOG.info("ReaperApplication constructor called with custom AppContext");
     this.context = context;
-    setInstanceAddress();
   }
 
   public static void main(String[] args) throws Exception {
     new ReaperApplication().run(args);
   }
   
-  private static void setInstanceAddress() {
-    try{
-      ReaperApplication.reaperInstanceAddress = InetAddress.getLocalHost().getHostAddress();
-    } catch(Exception e) {
-      LOG.warn("Cannot get instance address", e);
-      ReaperApplication.reaperInstanceAddress = DEFAULT_INSTANCE_ADDRESS;
-    }
-  }
-  
-  public static String getInstanceAddress() {
-    return reaperInstanceAddress;
-  }
-
   @Override
   public String getName() {
     return "cassandra-reaper";

--- a/src/server/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
-import com.spotify.reaper.ReaperApplication;
+import com.spotify.reaper.AppContext;
 import com.spotify.reaper.ReaperApplicationConfiguration;
 import com.spotify.reaper.core.Cluster;
 import com.spotify.reaper.core.NodeMetrics;
@@ -773,10 +773,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   public boolean takeLead(UUID leaderId) {
     LOG.debug("Trying to take lead on segment {}", leaderId);
     ResultSet lwtResult = session.execute(
-            takeLeadPrepStmt.bind(
-                    leaderId,
-                    ReaperApplication.REAPER_INSTANCE_ID,
-                    ReaperApplication.getInstanceAddress()));
+            takeLeadPrepStmt.bind(leaderId, AppContext.REAPER_INSTANCE_ID, AppContext.REAPER_INSTANCE_ADDRESS));
 
     if (lwtResult.wasApplied()) {
       LOG.debug("Took lead on segment {}", leaderId);
@@ -792,10 +789,10 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   public boolean renewLead(UUID leaderId) {
     ResultSet lwtResult = session.execute(
             renewLeadPrepStmt.bind(
-                    ReaperApplication.REAPER_INSTANCE_ID,
-                    ReaperApplication.getInstanceAddress(),
+                    AppContext.REAPER_INSTANCE_ID,
+                    AppContext.REAPER_INSTANCE_ADDRESS,
                     leaderId,
-                    ReaperApplication.REAPER_INSTANCE_ID));
+                    AppContext.REAPER_INSTANCE_ID));
 
     if (lwtResult.wasApplied()) {
       LOG.debug("Renewed lead on segment {}", leaderId);
@@ -808,7 +805,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   @Override
   public void releaseLead(UUID leaderId) {
-    ResultSet lwtResult = session.execute(releaseLeadPrepStmt.bind(leaderId, ReaperApplication.REAPER_INSTANCE_ID));
+    ResultSet lwtResult = session.execute(releaseLeadPrepStmt.bind(leaderId, AppContext.REAPER_INSTANCE_ID));
 
     if (lwtResult.wasApplied()) {
       LOG.debug("Released lead on segment {}", leaderId);
@@ -821,10 +818,10 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   private boolean hasLeadOnSegment(UUID leaderId) {
     ResultSet lwtResult = session.execute(
             renewLeadPrepStmt.bind(
-                ReaperApplication.REAPER_INSTANCE_ID,
-                ReaperApplication.getInstanceAddress(),
+                AppContext.REAPER_INSTANCE_ID,
+                AppContext.REAPER_INSTANCE_ADDRESS,
                 leaderId,
-                ReaperApplication.REAPER_INSTANCE_ID));
+                AppContext.REAPER_INSTANCE_ID));
 
     return lwtResult.wasApplied();
   }
@@ -868,8 +865,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     DateTime now = DateTime.now();
     // Send heartbeats every minute
     if(now.minusSeconds(60).getMillis() >= lastHeartBeat.getMillis()) {
-      session.executeAsync(
-              saveHeartbeatPrepStmt.bind(ReaperApplication.REAPER_INSTANCE_ID, ReaperApplication.getInstanceAddress()));
+      session.executeAsync(saveHeartbeatPrepStmt.bind(AppContext.REAPER_INSTANCE_ID, AppContext.REAPER_INSTANCE_ADDRESS));
 
       lastHeartBeat = now;
     }


### PR DESCRIPTION
The REAPER_INSTANCE_ID and reaperInstanceAddress fields form part of the application's context, and so do not belong in the controller class: ReaperApplication.
