### PR TITLE
ignore assertion on repair failure notification

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -675,7 +675,9 @@ public final class SegmentRunner implements RepairStatusHandler, Runnable {
         } finally {
           // if someone else does hold the lease, ie renewLead(..) was true,
           // then their writes to repair_run table and any call to releaseLead(..) will throw an exception
-          releaseLead();
+          try {
+            releaseLead();
+          } catch (AssertionError ignore) { }
         }
       }
     }


### PR DESCRIPTION
ignore assertion on repair failure notification ABORT|ERROR|SESSION_FAILED notification.

It doesn't matter, as we've marked the segment as failed.

this is to be merged into master, once #210 is merged.