### PR TITLE
Docker Cassandra configuration update

### DIFF
--- a/src/packaging/docker/cassandra/cassandra.env
+++ b/src/packaging/docker/cassandra/cassandra.env
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # use a non-localhost listen address that matches the Docker Compose hostname
-CASSANDRA_LISTEN_ADDRESS=cassandra
 CASSANDRA_SEEDS=cassandra
 
 # leave blank to auto configure


### PR DESCRIPTION
- Removed CASSANDRA_LISTEN_ADDRESS property from Cassandra env file as this
  was causing issues when Reaper was trying to obtain the status of the node