### PR TITLE
Refactored Travis to allow parallel Docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,85 +1,55 @@
 sudo: required
 language: java
 jdk:
-- oraclejdk8
+  - oraclejdk8
+
 env:
   global:
     - LOCAL_JMX=no
     - TEST=""
   matrix:
       # 2.1.18 runs all tests together because it's also for sonar reporting, see below
-    - CASSANDRA_VERSION=2.1.18
-    - CASSANDRA_VERSION=2.1.18 GRIM_MIN=2 GRIM_MAX=2
-    - CASSANDRA_VERSION=2.1.18 GRIM_MIN=2 GRIM_MAX=4
-    - CASSANDRA_VERSION=2.2.10 GRIM_MIN=1 GRIM_MAX=1
-    - CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=2 
-    - CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=4
-    - CASSANDRA_VERSION=3.0.10 GRIM_MIN=1 GRIM_MAX=1
-    - CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=2
-    - CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=4
-    - CASSANDRA_VERSION=3.11.0 GRIM_MIN=1 GRIM_MAX=1
-    - CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=2
-    - CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=4
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.18
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.18 GRIM_MIN=2 GRIM_MAX=2
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.18 GRIM_MIN=2 GRIM_MAX=4
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=1 GRIM_MAX=1
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=2
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=4
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.10 GRIM_MIN=1 GRIM_MAX=1
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=2
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=4
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.0 GRIM_MIN=1 GRIM_MAX=1
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=2
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=4
+    - TEST_TYPE=docker
+
 matrix:
   fast_finish: true
   allow_failures:
-  - env: CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=2
-  - env: CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=4
-  - env: CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=2
-  - env: CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=4
-  - env: CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=4
+  - env: TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=2
+  - env: TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=4
+  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=2
+  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=4
+  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=4
+
 services:
   - postgresql
-before_script:
-  - psql -c 'create database reaper;' -U postgres
-before_install:
-  - sudo apt-get install libjna-java > /dev/null
-  - sudo apt-get install python-support > /dev/null
-  - sudo easy_install pyYaml > /dev/null
-  - sudo easy_install pip > /dev/null
-  - sudo pip install ccm > /dev/null
+  - docker
 
-install:
-  - ccm create test -v $CASSANDRA_VERSION > /dev/null
-  - ccm populate --vnodes -n 2 > /dev/null
-  - sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/travis/.ccm/test/node1/conf/cassandra-env.sh
-  - sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/travis/.ccm/test/node2/conf/cassandra-env.sh
-  - sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="256m"/' /home/travis/.ccm/test/node1/conf/cassandra-env.sh
-  - sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="256m"/' /home/travis/.ccm/test/node2/conf/cassandra-env.sh
-  - "sudo sed -i 's/_timeout_in_ms:.*/_timeout_in_ms: 60000/' /home/travis/.ccm/test/node1/conf/cassandra.yaml"
-  - "sudo sed -i 's/_timeout_in_ms:.*/_timeout_in_ms: 60000/' /home/travis/.ccm/test/node2/conf/cassandra.yaml"
-  - "sudo sed -i 's/start_rpc: true/start_rpc: false/' /home/travis/.ccm/test/node1/conf/cassandra.yaml"
-  - "sudo sed -i 's/start_rpc: true/start_rpc: false/' /home/travis/.ccm/test/node2/conf/cassandra.yaml"
-  - "sudo sed -i 's/cross_node_timeout: false/cross_node_timeout: true/' /home/travis/.ccm/test/node1/conf/cassandra.yaml"
-  - "sudo sed -i 's/cross_node_timeout: false/cross_node_timeout: true/' /home/travis/.ccm/test/node2/conf/cassandra.yaml"
-  - "sudo sed -i 's/concurrent_reads: 32/concurrent_reads: 2/' /home/travis/.ccm/test/node1/conf/cassandra.yaml"
-  - "sudo sed -i 's/concurrent_reads: 32/concurrent_reads: 2/' /home/travis/.ccm/test/node2/conf/cassandra.yaml"
-  - "sudo sed -i 's/concurrent_writes: 32/concurrent_writes: 2/' /home/travis/.ccm/test/node1/conf/cassandra.yaml"
-  - "sudo sed -i 's/concurrent_writes: 32/concurrent_writes: 2/' /home/travis/.ccm/test/node2/conf/cassandra.yaml"
-  - "sudo sed -i 's/concurrent_counter_writes: 32/concurrent_counter_writes: 2/' /home/travis/.ccm/test/node1/conf/cassandra.yaml"
-  - "sudo sed -i 's/concurrent_counter_writes: 32/concurrent_counter_writes: 2/' /home/travis/.ccm/test/node2/conf/cassandra.yaml"
-  - "sudo sed -i 's/num_tokens: 256/num_tokens: 32/' /home/travis/.ccm/test/node1/conf/cassandra.yaml"
-  - "sudo sed -i 's/num_tokens: 256/num_tokens: 32/' /home/travis/.ccm/test/node2/conf/cassandra.yaml"
-  - ccm start -v
+before_install: ./src/ci/before_install.sh
 
-#before_script:
-#  - npm install -g bower
-script:
-  - ccm status
-  - ccm node1 nodetool status
-  - 'if [ "x$GRIM_MIN" = "x" ]; then mvn clean package && mvn surefire:test -Dtest=ReaperIT && mvn surefire:test -Dtest=ReaperH2IT && mvn surefire:test -Dtest=ReaperPostgresIT && mvn surefire:test -Dtest=ReaperCassandraIT  ; else  mvn clean package && mvn surefire:test -Dtest=ReaperCassandraIT -Dgrim.reaper.min=$GRIM_MIN -Dgrim.reaper.max=$GRIM_MAX ; fi'
-after_success:
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" -a "$CASSANDRA_VERSION" = "2.1.18" ]; then mvn sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=tlp-cassandra-reaper -Dsonar.github.oauth=$GITHUB_TOKEN -Dsonar.github.repository=thelastpickle/cassandra-reaper; fi'
-after_failure:
-  - ccm checklogerror
-before_deploy: 
-  - "mkdir cassandra-reaper-${TRAVIS_TAG}"
-  - "mkdir cassandra-reaper-${TRAVIS_TAG}/target"
-  - "mkdir cassandra-reaper-${TRAVIS_TAG}/server/target"
-  - "cp -R src/packaging/bin cassandra-reaper-${TRAVIS_TAG}/"
-  - "cp src/server/target/cassandra-reaper-*.jar cassandra-reaper-${TRAVIS_TAG}/server/target"
-  - "cp -R src/packaging/resource cassandra-reaper-${TRAVIS_TAG}/"
-  - "tar czf cassandra-reaper-${TRAVIS_TAG}-release.tar.gz cassandra-reaper-${TRAVIS_TAG}/"
+install: ./src/ci/install.sh
+
+before_script: ./src/ci/before_script.sh
+
+script: ./src/ci/script.sh
+
+after_success: ./src/ci/after_success.sh
+
+after_failure: ./src/ci/after_failure.sh
+
+before_deploy: ./src/ci/before_deploy.sh
+
 deploy:
   provider: releases
   api_key: $GITHUB_TOKEN
@@ -87,7 +57,7 @@ deploy:
   file: "cassandra-reaper-${TRAVIS_TAG}-release.tar.gz"
   skip_cleanup: true
   on:
-    tags: true 
+    tags: true
 
 notifications:
   webhooks:

--- a/src/ci/after_failure.sh
+++ b/src/ci/after_failure.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Starting After Failure step..."
+
+set -xe
+
+case "${TEST_TYPE}" in
+    "")
+        echo "ERROR: Environment variable TEST_TYPE is unspecified."
+        exit 1
+        ;;
+    "ccm")
+        ccm checklogerror
+        ;;
+    *)
+        echo "Skipping, no actions for TEST_TYPE=${TEST_TYPE}."
+esac

--- a/src/ci/after_success.sh
+++ b/src/ci/after_success.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Starting After Success step..."
+
+set -xe
+
+case "${TEST_TYPE}" in
+    "")
+        echo "ERROR: Environment variable TEST_TYPE is unspecified."
+        exit 1
+        ;;
+    "ccm")
+        if [ "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_BRANCH}" = "master" -a "${CASSANDRA_VERSION}" = "2.1.18" ]
+        then
+            mvn sonar:sonar \
+                -Dsonar.host.url=https://sonarqube.com \
+                -Dsonar.login=${SONAR_TOKEN} \
+                -Dsonar.projectKey=tlp-cassandra-reaper \
+                -Dsonar.github.oauth=${GITHUB_TOKEN} \
+                -Dsonar.github.repository=thelastpickle/cassandra-reaper
+        fi
+        ;;
+    *)
+        echo "Skipping, no actions for TEST_TYPE=${TEST_TYPE}."
+esac

--- a/src/ci/before_deploy.sh
+++ b/src/ci/before_deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Starting Before Deploy step..."
+
+set -xe
+
+mkdir cassandra-reaper-${TRAVIS_TAG}
+mkdir cassandra-reaper-${TRAVIS_TAG}/target
+mkdir cassandra-reaper-${TRAVIS_TAG}/server/target
+cp -R src/packaging/bin cassandra-reaper-${TRAVIS_TAG}/
+cp src/server/target/cassandra-reaper-*.jar cassandra-reaper-${TRAVIS_TAG}/server/target
+cp -R src/packaging/resource cassandra-reaper-${TRAVIS_TAG}/
+tar czf cassandra-reaper-${TRAVIS_TAG}-release.tar.gz cassandra-reaper-${TRAVIS_TAG}/

--- a/src/ci/before_install.sh
+++ b/src/ci/before_install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Starting Before Install step..."
+
+set -xe
+
+sudo apt-get update
+sudo apt-get install libjna-java > /dev/null
+sudo apt-get install python-support > /dev/null
+sudo apt-get install python-pip > /dev/null
+pip install --user pyyaml > /dev/null
+pip install --user ccm > /dev/null
+
+# npm install -g bower
+
+if [ "${TEST_TYPE}" = "docker" ]
+then
+    sudo apt-get install docker > /dev/null
+    sudo curl -o /usr/local/bin/docker-compose -L "https://github.com/docker/compose/releases/download/1.15.0/docker-compose-$(uname -s)-$(uname -m)"
+    sudo chmod +x /usr/local/bin/docker-compose
+
+    # Requests needed for the src/packaging/bin/spreaper python script which calls the Reaper API
+    pip install --user requests > /dev/null
+fi

--- a/src/ci/before_script.sh
+++ b/src/ci/before_script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Starting Before Script step..."
+
+set -xe
+
+case "${TEST_TYPE}" in
+    "")
+        echo "ERROR: Environment variable TEST_TYPE is unspecified."
+        exit 1
+        ;;
+    "ccm")
+        psql -c 'create database reaper;' -U postgres
+        ;;
+    *)
+        echo "Skipping, no actions for TEST_TYPE=${TEST_TYPE}."
+esac

--- a/src/ci/install.sh
+++ b/src/ci/install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "Starting Install step..."
+
+set -xe
+
+case "${TEST_TYPE}" in
+    "")
+        echo "ERROR: Environment variable TEST_TYPE is unspecified."
+        exit 1
+        ;;
+    "ccm")
+        ccm create test -v $CASSANDRA_VERSION > /dev/null
+        ccm populate --vnodes -n 2 > /dev/null
+        sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/travis/.ccm/test/node1/conf/cassandra-env.sh
+        sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/travis/.ccm/test/node2/conf/cassandra-env.sh
+        sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="256m"/' /home/travis/.ccm/test/node1/conf/cassandra-env.sh
+        sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="256m"/' /home/travis/.ccm/test/node2/conf/cassandra-env.sh
+        sed -i 's/_timeout_in_ms:.*/_timeout_in_ms: 60000/' /home/travis/.ccm/test/node1/conf/cassandra.yaml
+        sed -i 's/_timeout_in_ms:.*/_timeout_in_ms: 60000/' /home/travis/.ccm/test/node2/conf/cassandra.yaml
+        sed -i 's/start_rpc: true/start_rpc: false/' /home/travis/.ccm/test/node1/conf/cassandra.yaml
+        sed -i 's/start_rpc: true/start_rpc: false/' /home/travis/.ccm/test/node2/conf/cassandra.yaml
+        sed -i 's/cross_node_timeout: false/cross_node_timeout: true/' /home/travis/.ccm/test/node1/conf/cassandra.yaml
+        sed -i 's/cross_node_timeout: false/cross_node_timeout: true/' /home/travis/.ccm/test/node2/conf/cassandra.yaml
+        sed -i 's/concurrent_reads: 32/concurrent_reads: 2/' /home/travis/.ccm/test/node1/conf/cassandra.yaml
+        sed -i 's/concurrent_reads: 32/concurrent_reads: 2/' /home/travis/.ccm/test/node2/conf/cassandra.yaml
+        sed -i 's/concurrent_writes: 32/concurrent_writes: 2/' /home/travis/.ccm/test/node1/conf/cassandra.yaml
+        sed -i 's/concurrent_writes: 32/concurrent_writes: 2/' /home/travis/.ccm/test/node2/conf/cassandra.yaml
+        sed -i 's/concurrent_counter_writes: 32/concurrent_counter_writes: 2/' /home/travis/.ccm/test/node1/conf/cassandra.yaml
+        sed -i 's/concurrent_counter_writes: 32/concurrent_counter_writes: 2/' /home/travis/.ccm/test/node2/conf/cassandra.yaml
+        sed -i 's/num_tokens: 256/num_tokens: 32/' /home/travis/.ccm/test/node1/conf/cassandra.yaml
+        sed -i 's/num_tokens: 256/num_tokens: 32/' /home/travis/.ccm/test/node2/conf/cassandra.yaml
+        ;;
+    *)
+        echo "Skipping, no actions for TEST_TYPE=${TEST_TYPE}."
+esac

--- a/src/ci/script.sh
+++ b/src/ci/script.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+echo "Starting Script step..."
+
+set -xe
+
+case "${TEST_TYPE}" in
+    "")
+        echo "ERROR: Environment variable TEST_TYPE is unspecified."
+        exit 1
+        ;;
+    "ccm")
+        ccm start -v
+        sleep 30
+        ccm status
+        ccm node1 nodetool status
+
+        mvn clean package
+        if [ "x${GRIM_MIN}" = "x" ]
+        then
+            mvn surefire:test -Dtest=ReaperIT
+            mvn surefire:test -Dtest=ReaperH2IT
+            mvn surefire:test -Dtest=ReaperPostgresIT
+            mvn surefire:test -Dtest=ReaperCassandraIT
+        else
+            mvn surefire:test -Dtest=ReaperCassandraIT -Dgrim.reaper.min=${GRIM_MIN} -Dgrim.reaper.max=${GRIM_MAX}
+        fi
+        ;;
+    "docker")
+        docker-compose -f ./src/packaging/docker-compose.yml build reaper-build-packages
+        docker-compose -f ./src/packaging/docker-compose.yml run reaper-build-packages
+
+        # Need to change the permissions after building the packages using the Docker image because they
+        # are set to root and if left unchanged they will cause Maven to fail
+        sudo chown -R travis:travis ./src/server/target/
+        mvn -f src/server/pom.xml docker:build -Ddocker.directory=src/server/src/main/docker -DskipTests
+        docker images
+
+        # Generation of SSL stores - this can be done at any point in time prior to running setting up the SSL environment
+        docker-compose -f ./src/packaging/docker-compose.yml run generate-ssl-stores
+
+        # Test default environment then test SSL encrypted environment
+        for docker_env in "" "-ssl"
+        do
+            # Clear out Cassandra data before starting a new cluster
+            sudo rm -vfr ./src/packaging/data/
+
+            docker-compose -f ./src/packaging/docker-compose.yml up -d cassandra${docker_env}
+            sleep 30
+            docker-compose -f ./src/packaging/docker-compose.yml run cqlsh-initialize-reaper_db${docker_env}
+            sleep 10
+            docker-compose -f ./src/packaging/docker-compose.yml up -d reaper${docker_env}
+            sleep 30
+            docker ps -a
+
+            src/packaging/bin/spreaper add-cluster $(docker-compose -f ./src/packaging/docker-compose.yml run nodetool${docker_env} status | grep UN | tr -s ' ' | cut -d' ' -f2)
+            sleep 5
+            docker-compose -f ./src/packaging/docker-compose.yml down
+        done
+        ;;
+    *)
+        echo "Skipping, no actions for TEST_TYPE=${TEST_TYPE}."
+esac


### PR DESCRIPTION
- Created shell scripts for stage in Travis that conntained commands
- Moved commands from .travis.yml into their respective shell scripts
- Added a TEST_TYPE variable to allow different commands to be run at
   each Travis stage depending on that type
- Added a Docker test to the Travis build