### PR TITLE
For Cassandra storage minimise the number of tombstones (NULL entries) in the repair_run table

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/CommonTools.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/CommonTools.java
@@ -241,7 +241,7 @@ public final class CommonTools {
       RepairUnit repairUnit) {
 
     List<RepairSegment.Builder> repairSegmentBuilders = Lists.newArrayList();
-    tokenSegments.forEach(range -> repairSegmentBuilders.add(new RepairSegment.Builder(range, repairUnit.getId())));
+    tokenSegments.forEach(range -> repairSegmentBuilders.add(RepairSegment.builder(range, repairUnit.getId())));
     return repairSegmentBuilders;
   }
 
@@ -260,7 +260,7 @@ public final class CommonTools {
         .forEach(
             range
               -> repairSegmentBuilders.add(
-                  new RepairSegment.Builder(range.getValue(), repairUnit.getId()).coordinatorHost(range.getKey())));
+                  RepairSegment.builder(range.getValue(), repairUnit.getId()).coordinatorHost(range.getKey())));
 
     return repairSegmentBuilders;
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairSegmentMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairSegmentMapper.java
@@ -30,13 +30,21 @@ public final class RepairSegmentMapper implements ResultSetMapper<RepairSegment>
     RingRange range
         = new RingRange(rs.getBigDecimal("start_token").toBigInteger(), rs.getBigDecimal("end_token").toBigInteger());
 
-    return new RepairSegment.Builder(range, UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")))
+    RepairSegment.Builder builder = RepairSegment
+        .builder(range, UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")))
         .withRunId(UuidUtil.fromSequenceId(rs.getLong("run_id")))
         .state(RepairSegment.State.values()[rs.getInt("state")])
-        .coordinatorHost(rs.getString("coordinator_host"))
-        .startTime(RepairRunMapper.getDateTimeOrNull(rs, "start_time"))
-        .endTime(RepairRunMapper.getDateTimeOrNull(rs, "end_time"))
-        .failCount(rs.getInt("fail_count"))
-        .build(UuidUtil.fromSequenceId(rs.getLong("id")));
+        .failCount(rs.getInt("fail_count"));
+
+    if (null != rs.getString("coordinator_host")) {
+      builder = builder.coordinatorHost(rs.getString("coordinator_host"));
+    }
+    if (null != RepairRunMapper.getDateTimeOrNull(rs, "start_time")) {
+      builder = builder.startTime(RepairRunMapper.getDateTimeOrNull(rs, "start_time"));
+    }
+    if (null != RepairRunMapper.getDateTimeOrNull(rs, "end_time")) {
+      builder = builder.endTime(RepairRunMapper.getDateTimeOrNull(rs, "end_time"));
+    }
+    return builder.build(UuidUtil.fromSequenceId(rs.getLong("id")));
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/unit/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/unit/service/RepairManagerTest.java
@@ -94,7 +94,7 @@ public class RepairManagerTest {
             .build(UUIDs.timeBased());
 
     final RepairSegment segment =
-        new RepairSegment.Builder(new RingRange("-1", "1"), cf.getId())
+        RepairSegment.builder(new RingRange("-1", "1"), cf.getId())
             .withRunId(run.getId())
             .build(UUIDs.timeBased());
 
@@ -164,7 +164,7 @@ public class RepairManagerTest {
             .build(UUIDs.timeBased());
 
     final RepairSegment segment =
-        new RepairSegment.Builder(new RingRange("-1", "1"), cf.getId())
+        RepairSegment.builder(new RingRange("-1", "1"), cf.getId())
             .withRunId(run.getId())
             .build(UUIDs.timeBased());
 
@@ -236,7 +236,7 @@ public class RepairManagerTest {
             .build(UUIDs.timeBased());
 
     final RepairSegment segment =
-        new RepairSegment.Builder(new RingRange("-1", "1"), cf.getId())
+        RepairSegment.builder(new RingRange("-1", "1"), cf.getId())
             .withRunId(run.getId())
             .build(UUIDs.timeBased());
 
@@ -305,7 +305,7 @@ public class RepairManagerTest {
             .build(UUIDs.timeBased());
 
     final RepairSegment segment =
-        new RepairSegment.Builder(new RingRange("-1", "1"), cf.getId())
+        RepairSegment.builder(new RingRange("-1", "1"), cf.getId())
             .withRunId(run.getId())
             .build(UUIDs.timeBased());
 

--- a/src/server/src/test/java/io/cassandrareaper/unit/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/unit/service/RepairRunnerTest.java
@@ -102,7 +102,7 @@ public final class RepairRunnerTest {
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
     RepairRun run = storage.addRepairRun(
         new RepairRun.Builder(CLUSTER_NAME, cf.getId(), DateTime.now(), INTENSITY, 1, RepairParallelism.PARALLEL),
-        Collections.singleton(new RepairSegment.Builder(new RingRange(BigInteger.ZERO, BigInteger.ONE), cf.getId())));
+        Collections.singleton(RepairSegment.builder(new RingRange(BigInteger.ZERO, BigInteger.ONE), cf.getId())));
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
@@ -254,7 +254,7 @@ public final class RepairRunnerTest {
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
     RepairRun run = storage.addRepairRun(
         new RepairRun.Builder(CLUSTER_NAME, cf.getId(), DateTime.now(), INTENSITY, 1, RepairParallelism.PARALLEL),
-        Collections.singleton(new RepairSegment.Builder(new RingRange(BigInteger.ZERO, BigInteger.ONE), cf.getId())));
+        Collections.singleton(RepairSegment.builder(new RingRange(BigInteger.ZERO, BigInteger.ONE), cf.getId())));
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
@@ -388,13 +388,16 @@ public final class RepairRunnerTest {
                     BLACKLISTED_TABLES))
             .getId();
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
+
     RepairRun run = storage.addRepairRun(
         new RepairRun.Builder(CLUSTER_NAME, cf, DateTime.now(), INTENSITY, 1, RepairParallelism.PARALLEL),
         Lists.newArrayList(
-            new RepairSegment.Builder(new RingRange(BigInteger.ZERO, BigInteger.ONE), cf)
-                .state(RepairSegment.State.RUNNING).startTime(DateTime.now()).coordinatorHost("reaper")
-                .repairCommandId(1337),
-            new RepairSegment.Builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf)));
+            RepairSegment.builder(new RingRange(BigInteger.ZERO, BigInteger.ONE), cf)
+                .state(RepairSegment.State.RUNNING)
+                .startTime(DateTime.now())
+                .coordinatorHost("reaper"),
+            RepairSegment.builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf)));
+
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 

--- a/src/server/src/test/java/io/cassandrareaper/unit/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/unit/service/SegmentRunnerTest.java
@@ -85,7 +85,7 @@ public final class SegmentRunnerTest {
                 Collections.emptySet()));
     RepairRun run = context.storage.addRepairRun(
         new RepairRun.Builder("reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
-        Collections.singleton(new RepairSegment.Builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf.getId())));
+        Collections.singleton(RepairSegment.builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf.getId())));
 
     final UUID runId = run.getId();
     final UUID segmentId = context.storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
@@ -177,7 +177,7 @@ public final class SegmentRunnerTest {
                 Collections.emptySet()));
     RepairRun run = storage.addRepairRun(
         new RepairRun.Builder("reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
-        Collections.singleton(new RepairSegment.Builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf.getId())));
+        Collections.singleton(RepairSegment.builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf.getId())));
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
@@ -292,7 +292,7 @@ public final class SegmentRunnerTest {
                 Collections.emptySet()));
     RepairRun run = storage.addRepairRun(
         new RepairRun.Builder("reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
-        Collections.singleton(new RepairSegment.Builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf.getId())));
+        Collections.singleton(RepairSegment.builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf.getId())));
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 


### PR DESCRIPTION
Remove RepairSegment.repairCommandId as no one was using/storing it.

Make explicit which fields in RepairSegment can be null and be nulled.
Hide the RepairSegment.Builder constructor.

Add Preconditions and asserts in ensuring lifecycle state is correct and null fields only exist as/when appropriate.
Preconditions are used when checks are fast and for providing fail-fast design. Asserts are used where checks are expensive and/or are secondary checks.

ref: https://github.com/thelastpickle/cassandra-reaper/issues/240