### PR TITLE
Add JMX connection test for the whole cluster on init to speed up sub…

### DIFF
--- a/src/packaging/docker-build/docker-entrypoint.sh
+++ b/src/packaging/docker-build/docker-entrypoint.sh
@@ -9,7 +9,8 @@ set -ex
 cd ${WORKDIR}/cassandra-reaper/src/packaging \
     && make all \
     && mv *.deb *.rpm ${WORKDIR}/packages \
-    && cp ../server/target/cassandra-*.jar ${WORKDIR}/packages
+    && cp ../server/target/cassandra-*.jar ${WORKDIR}/packages \
+    && rm ${WORKDIR}/packages/cassandra*-sources.jar
 
 # execute any provided command
 $@

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionsInitializer.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionsInitializer.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.jmx;
+
+import io.cassandrareaper.AppContext;
+import io.cassandrareaper.core.Cluster;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import com.google.common.base.Optional;
+import jersey.repackaged.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JmxConnectionsInitializer implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JmxConnectionsInitializer.class);
+  private final ExecutorService executor = Executors.newFixedThreadPool(10);
+
+  private final AppContext context;
+
+  public JmxConnectionsInitializer(AppContext context) {
+    this.context = context;
+  }
+
+  public void on(Cluster cluster) {
+    LOG.info("Initializing JMX seed list for cluster {}...", cluster.getName());
+    List<Callable<Optional<String>>> jmxTasks = Lists.newArrayList();
+    List<String> seedHosts = Lists.newArrayList();
+    seedHosts.addAll(cluster.getSeedHosts());
+
+    for (int i = 0; i < seedHosts.size(); i++) {
+      jmxTasks.add(connectToJmx(Arrays.asList(seedHosts.get(i))));
+      if (i % 10 == 0 || i == seedHosts.size() - 1) {
+        tryConnectingToJmxSeeds(jmxTasks);
+        jmxTasks = Lists.newArrayList();
+      }
+    }
+  }
+
+  private Callable<Optional<String>> connectToJmx(List<String> endpoints) {
+    return () -> {
+      try (JmxProxy jmxProxy =
+          context.jmxConnectionFactory.connectAny(
+              Optional.absent(), endpoints, JmxProxy.JMX_CONNECTION_TIMEOUT)) {
+
+        return Optional.of(endpoints.get(0));
+
+      } catch (RuntimeException e) {
+        LOG.debug("failed to connect to hosts {} through JMX", endpoints.get(0), e);
+        return Optional.absent();
+      }
+    };
+  }
+
+  private void tryConnectingToJmxSeeds(List<Callable<Optional<String>>> jmxTasks) {
+    try {
+      List<Future<Optional<String>>> endpointFutures
+          = executor.invokeAll(jmxTasks, JmxProxy.JMX_CONNECTION_TIMEOUT, JmxProxy.JMX_CONNECTION_TIMEOUT_UNIT);
+
+      for (Future<Optional<String>> endpointFuture : endpointFutures) {
+        try {
+          endpointFuture.get(JmxProxy.JMX_CONNECTION_TIMEOUT, JmxProxy.JMX_CONNECTION_TIMEOUT_UNIT);
+        } catch (RuntimeException | ExecutionException | TimeoutException expected) {
+          LOG.trace("Failed accessing one node through JMX", expected);
+        }
+      }
+    } catch (InterruptedException e) {
+      LOG.debug("Interrupted when trying to compile the list of nodes accessible through JMX", e);
+    }
+  }
+
+  @Override
+  public void close() throws RuntimeException {
+    executor.shutdown();
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
@@ -346,13 +346,13 @@ public final class JmxProxy implements NotificationListener, AutoCloseable {
     for (Map.Entry<List<String>, List<String>> entry : entries) {
       BigInteger rangeStart = new BigInteger(entry.getKey().get(0));
       BigInteger rangeEnd = new BigInteger(entry.getKey().get(1));
-      LOG.debug("[tokenRangeToEndpoint] checking token range [{}, {}) against {}", rangeStart, rangeEnd, tokenRange);
       if (new RingRange(rangeStart, rangeEnd).encloses(tokenRange)) {
         LOG.debug("[tokenRangeToEndpoint] Found replicas for token range {} : {}", tokenRange, entry.getValue());
         return entry.getValue();
       }
     }
     LOG.error("[tokenRangeToEndpoint] no replicas found for token range {}", tokenRange);
+    LOG.debug("[tokenRangeToEndpoint] checked token ranges were {}", entries);
     return Lists.newArrayList();
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -20,7 +20,6 @@ import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.NodeMetrics;
 import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.core.RepairUnit;
-import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.jmx.RepairStatusHandler;
 import io.cassandrareaper.storage.IDistributedStorage;
@@ -834,7 +833,7 @@ public final class SegmentRunner implements RepairStatusHandler, Runnable {
     if (repairId != null) {
       for (String involvedNode : potentialCoordinators) {
         try (JmxProxy jmx
-            = new JmxConnectionFactory().connect(involvedNode, context.config.getJmxConnectionTimeoutInSeconds())) {
+            = context.jmxConnectionFactory.connect(involvedNode, context.config.getJmxConnectionTimeoutInSeconds())) {
           // there is no way of telling if the snapshot was cleared or not :(
           jmx.clearSnapshot(repairId, keyspace);
           jmx.close();

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -596,7 +596,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   @Override
   public Collection<RepairSegment> getRepairSegmentsForRunInLocalMode(UUID runId, List<RingRange> localRanges) {
-    LOG.debug("Getting ranges for local node {}", localRanges);
+    LOG.trace("Getting ranges for local node {}", localRanges);
     Collection<RepairSegment> segments = Lists.newArrayList();
 
     // First gather segments ids
@@ -685,7 +685,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
       }
     }
 
-    LOG.debug("found ongoing repairs {} {}", repairs.size(), repairs);
+    LOG.trace("found ongoing repairs {} {}", repairs.size(), repairs);
 
     return repairs;
   }
@@ -698,7 +698,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
       repairRunIds.add(result.getUUID("id"));
     }
 
-    LOG.debug("repairRunIds : {}", repairRunIds);
+    LOG.trace("repairRunIds : {}", repairRunIds);
     return repairRunIds;
   }
 
@@ -899,7 +899,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   }
 
   private RepairRun buildRepairRunFromRow(Row repairRunResult, UUID id) {
-    LOG.debug("buildRepairRunFromRow {} / {}", id, repairRunResult);
+    LOG.trace("buildRepairRunFromRow {} / {}", id, repairRunResult);
     return new RepairRun.Builder(
         repairRunResult.getString("cluster_name"),
         repairRunResult.getUUID("repair_unit_id"),


### PR DESCRIPTION
Currently, for some of the operations, Reaper will try to connect to any node in the cluster through JMX. 
When running on multi region clusters, this can lead to a lot of connection failures as JMX is not authorized on the cross region link.

With this PR, Reaper will build a map of accessible nodes during initialization so that subsequent calls are made on accessible nodes straight away.