### PR TITLE
In cassandra storage override pooling options to allow bigger queue and longer timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,10 @@ jobs:
               sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/circleci/.ccm/test/node2/conf/cassandra-env.sh
               sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/circleci/.ccm/test/node3/conf/cassandra-env.sh
               sed -i 's/jmxremote.authenticate=true/jmxremote.authenticate=false/' /home/circleci/.ccm/test/node4/conf/cassandra-env.sh
-              sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="256m"/' /home/circleci/.ccm/test/node1/conf/cassandra-env.sh
-              sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="256m"/' /home/circleci/.ccm/test/node2/conf/cassandra-env.sh
-              sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="256m"/' /home/circleci/.ccm/test/node3/conf/cassandra-env.sh
-              sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="256m"/' /home/circleci/.ccm/test/node4/conf/cassandra-env.sh
+              sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="192m"/' /home/circleci/.ccm/test/node1/conf/cassandra-env.sh
+              sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="192m"/' /home/circleci/.ccm/test/node2/conf/cassandra-env.sh
+              sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="192m"/' /home/circleci/.ccm/test/node3/conf/cassandra-env.sh
+              sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="192m"/' /home/circleci/.ccm/test/node4/conf/cassandra-env.sh
               sed -i 's/_timeout_in_ms:.*/_timeout_in_ms: 60000/' /home/circleci/.ccm/test/node1/conf/cassandra.yaml
               sed -i 's/_timeout_in_ms:.*/_timeout_in_ms: 60000/' /home/circleci/.ccm/test/node2/conf/cassandra.yaml
               sed -i 's/_timeout_in_ms:.*/_timeout_in_ms: 60000/' /home/circleci/.ccm/test/node3/conf/cassandra.yaml
@@ -88,9 +88,9 @@ jobs:
               mvn surefire:test -Dtest=ReaperIT
               mvn surefire:test -Dtest=ReaperH2IT
               #mvn surefire:test -Dtest=ReaperPostgresIT # TODO set up postgres
-              mvn surefire:test -Dtest=ReaperCassandraIT
-              mvn surefire:test -Dtest=ReaperCassandraIT -Dgrim.reaper.min=2 -Dgrim.reaper.max=2
-              mvn surefire:test -Dtest=ReaperCassandraIT -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
+              mvn surefire:test -DsurefireArgLine="-Xmx1g" -Dtest=ReaperCassandraIT
+              mvn surefire:test -DsurefireArgLine="-Xmx1g" -Dtest=ReaperCassandraIT -Dgrim.reaper.min=2 -Dgrim.reaper.max=2
+              mvn surefire:test -DsurefireArgLine="-Xmx1g" -Dtest=ReaperCassandraIT -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
 
       - store_test_results:
           path: target/surefire-reports

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -106,6 +106,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>3.1.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>9.3-1100-jdbc41</version>

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PoolingOptions;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.QueryLogger;
 import com.datastax.driver.core.QueryOptions;
@@ -66,6 +67,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.util.Duration;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.cognitor.cassandra.migration.Database;
 import org.cognitor.cassandra.migration.MigrationRepository;
@@ -74,6 +76,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import systems.composable.dropwizard.cassandra.CassandraFactory;
+import systems.composable.dropwizard.cassandra.pooling.PoolingOptionsFactory;
 import systems.composable.dropwizard.cassandra.retry.RetryPolicyFactory;
 
 public final class CassandraStorage implements IStorage, IDistributedStorage {
@@ -125,21 +128,13 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   public CassandraStorage(ReaperApplicationConfiguration config, Environment environment) {
     CassandraFactory cassandraFactory = config.getCassandraFactory();
-    // all INSERT and DELETE stmt prepared in this class are idempoten
-    if (cassandraFactory.getQueryOptions().isPresent()
-        && ConsistencyLevel.LOCAL_ONE != cassandraFactory.getQueryOptions().get().getConsistencyLevel()) {
-      LOG.warn("Customization of cassandra's queryOptions is not supported and will be overridden");
-    }
-    cassandraFactory.setQueryOptions(java.util.Optional.of(new QueryOptions().setDefaultIdempotence(true)));
-    if (cassandraFactory.getRetryPolicy().isPresent()) {
-      LOG.warn("Customization of cassandra's retry policy is not supported and will be overridden");
-    }
-    cassandraFactory.setRetryPolicy(java.util.Optional.of((RetryPolicyFactory) () -> new RetryPolicyImpl()));
+    overrideQueryOptions(cassandraFactory);
+    overrideRetryPolicy(cassandraFactory);
+    overridePoolingOptions(cassandraFactory);
     cassandra = cassandraFactory.build(environment);
     if (config.getActivateQueryLogger()) {
       cassandra.register(QueryLogger.builder().build());
     }
-
     CodecRegistry codecRegistry = cassandra.getConfiguration().getCodecRegistry();
     codecRegistry.register(new DateTimeCodec());
     session = cassandra.connect(config.getCassandraFactory().getKeyspace());
@@ -1020,6 +1015,43 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
       lastHeartBeat = now;
     }
+  }
+
+
+  private static void overrideQueryOptions(CassandraFactory cassandraFactory) {
+    // all INSERT and DELETE stmt prepared in this class are idempoten
+    if (cassandraFactory.getQueryOptions().isPresent()
+        && ConsistencyLevel.LOCAL_ONE != cassandraFactory.getQueryOptions().get().getConsistencyLevel()) {
+      LOG.warn("Customization of cassandra's queryOptions is not supported and will be overridden");
+    }
+    cassandraFactory.setQueryOptions(java.util.Optional.of(new QueryOptions().setDefaultIdempotence(true)));
+  }
+
+  private static void overrideRetryPolicy(CassandraFactory cassandraFactory) {
+    if (cassandraFactory.getRetryPolicy().isPresent()) {
+      LOG.warn("Customization of cassandra's retry policy is not supported and will be overridden");
+    }
+    cassandraFactory.setRetryPolicy(java.util.Optional.of((RetryPolicyFactory) () -> new RetryPolicyImpl()));
+  }
+
+  private static void overridePoolingOptions(CassandraFactory cassandraFactory) {
+    PoolingOptionsFactory newPoolingOptionsFactory = new PoolingOptionsFactory() {
+      @Override
+      public PoolingOptions build() {
+        if (null == getPoolTimeout()) {
+          setPoolTimeout(Duration.minutes(2));
+        }
+        return super.build().setMaxQueueSize(40960);
+      }
+    };
+    cassandraFactory.getPoolingOptions().ifPresent((originalPoolingOptions) -> {
+      newPoolingOptionsFactory.setHeartbeatInterval(originalPoolingOptions.getHeartbeatInterval());
+      newPoolingOptionsFactory.setIdleTimeout(originalPoolingOptions.getIdleTimeout());
+      newPoolingOptionsFactory.setLocal(originalPoolingOptions.getLocal());
+      newPoolingOptionsFactory.setRemote(originalPoolingOptions.getRemote());
+      newPoolingOptionsFactory.setPoolTimeout(originalPoolingOptions.getPoolTimeout());
+    });
+    cassandraFactory.setPoolingOptions(java.util.Optional.of(newPoolingOptionsFactory));
   }
 
   private static boolean withinRange(RepairSegment segment, Optional<RingRange> range) {

--- a/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
@@ -52,6 +52,16 @@ cassandra:
   socketOptions:
       connectTimeoutMillis: 20000
       readTimeoutMillis: 40000
+  poolingOptions:
+      idleTimeout: 5s
+      local:
+        coreConnections: 1
+        maxConnections: 4
+        maxRequestsPerConnection: 16
+      remote:
+        coreConnections: 1
+        maxConnections: 1
+        maxRequestsPerConnection: 4
 
 metrics:
   frequency: 1 second


### PR DESCRIPTION

We fetch every repair run in a separate async execute, so the default queue length of 256 will be quickly hit.

ref: https://gitter.im/thelastpickle/cassandra-reaper?at=59d66c7be44c43700afa2fce