### PR TITLE
Only consider segments belonging to running jobs.

### DIFF
--- a/src/server/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/com/spotify/reaper/storage/CassandraStorage.java
@@ -539,6 +539,9 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     Collection<RepairRun> repairRuns = getRepairRunsForCluster(clusterName);
 
     for(RepairRun repairRun:repairRuns){
+      if (repairRun.getRunState() != RunState.RUNNING) {
+        continue;
+      }
       Collection<RepairSegment> runningSegments = getSegmentsWithState(repairRun.getId(), State.RUNNING);
       for(RepairSegment segment:runningSegments){
         Optional<RepairUnit> repairUnit = getRepairUnit(repairRun.getRepairUnitId());

--- a/src/server/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
+++ b/src/server/src/main/java/com/spotify/reaper/storage/postgresql/IStoragePostgreSQL.java
@@ -130,7 +130,7 @@ public interface IStoragePostgreSQL {
           + "FROM repair_segment "
           + "JOIN repair_run ON run_id = repair_run.id "
           + "JOIN repair_unit ON repair_run.repair_unit_id = repair_unit.id "
-          + "WHERE repair_segment.state = 1 AND repair_unit.cluster_name = :clusterName";
+          + "WHERE repair_segment.state = 1 AND repair_run.state = 'RUNNING' AND repair_unit.cluster_name = :clusterName";
   String SQL_GET_NEXT_FREE_REPAIR_SEGMENT =
       "SELECT " + SQL_REPAIR_SEGMENT_ALL_FIELDS + " FROM repair_segment WHERE run_id = :runId "
       + "AND state = 0 ORDER BY fail_count ASC, start_token ASC LIMIT 1";


### PR DESCRIPTION
This PR fixed issue #185 by making `CassandraStorage` and `PostgresStorage` behave like `MemoryStorage` in that only running segments belonging to running jobs will keep Cassandra Reaper from terminating the repair process on a node.