### PR TITLE
Add support for AllEndpointStates output in pre-2.2 versions

### DIFF
--- a/src/server/src/main/java/com/spotify/reaper/resources/view/NodesStatus.java
+++ b/src/server/src/main/java/com/spotify/reaper/resources/view/NodesStatus.java
@@ -20,6 +20,7 @@ import jersey.repackaged.com.google.common.collect.Lists;
 import jersey.repackaged.com.google.common.collect.Maps;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.*;
@@ -28,113 +29,124 @@ import java.util.stream.Collectors;
 public class NodesStatus {
   @JsonProperty
   public final List<GossipInfo> endpointStates;
-  private static Pattern endpointNamePattern = Pattern.compile("^([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})", Pattern.MULTILINE | Pattern.DOTALL);
-  private static Pattern endpointStatusPattern = Pattern.compile("(STATUS):([0-9]*):(\\w+)");
-  private static Pattern endpointDcPattern = Pattern.compile("(DC):([0-9]*):([0-9a-zA-Z-\\.]+)");
-  private static Pattern endpointRackPattern = Pattern.compile("(RACK):([0-9]*):([0-9a-zA-Z-\\.]+)");
-  private static Pattern endpointLoadPattern = Pattern.compile("(LOAD):([0-9]*):([0-9eE.]+)");
-  private static Pattern endpointReleasePattern = Pattern.compile("(RELEASE_VERSION):([0-9]*):([0-9.]+)");
-  private static Pattern endpointSeverityPattern = Pattern.compile("(SEVERITY):([0-9]*):([0-9.]+)");
-  private static Pattern endpointHostIdPattern = Pattern.compile("(HOST_ID):([0-9]*):([0-9a-z-]+)");
-  private static Pattern endpointTokensPattern = Pattern.compile("(TOKENS):([0-9]*)");
-  
+  private static final List<Pattern> ENDPOINT_NAME_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_STATUS_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_DC_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_RACK_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_LOAD_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_RELEASE_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_SEVERITY_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_HOSTID_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_TOKENS_PATTERNS = Lists.newArrayList();
+
+  private static final Pattern ENDPOINT_NAME_PATTERN = Pattern.compile("^([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})",
+      Pattern.MULTILINE | Pattern.DOTALL);
+  private static final Pattern ENDPOINT_STATUS_22_PATTERN = Pattern.compile("(STATUS):([0-9]*):(\\w+)");
+  private static final Pattern ENDPOINT_DC_22_PATTERN = Pattern.compile("(DC):([0-9]*):([0-9a-zA-Z-\\.]+)");
+  private static final Pattern ENDPOINT_RACK_22_PATTERN = Pattern.compile("(RACK):([0-9]*):([0-9a-zA-Z-\\.]+)");
+  private static final Pattern ENDPOINT_LOAD_22_PATTERN = Pattern.compile("(LOAD):([0-9]*):([0-9eE.]+)");
+  private static final Pattern ENDPOINT_RELEASE_22_PATTERN = Pattern.compile("(RELEASE_VERSION):([0-9]*):([0-9.]+)");
+  private static final Pattern ENDPOINT_SEVERITY_22_PATTERN = Pattern.compile("(SEVERITY):([0-9]*):([0-9.]+)");
+  private static final Pattern ENDPOINT_HOSTID_22_PATTERN = Pattern.compile("(HOST_ID):([0-9]*):([0-9a-z-]+)");
+  private static final Pattern ENDPOINT_TOKENS_22_PATTERN = Pattern.compile("(TOKENS):([0-9]*)");
+  private static final Pattern ENDPOINT_STATUS_21_PATTERN = Pattern.compile("(STATUS)(:)(\\w+)");
+  private static final Pattern ENDPOINT_DC_21_PATTERN = Pattern.compile("(DC)(:)([0-9a-zA-Z-\\.]+)");
+  private static final Pattern ENDPOINT_RACK_21_PATTERN = Pattern.compile("(RACK)(:)([0-9a-zA-Z-\\.]+)");
+  private static final Pattern ENDPOINT_LOAD_21_PATTERN = Pattern.compile("(LOAD)(:)([0-9eE.]+)");
+  private static final Pattern ENDPOINT_RELEASE_21_PATTERN = Pattern.compile("(RELEASE_VERSION)(:)([0-9.]+)");
+  private static final Pattern ENDPOINT_SEVERITY_21_PATTERN = Pattern.compile("(SEVERITY)(:)([0-9.]+)");
+  private static final Pattern ENDPOINT_HOSTID_21_PATTERN = Pattern.compile("(HOST_ID)(:)([0-9a-z-]+)");
+
   private static final String NOT_AVAILABLE = "Not available";
-  
+
+  static {
+    initPatterns();
+  }
+
   public NodesStatus(List<GossipInfo> endpointStates) {
     this.endpointStates = endpointStates;
   }
-  
+
   public NodesStatus(String sourceNode, String allEndpointStates, Map<String, String> simpleStates) {
     this.endpointStates = Lists.newArrayList();
-    this.endpointStates.add(parseEndpointStatesString(sourceNode, allEndpointStates, simpleStates)); 
+    this.endpointStates.add(parseEndpointStatesString(sourceNode, allEndpointStates, simpleStates));
   }
 
   private GossipInfo parseEndpointStatesString(String sourceNode, String allEndpointStates, Map<String, String> simpleStates) {
     List<EndpointState> endpoints = Lists.newArrayList();
     Matcher matcher;
-    
+
     String[] strEndpoints = allEndpointStates.split("/");
     Double totalLoad = 0.0;
-    
+
     for(int i=1;i<strEndpoints.length;i++){
-      Optional<String> endpoint = Optional.absent();
-      Optional<String> hostId = Optional.absent();
-      Optional<String> dc = Optional.absent();
-      Optional<String> rack = Optional.absent();
-      Optional<String> status = Optional.absent();
-      Optional<Double> severity = Optional.absent();
-      Optional<String> releaseVersion = Optional.absent();
-      Optional<String> tokens = Optional.absent();
-      Optional<Double> load = Optional.absent();
-      
       String endpointString = strEndpoints[i];
-      
-      matcher = endpointNamePattern.matcher(endpointString);
-      if(matcher.find()) {
-        endpoint = Optional.fromNullable(matcher.group(1));
+      Optional<String> status = Optional.absent();
+      Optional<String> endpoint = parseEndpointState(ENDPOINT_NAME_PATTERNS, endpointString, 1, String.class);
+
+      for (Pattern endpointStatusPattern : ENDPOINT_STATUS_PATTERNS) {
+        matcher = endpointStatusPattern.matcher(endpointString);
+        if (matcher.find() && matcher.groupCount() >= 3) {
+          status = Optional.of(matcher.group(3) + " - " + simpleStates.getOrDefault("/" + endpoint.or(""), "UNKNOWN"));
+          break;
+        }
       }
-      
-      matcher = endpointStatusPattern.matcher(endpointString);
-      if(matcher.find()) {
-        status = Optional.fromNullable(matcher.group(3) + " - " + simpleStates.getOrDefault("/" + endpoint.or(""), "UNKNOWN")) ;
-      }
-      
-      matcher = endpointDcPattern.matcher(endpointString);
-      if(matcher.find()) {
-        dc = Optional.fromNullable(matcher.group(3));
-      }
-      
-      matcher = endpointRackPattern.matcher(endpointString);
-      if(matcher.find()) {
-        rack = Optional.fromNullable(matcher.group(3));
-      }
-      
-      matcher = endpointSeverityPattern.matcher(endpointString);
-      if(matcher.find()) {
-        severity = Optional.fromNullable(Double.parseDouble(matcher.group(3)));
-      }
-      
-      matcher = endpointLoadPattern.matcher(endpointString);
-      if(matcher.find()) {
-        load = Optional.fromNullable(new BigDecimal(matcher.group(3)).doubleValue());
-        totalLoad+=load.or(0.0);
-      }
-      
-      matcher = endpointReleasePattern.matcher(endpointString);
-      if(matcher.find()) {
-        releaseVersion = Optional.fromNullable(matcher.group(3));
-      }
-      
-      matcher = endpointHostIdPattern.matcher(endpointString);
-      if(matcher.find()) {
-        hostId = Optional.fromNullable(matcher.group(3));
-      }
-      
-      matcher = endpointTokensPattern.matcher(endpointString);
-      if(matcher.find()) {
-        tokens = Optional.fromNullable(matcher.group(2));
-      }
-      
-      
-      
+
+      Optional<String> dc = parseEndpointState(ENDPOINT_DC_PATTERNS, endpointString, 3, String.class);
+      Optional<String> rack = parseEndpointState(ENDPOINT_RACK_PATTERNS, endpointString, 3, String.class);
+      Optional<Double> severity = parseEndpointState(ENDPOINT_SEVERITY_PATTERNS, endpointString, 3, Double.class);
+      Optional<String> releaseVersion = parseEndpointState(ENDPOINT_RELEASE_PATTERNS, endpointString, 3, String.class);
+      Optional<String> hostId = parseEndpointState(ENDPOINT_HOSTID_PATTERNS, endpointString, 3, String.class);
+      Optional<String> tokens = parseEndpointState(ENDPOINT_TOKENS_PATTERNS, endpointString, 2, String.class);
+      Optional<Double> load = parseEndpointState(ENDPOINT_LOAD_PATTERNS, endpointString, 3, Double.class);
+      totalLoad += load.or(0.0);
+
       EndpointState endpointState = new EndpointState(endpoint.or(NOT_AVAILABLE), hostId.or(NOT_AVAILABLE), dc.or(NOT_AVAILABLE), rack.or(NOT_AVAILABLE), status.or(NOT_AVAILABLE), severity.or(0.0),
           releaseVersion.or(NOT_AVAILABLE), tokens.or(NOT_AVAILABLE), load.or(0.0));
-      
+
       endpoints.add(endpointState);
     }
-    
+
     Map<String, Map<String, List<EndpointState>>> endpointsByDcAndRack = Maps.newHashMap();
     Map<String, List<EndpointState>> endpointsByDc = endpoints.stream().collect(Collectors.groupingBy(EndpointState::getDc, Collectors.toList()));
-    
+
     for(String dc:endpointsByDc.keySet()) {
       Map<String, List<EndpointState>> endpointsByRack = endpointsByDc.get(dc).stream().collect(Collectors.groupingBy(EndpointState::getRack, Collectors.toList()));
       endpointsByDcAndRack.put(dc, endpointsByRack);
     }
-    
+
     return new GossipInfo(sourceNode ,endpointsByDcAndRack, totalLoad);
   }
-  
-  
+
+  private <T> Optional<T> parseEndpointState(List<Pattern> patterns, String endpointString, int group, Class<T> type) {
+    Optional<T> result = Optional.absent();
+    for (Pattern pattern : patterns) {
+      Matcher matcher = pattern.matcher(endpointString);
+      if (matcher.find() && matcher.groupCount() >= group) {
+        result = (Optional<T>) Optional.of(matcher.group(group));
+        if(type.equals(Double.class)) {
+          result = (Optional<T>) Optional.of(Double.parseDouble(matcher.group(group)));
+        }
+        break;
+      }
+    }
+
+    return result;
+  }
+
+  private static void initPatterns() {
+    ENDPOINT_NAME_PATTERNS.add(ENDPOINT_NAME_PATTERN);
+    ENDPOINT_STATUS_PATTERNS.addAll(Arrays.asList(ENDPOINT_STATUS_22_PATTERN, ENDPOINT_STATUS_21_PATTERN));
+    ENDPOINT_DC_PATTERNS.addAll(Arrays.asList(ENDPOINT_DC_22_PATTERN, ENDPOINT_DC_21_PATTERN));
+    ENDPOINT_RACK_PATTERNS.addAll(Arrays.asList(ENDPOINT_RACK_22_PATTERN, ENDPOINT_RACK_21_PATTERN));
+    ENDPOINT_LOAD_PATTERNS.addAll(Arrays.asList(ENDPOINT_LOAD_22_PATTERN, ENDPOINT_LOAD_21_PATTERN));
+    ENDPOINT_RELEASE_PATTERNS.addAll(Arrays.asList(ENDPOINT_RELEASE_22_PATTERN, ENDPOINT_RELEASE_21_PATTERN));
+    ENDPOINT_SEVERITY_PATTERNS.addAll(Arrays.asList(ENDPOINT_SEVERITY_22_PATTERN, ENDPOINT_SEVERITY_21_PATTERN));
+    ENDPOINT_HOSTID_PATTERNS.addAll(Arrays.asList(ENDPOINT_HOSTID_22_PATTERN, ENDPOINT_HOSTID_21_PATTERN));
+    ENDPOINT_TOKENS_PATTERNS.add(ENDPOINT_TOKENS_22_PATTERN);
+  }
+
+
 
   public class GossipInfo {
     @JsonProperty
@@ -143,14 +155,14 @@ public class NodesStatus {
     public final Map<String, Map<String, List<EndpointState>>> endpoints;
     @JsonProperty
     public final Double totalLoad;
-    
+
     public GossipInfo(String sourceNode, Map<String, Map<String, List<EndpointState>>> endpoints, Double totalLoad) {
       this.sourceNode = sourceNode;
       this.endpoints = endpoints;
       this.totalLoad = totalLoad;
-    } 
+    }
   }
-  
+
   public class EndpointState {
     @JsonProperty
     public final String endpoint;
@@ -170,7 +182,7 @@ public class NodesStatus {
     public final String tokens;
     @JsonProperty
     public final Double load;
-    
+
     public EndpointState(String endpoint, String hostId, String dc, String rack, String status, Double severity,
         String releaseVersion, String tokens, Double load) {
       this.endpoint = endpoint;
@@ -183,25 +195,26 @@ public class NodesStatus {
       this.tokens = tokens;
       this.load = load;
    }
-    
+
    public String getDc() {
      return this.dc;
    }
-   
+
    public String getRack() {
      return this.rack;
    }
-    
-   public String toString() {
-     return "Endpoint : " + endpoint + " / " 
-           + "Status : " + status + " / " 
-           + "DC : " + dc + " / " 
-           + "Rack : " + rack + " / " 
-           + "Release version : " + releaseVersion + " / " 
-           + "Load : " + load + " / " 
-           + "Severity : " + severity + " / " 
-           + "Host Id : " + hostId + " / " 
+
+   @Override
+  public String toString() {
+     return "Endpoint : " + endpoint + " / "
+           + "Status : " + status + " / "
+           + "DC : " + dc + " / "
+           + "Rack : " + rack + " / "
+           + "Release version : " + releaseVersion + " / "
+           + "Load : " + load + " / "
+           + "Severity : " + severity + " / "
+           + "Host Id : " + hostId + " / "
            + "Tokens : " + tokens;
    }
-  } 
+  }
 }

--- a/src/server/src/test/java/com/spotify/reaper/resources/view/NodesStatusTest.java
+++ b/src/server/src/test/java/com/spotify/reaper/resources/view/NodesStatusTest.java
@@ -16,7 +16,7 @@ public class NodesStatusTest {
 
 
   @Test
-  public void testParseEndpointStatusString(){
+  public void testParseEndpoint22StatusString() {
     Map<String, String> simpleStates = Maps.newHashMap();
 
     StringBuilder endpointsStatusString = new StringBuilder().append("/127.0.0.1")
@@ -38,16 +38,16 @@ public class NodesStatusTest {
         .append("  generation:1497347537 ")
         .append("  heartbeat:27077 ")
         .append("  STATUS:14:NORMAL,-3074457345618258603 ")
-        .append("  LOAD:26921:3988763.0 ")
+        .append("  LOAD:1231851:3988763.0 ")
         .append("  SCHEMA:10:2de0af6a-bf86-38e0-b62b-474ff6aefb51 ")
         .append("  DC:6:datacenter2 ")
         .append("  RACK:8:rack2 ")
         .append("  RELEASE_VERSION:4:3.0.8 ")
         .append("  RPC_ADDRESS:3:127.0.0.2 ")
-        .append("  SEVERITY:27076:0.0 ")
+        .append("  SEVERITY:1231899:0.0 ")
         .append("  NET_VERSION:1:10 ")
         .append("  HOST_ID:2:08f819b5-d96f-444e-9d4d-ec4136e1b716 ")
-        .append("  RPC_READY:44:true ")
+        .append("  RPC_READY:16:true")
         .append("  TOKENS:13:<hidden> \r")
         .append("/127.0.0.3")
         .append("  generation:1496849191 ")
@@ -64,6 +64,80 @@ public class NodesStatusTest {
         .append("  HOST_ID:2:20769fed-7916-4b7a-a729-8b99bcdc9b95 ")
         .append("  RPC_READY:44:true ")
         .append("  TOKENS:15:<hidden> ");
+
+    simpleStates.put("/127.0.0.3", "UP");
+    simpleStates.put("/127.0.0.1", "DOWN");
+
+    NodesStatus nodesStatus = new NodesStatus("127.0.0.1", endpointsStatusString.toString(), simpleStates);
+
+    assertEquals(nodesStatus.endpointStates.size(), 1);
+    assertEquals(nodesStatus.endpointStates.get(0).sourceNode, "127.0.0.1");
+
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").keySet().size(), 1);
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").size(), 1);
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).status, "NORMAL - DOWN");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter2").get("rack2").get(0).status, "NORMAL - UNKNOWN");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("us-west-1").get("rack3").get(0).status, "NORMAL - UP");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).endpoint, "127.0.0.1");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).hostId, "f091f82b-ce2c-40ee-b30c-6e761e94e821");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).tokens, "13");
+    assertTrue(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).severity.equals(0.0));
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).releaseVersion, "3.0.8");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter2").get("rack2").get(0).dc, "datacenter2");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter2").get("rack2").get(0).rack, "rack2");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("us-west-1").get("rack3").get(0).dc, "us-west-1");
+    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("us-west-1").get("rack3").get(0).rack, "rack3");
+    assertTrue(nodesStatus.endpointStates.get(0).endpoints.get("us-west-1").get("rack3").get(0).load.equals(3974144.0));
+  }
+
+  @Test
+  public void testParseEndpoint21StatusString() {
+    Map<String, String> simpleStates = Maps.newHashMap();
+
+    StringBuilder endpointsStatusString = new StringBuilder().append("/127.0.0.1")
+        .append("  generation:1496849190 ")
+        .append("  heartbeat:1231900 ")
+        .append("  STATUS:NORMAL,-9223372036854775808 ")
+        .append("  LOAD:4043215.0 ")
+        .append("  SCHEMA:2de0af6a-bf86-38e0-b62b-474ff6aefb51 ")
+        .append("  DC:datacenter1 ")
+        .append("  RACK:rack1 ")
+        .append("  RELEASE_VERSION:3.0.8 ")
+        .append("  RPC_ADDRESS:127.0.0.1 ")
+        .append("  SEVERITY:0.0 ")
+        .append("  NET_VERSION:10 ")
+        .append("  HOST_ID:f091f82b-ce2c-40ee-b30c-6e761e94e821 ")
+        .append("  RPC_READY:true ")
+        .append("  TOKENS:<hidden> \r")
+        .append("/127.0.0.2")
+        .append("  generation:1497347537 ")
+        .append("  heartbeat:27077 ")
+        .append("  STATUS:NORMAL,-3074457345618258603 ")
+        .append("  LOAD:3988763.0 ")
+        .append("  SCHEMA:2de0af6a-bf86-38e0-b62b-474ff6aefb51 ")
+        .append("  DC:datacenter2 ")
+        .append("  RACK:rack2 ")
+        .append("  RELEASE_VERSION:3.0.8 ")
+        .append("  RPC_ADDRESS:127.0.0.2 ")
+        .append("  SEVERITY:0.0 ")
+        .append("  NET_VERSION:10 ")
+        .append("  HOST_ID:08f819b5-d96f-444e-9d4d-ec4136e1b716 ")
+        .append("  RPC_READY:true \r")
+        .append("/127.0.0.3")
+        .append("  generation:1496849191 ")
+        .append("  heartbeat:1230183 ")
+        .append("  STATUS:NORMAL,3074457345618258602 ")
+        .append("  LOAD:3.974144E6")
+        .append("  SCHEMA:2de0af6a-bf86-38e0-b62b-474ff6aefb51 ")
+        .append("  DC:us-west-1")
+        .append("  RACK:rack3 ")
+        .append("  RELEASE_VERSION:3.0.8 ")
+        .append("  RPC_ADDRESS:127.0.0.3 ")
+        .append("  SEVERITY:0.0 ")
+        .append("  NET_VERSION:10 ")
+        .append("  HOST_ID:20769fed-7916-4b7a-a729-8b99bcdc9b95 ")
+        .append("  RPC_READY:true ")
+        .append("  TOKENS:<hidden> ");
 
     simpleStates.put("/127.0.0.3","UP");
     simpleStates.put("/127.0.0.1","DOWN");
@@ -83,8 +157,7 @@ public class NodesStatusTest {
     assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("us-west-1").get("rack3").get(0).status, "NORMAL - UP");
     assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).endpoint, "127.0.0.1");
     assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).hostId, "f091f82b-ce2c-40ee-b30c-6e761e94e821");
-    assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).tokens, "13");
-    assertTrue(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).severity.equals((double)0.0));
+    assertTrue(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).severity.equals(0.0));
     assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter1").get("rack1").get(0).releaseVersion, "3.0.8");
     assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter2").get("rack2").get(0).dc, "datacenter2");
     assertEquals(nodesStatus.endpointStates.get(0).endpoints.get("datacenter2").get("rack2").get(0).rack, "rack2");


### PR DESCRIPTION
Fix for issue #186 

The node status screen was broken on C* 2.1 clusters as the gossipinfo output is different.
2.1 : 
```
/127.0.0.3
  generation:1504618212
  heartbeat:827
  DC:datacenter1
  RACK:rack1
  RELEASE_VERSION:2.1.9
  NET_VERSION:8
  SEVERITY:0.0
  STATUS:NORMAL,3074457345618258602
  HOST_ID:05721007-3fa2-41bf-b5aa-d088f6b62a32
  SCHEMA:6403a0ff-f93b-3b1f-8c35-0a8dc85a5b66
  LOAD:47634.0
  RPC_ADDRESS:127.0.0.3 
```

2.2 : 
```
/127.0.0.3
  generation:1504541255
  heartbeat:195237
  STATUS:14:NORMAL,3074457345618258602
  LOAD:195072:1.92833986E8
  SCHEMA:10:12b53a24-4d42-3080-959a-edab48b32402
  DC:6:datacenter1
  RACK:8:rack1
  RELEASE_VERSION:4:2.2.5
  RPC_ADDRESS:3:127.0.0.3
  SEVERITY:195236:0.0
  NET_VERSION:1:9
  HOST_ID:2:9ad3b85c-3431-4d7c-bd47-7b9e0f18f82d
  RPC_READY:42:true
  TOKENS:13:<hidden>
```

The PR allows both formats with 2 sets of regex. 