### PR TITLE
remove local mode

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -145,7 +145,6 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     if (context.jmxConnectionFactory == null) {
       LOG.info("no JMX connection factory given in context, creating default");
       context.jmxConnectionFactory = new JmxConnectionFactory(context.metricRegistry);
-      context.jmxConnectionFactory.setLocalMode(context.config.getLocalJmxMode());
 
       // read jmx host/port mapping from config and provide to jmx con.factory
       Map<String, Integer> jmxPorts = config.getJmxPorts();

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -86,19 +86,11 @@ public final class ReaperApplicationConfiguration extends Configuration {
   private JmxCredentials jmxAuth;
 
   @JsonProperty
-  @DefaultValue("false")
-  private Boolean allowUnreachableNodes;
-
-  @JsonProperty
   private AutoSchedulingConfiguration autoScheduling;
 
   @JsonProperty
   @DefaultValue("true")
   private Boolean enableDynamicSeedList;
-
-  @JsonProperty
-  @DefaultValue("false")
-  private Boolean localJmxMode;
 
   @JsonProperty
   private Integer repairManagerSchedulingIntervalSeconds;
@@ -243,14 +235,6 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   public boolean getEnableDynamicSeedList() {
     return this.enableDynamicSeedList == null ? true : this.enableDynamicSeedList;
-  }
-
-  public void setLocalJmxMode(boolean localJmxMode) {
-    this.localJmxMode = localJmxMode;
-  }
-
-  public boolean getLocalJmxMode() {
-    return this.localJmxMode == null ? false : this.localJmxMode;
   }
 
   public void setActivateQueryLogger(boolean activateQueryLogger) {

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
@@ -42,7 +42,6 @@ public class JmxConnectionFactory {
   private Map<String, Integer> jmxPorts;
   private JmxCredentials jmxAuth;
   private EC2MultiRegionAddressTranslator addressTranslator;
-  private boolean localMode = false;
 
   @VisibleForTesting
   public JmxConnectionFactory() {
@@ -58,9 +57,6 @@ public class JmxConnectionFactory {
   public JmxProxy connect(Optional<RepairStatusHandler> handler, String host, int connectionTimeout)
       throws ReaperException, NumberFormatException, InterruptedException {
     // use configured jmx port for host if provided
-    if (localMode) {
-      host = "127.0.0.1";
-    }
     if (jmxPorts != null && jmxPorts.containsKey(host) && !host.contains(":")) {
       host = host + ":" + jmxPorts.get(host);
     }
@@ -132,10 +128,6 @@ public class JmxConnectionFactory {
 
   public final void setAddressTranslator(EC2MultiRegionAddressTranslator addressTranslator) {
     this.addressTranslator = addressTranslator;
-  }
-
-  public final void setLocalMode(boolean localMode) {
-    this.localMode = localMode;
   }
 
   public final HostConnectionCounters getHostConnectionCounters() {

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -21,7 +21,6 @@ import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.jmx.JmxProxy;
-import io.cassandrareaper.storage.IDistributedStorage;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -76,7 +75,7 @@ final class RepairRunner implements Runnable {
     int parallelRepairs
         = getPossibleParallelRepairsCount(jmx.getRangeToEndpointMap(keyspace), jmx.getEndpointToHostId());
 
-    if ((repairUnitOpt.isPresent() && repairUnitOpt.get().getIncrementalRepair()) || context.config.getLocalJmxMode()) {
+    if ((repairUnitOpt.isPresent() && repairUnitOpt.get().getIncrementalRepair())) {
       // with incremental repair, can't have more parallel repairs than nodes
       // Same goes for local mode
       parallelRepairs = 1;
@@ -85,12 +84,8 @@ final class RepairRunner implements Runnable {
     for (int i = 0; i < parallelRepairs; i++) {
       currentlyRunningSegments.set(i, null);
     }
-    List<RingRange> ranges = jmx.getRangesForLocalEndpoint(keyspace);
 
-    Collection<RepairSegment> repairSegments = context.config.getLocalJmxMode()
-        && context.storage instanceof IDistributedStorage
-            ? ((IDistributedStorage) context.storage).getRepairSegmentsForRunInLocalMode(repairRunId, ranges)
-            : context.storage.getRepairSegmentsForRun(repairRunId);
+    Collection<RepairSegment> repairSegments = context.storage.getRepairSegmentsForRun(repairRunId);
 
     parallelRanges = getParallelRanges(
         parallelRepairs,

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -652,30 +652,6 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     return segments;
   }
 
-  @Override
-  public Collection<RepairSegment> getRepairSegmentsForRunInLocalMode(UUID runId, List<RingRange> localRanges) {
-    LOG.trace("Getting ranges for local node {}", localRanges);
-    Collection<RepairSegment> segments = Lists.newArrayList();
-
-    // First gather segments ids
-    ResultSet segmentsResultSet = session.execute(getRepairSegmentsByRunIdPrepStmt.bind(runId));
-    segmentsResultSet.forEach(
-        segmentRow -> {
-          RepairSegment seg = createRepairSegmentFromRow(segmentRow);
-          RingRange range = new RingRange(seg.getStartToken(), seg.getEndToken());
-          localRanges
-              .stream()
-              .forEach(
-                  localRange -> {
-                    if (localRange.encloses(range)) {
-                      segments.add(seg);
-                    }
-                  });
-        });
-
-    return segments;
-  }
-
   private static boolean segmentIsWithinRange(RepairSegment segment, RingRange range) {
     return range.encloses(new RingRange(segment.getStartToken(), segment.getEndToken()));
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -15,8 +15,6 @@
 package io.cassandrareaper.storage;
 
 import io.cassandrareaper.core.NodeMetrics;
-import io.cassandrareaper.core.RepairSegment;
-import io.cassandrareaper.service.RingRange;
 
 import java.util.Collection;
 import java.util.List;
@@ -36,8 +34,6 @@ public interface IDistributedStorage {
   List<UUID> getLeaders();
 
   void releaseLead(UUID leaderId);
-
-  Collection<RepairSegment> getRepairSegmentsForRunInLocalMode(UUID runId, List<RingRange> localRanges);
 
   int countRunningReapers();
 

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -70,7 +70,6 @@ public final class RepairManagerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    context.config.setLocalJmxMode(false);
     RepairManager repairManager = RepairManager.create(context);
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
@@ -138,7 +137,6 @@ public final class RepairManagerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    context.config.setLocalJmxMode(false);
     RepairManager repairManager = RepairManager.create(context);
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
@@ -207,7 +205,6 @@ public final class RepairManagerTest {
 
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
-    context.config.setLocalJmxMode(false);
     context.storage = storage;
     RepairManager repairManager = RepairManager.create(context);
     repairManager = Mockito.spy(repairManager);
@@ -275,7 +272,6 @@ public final class RepairManagerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    context.config.setLocalJmxMode(false);
     RepairManager repairManager = RepairManager.create(context);
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -110,7 +110,6 @@ public final class RepairRunnerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    context.config.setLocalJmxMode(false);
     context.repairManager = RepairManager.create(context);
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
@@ -262,7 +261,6 @@ public final class RepairRunnerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    context.config.setLocalJmxMode(false);
     context.repairManager = RepairManager.create(context);
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
@@ -371,7 +369,6 @@ public final class RepairRunnerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    context.config.setLocalJmxMode(false);
     context.repairManager = RepairManager.create(context);
 
     storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton("127.0.0.1")));

--- a/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
@@ -9,6 +9,7 @@ hangingRepairTimeoutMins: 1
 storageType: cassandra
 incrementalRepair: false
 jmxConnectionTimeoutInSeconds: 300
+activateQueryLogger: true
 datacenterAvailability: EACH
 
 logging:


### PR DESCRIPTION
Remove localMode configuration and logic, as it's not actually implemented yet.

It will be easy enough to bring these changes back when a full implementation comes back into play.

this is waiting on https://github.com/thelastpickle/cassandra-reaper/pull/249 to land in master, before being merged.