### PR TITLE
Change default configurations for more safety.

### DIFF
--- a/src/packaging/resource/cassandra-reaper-cassandra-ssl.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra-ssl.yaml
@@ -10,8 +10,9 @@ hangingRepairTimeoutMins: 30
 storageType: cassandra
 enableCrossOrigin: true
 incrementalRepair: false
-enableDynamicSeedList: true
-repairManagerSchedulingIntervalSeconds: 30
+repairManagerSchedulingIntervalSeconds: 10
+activateQueryLogger: false
+jmxConnectionTimeoutInSeconds: 5
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible
@@ -64,6 +65,14 @@ cassandra:
   clusterName: "test"
   contactPoints: ["127.0.0.1"]
   keyspace: reaper_db
+  loadBalancingPolicy:
+    type: tokenAware
+    shuffleReplicas: true
+    subPolicy:
+      type: dcAwareRoundRobin
+      localDC:
+      usedHostsPerRemoteDC: 0
+      allowRemoteDCsForLocalConsistencyLevel: false
   authProvider:
     type: plainText
     username: cassandra

--- a/src/packaging/resource/cassandra-reaper-cassandra.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra.yaml
@@ -11,8 +11,9 @@ storageType: cassandra
 enableCrossOrigin: true
 incrementalRepair: false
 enableDynamicSeedList: true
-repairManagerSchedulingIntervalSeconds: 30
+repairManagerSchedulingIntervalSeconds: 10
 activateQueryLogger: false
+jmxConnectionTimeoutInSeconds: 5
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible
@@ -73,7 +74,14 @@ cassandra:
   clusterName: "test"
   contactPoints: ["127.0.0.1"]
   keyspace: reaper_db
-
+  loadBalancingPolicy:
+    type: tokenAware
+    shuffleReplicas: true
+    subPolicy:
+      type: dcAwareRoundRobin
+      localDC:
+      usedHostsPerRemoteDC: 0
+      allowRemoteDCsForLocalConsistencyLevel: false
 autoScheduling:
   enabled: false
   initialDelayPeriod: PT15S

--- a/src/packaging/resource/cassandra-reaper-h2.yaml
+++ b/src/packaging/resource/cassandra-reaper-h2.yaml
@@ -11,7 +11,8 @@ storageType: database
 enableCrossOrigin: true
 incrementalRepair: false
 enableDynamicSeedList: true
-repairManagerSchedulingIntervalSeconds: 30
+repairManagerSchedulingIntervalSeconds: 10
+jmxConnectionTimeoutInSeconds: 5
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/packaging/resource/cassandra-reaper-memory.yaml
+++ b/src/packaging/resource/cassandra-reaper-memory.yaml
@@ -11,7 +11,8 @@ storageType: memory
 enableCrossOrigin: true
 incrementalRepair: false
 enableDynamicSeedList: true
-repairManagerSchedulingIntervalSeconds: 30
+repairManagerSchedulingIntervalSeconds: 10
+jmxConnectionTimeoutInSeconds: 5
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/packaging/resource/cassandra-reaper-postgres.yaml
+++ b/src/packaging/resource/cassandra-reaper-postgres.yaml
@@ -11,7 +11,8 @@ storageType: database
 enableCrossOrigin: true
 incrementalRepair: false
 enableDynamicSeedList: true
-repairManagerSchedulingIntervalSeconds: 30
+repairManagerSchedulingIntervalSeconds: 10
+jmxConnectionTimeoutInSeconds: 5
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/packaging/resource/cassandra-reaper.yaml
+++ b/src/packaging/resource/cassandra-reaper.yaml
@@ -11,7 +11,9 @@ storageType: memory
 enableCrossOrigin: true
 incrementalRepair: false
 enableDynamicSeedList: true
-repairManagerSchedulingIntervalSeconds: 30
+repairManagerSchedulingIntervalSeconds: 10
+activateQueryLogger: false
+jmxConnectionTimeoutInSeconds: 5
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible


### PR DESCRIPTION
For Cassandra backend yamls, use the token aware policy by default
and the DC aware policy to handle multi DC setups out of the box.
Explicitely set JMX connection timeout to 5s and reduce the repair manager
polling interval to speed up light repairs.