### PR TITLE
Split 'database' configuration setting

### DIFF
--- a/src/docs/content/docs/backends/_index.md
+++ b/src/docs/content/docs/backends/_index.md
@@ -7,24 +7,20 @@ weight = 10
 
 # Backends
 
-Cassandra Reaper can be used with either an ephemeral memory storage or persistent database.
+Cassandra Reaper can be used with either an ephemeral memory storage or persistent database. For persistent scalable database storage, a Cassandra cluster can be set up to back Reaper. To use a Cassandra cluster as the backed storage for Reaper set `storageType` to a value of **cassandra** in the Reaper configuration file. Alternatively, a relational database storage; either H2 or Postgres can be set up to back Reaper. To use one of the relational database options as the backed storage for Reaper set `storageType` to a value of either **h2** or **postrges** in the Reaper configuration file.
 
-For persistent relational database storage, you must either setup PostgreSQL or H2. You also need to set `storageType: database` in the config file.
-
-Reaper provides a number of backend storage options:
+Further information on the available storage options is provided in the following section.
 
 * [In-Memory]({{<ref "memory.md" >}})
 * [Cassanda]({{<ref "cassandra.md">}})
 * [PostgresQL]({{<ref "postgres.md">}})
 * [H2]({{<ref "h2.md">}})
 
-Sample yaml files are available in the `src/packaging/resource` directory for each of the above storage backends:
-
-
+Sample YAML files are available in the *[src/packaging/resource](https://github.com/thelastpickle/cassandra-reaper/tree/master/src/packaging/resource)* directory for each of the above storage options:
 
 * cassandra-reaper-memory.yaml
 * cassandra-reaper-cassandra.yaml
 * cassandra-reaper-postgres.yaml
 * cassandra-reaper-h2.yaml
 
-For configuring other aspects of the service, see the available configuration options in the [Configuration Reference](../configuration)
+For configuring other aspects of the service, see the available configuration options in the [Configuration Reference](../configuration).

--- a/src/docs/content/docs/backends/cassandra.md
+++ b/src/docs/content/docs/backends/cassandra.md
@@ -7,9 +7,7 @@ weight = 4
 
 # Cassandra Backend
 
-To use Apache Cassandra as the persistent storage for Reaper, the storageType setting must be set to cassandra in the Reaper configuration YAML file. In addition, the connection details for the Apache Cassandra cluster being used to store Reaper data must be specified in the configuration YAML file.
-
-For example:
+To use Apache Cassandra as the persistent storage for Reaper, the `storageType` setting must be set to **cassandra** in the Reaper configuration YAML file. In addition, the connection details for the Apache Cassandra cluster being used to store Reaper data must be specified in the configuration YAML file. An example of how to configure H2 as persistent storage for Reaper can be found in the *[cassandra-reaper-cassandra.yaml](https://github.com/thelastpickle/cassandra-reaper/blob/master/src/packaging/resource/cassandra-reaper-cassandra.yaml)*.
 
 ```yaml
 storageType: cassandra
@@ -40,9 +38,7 @@ cassandra:
 
 The Apache Cassandra backend is the only one that allows running several Reaper instances at once. This provides high availability and allows to repair multi DC clusters.
 
-
 To run Reaper using the Cassandra backend, create a reaper_db keyspace with an appropriate placement strategy. This is installation specific, and names of the data centers in the cluster that will host the Reaper data must be specified. For example:
-
 
 ```none
 CREATE KEYSPACE reaper_db WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 3};

--- a/src/docs/content/docs/backends/h2.md
+++ b/src/docs/content/docs/backends/h2.md
@@ -1,6 +1,6 @@
 +++
 [menu.docs]
-name = "H2 (Local Storage)"
+name = "H2"
 parent = "backends"
 weight = 2
 +++
@@ -8,14 +8,13 @@ weight = 2
 
 # H2 Backend
 
-To use H2 as the persistent storage for Reaper, the storageType setting must be set to database in the Reaper configuration YAML file. When using H2 storage, the database will be automatically created under the path configured in the configuration YAML file. An example of how to configure H2 as persistent storage for Reaper can be found in the cassandra-reaper-h2.yaml.
+To use H2 as the persistent storage for Reaper, the `storageType` setting must be set to **h2** in the Reaper configuration YAML file. When using H2 storage, the database will be automatically created under the path configured in the configuration YAML file. An example of how to configure H2 as persistent storage for Reaper can be found in the *[cassandra-reaper-h2.yaml](https://github.com/thelastpickle/cassandra-reaper/blob/master/src/packaging/resource/cassandra-reaper-h2.yaml)*.
 
 
 ```yaml
-storageType: database
-database:
+storageType: h2
+h2:
   # H2 JDBC settings
-  driverClass: org.h2.Driver
   url: jdbc:h2:~/reaper-db/db;MODE=PostgreSQL
   user:
   password:

--- a/src/docs/content/docs/backends/memory.md
+++ b/src/docs/content/docs/backends/memory.md
@@ -7,10 +7,10 @@ weight = 1
 
 # Memory Backend
 
-To use in memory storage as the storage type for Reaper, the `storageType` setting must be set to **memory** in the Reaper configuration YAML file. Note that the in memory storage is enabled by default.
-
-In memory storage is volatile and as such all registered cluster, column families and repair un information will be lost upon service restart. This storage setting is intended for testing purposes only.
+To use in memory storage as the storage type for Reaper, the `storageType` setting must be set to **memory** in the Reaper configuration YAML file. Note that the in memory storage is enabled by default. An example of how to configure H2 as persistent storage for Reaper can be found in the *[cassandra-reaper-memory.yaml](https://github.com/thelastpickle/cassandra-reaper/blob/master/src/packaging/resource/cassandra-reaper-memory.yaml)*.
 
 ```yaml
 storageType: memory
 ```
+
+In memory storage is volatile and as such all registered cluster, column families and repair un information will be lost upon service restart. This storage setting is intended for testing purposes only.

--- a/src/docs/content/docs/backends/postgres.md
+++ b/src/docs/content/docs/backends/postgres.md
@@ -7,14 +7,13 @@ weight = 3
 
 # Postgres Backend
 
-To use PostgreSQL as the persistent storage for Reaper, the `storageType` setting must be set to **database** in the Reaper configuration YAML file. The schema will be initialized/upgraded automatically upon startup in the configured database. Ensure that the correct JDBC credentials are specified in the `cassandra-reaper.yaml` to allow object creation.
+To use PostgreSQL as the persistent storage for Reaper, the `storageType` setting must be set to **postgres** in the Reaper configuration YAML file. The schema will be initialized/upgraded automatically upon startup in the configured database. Ensure that the correct JDBC credentials are specified in the *cassandra-reaper.yaml* to allow object creation. An example of how to configure Postgres as persistent storage for Reaper can be found in the *[cassandra-reaper-postgres.yaml](https://github.com/thelastpickle/cassandra-reaper/blob/master/src/packaging/resource/cassandra-reaper-postgres.yaml)*.
 
 
 ```yaml
-storageType: database
-database:
+storageType: postgres
+postgres:
   # PostgreSQL JDBC settings
-  driverClass: org.postgresql.Driver
   user: postgres
   password: 
   url: jdbc:postgresql://127.0.0.1/reaper

--- a/src/docs/content/docs/configuration/backend_specific.md
+++ b/src/docs/content/docs/configuration/backend_specific.md
@@ -116,8 +116,7 @@ Cassandra native protocol password.
 The following settings are specific to a Reaper deployment that is backed by either a H2 or Postgres database. An example of the configuration settings for a Postgres database are as follows.
 
 ```yaml
-database:
-  driverClass: org.postgresql.Driver
+postgres:
   url: jdbc:postgresql://127.0.0.1/reaper
   user: postgres
   password:
@@ -127,13 +126,19 @@ Definitions for the above sub-settings are as follows.
 
 </br>
 
-### `database`
+### `h2`
 
-Settings to configure Reaper to use Cassandra for storage of its control data.
+Settings to configure Reaper to use H2 for storage of its control data.
+
+### `postgres`
+
+Settings to configure Reaper to use Postgres for storage of its control data.
 
 #### `driverClass`
 
 Type: *String*
+
+**WARNING** this setting is **DEPRECATED** and its usage should be avoided.
 
 Specifies the driver to use to connect to the database.
 
@@ -141,7 +146,7 @@ Specifies the driver to use to connect to the database.
 
 Type: *String*
 
-Specifies the URL to connect to the database on.
+Specifies the URL to connect to the database (either H2 or Postgres) on.
 
 #### `user`
 

--- a/src/docs/content/docs/configuration/docker_vars.md
+++ b/src/docs/content/docs/configuration/docker_vars.md
@@ -52,7 +52,7 @@ Environment Variable | Configuration Setting | Default Value
 
 **Note:**
 
-Some variable names have changed between the release of Docker-support and Reaper for Apache Cassandra 1.0. The following Reaper specific variable name changes have occurred in an effort to match closely with our YAML parameter names:
+Some variable names have changed between the release of Docker-support and Reaper for Apache Cassandra 1.0. The following Reaper specific variable name changes have occurred in an effort to match closely with the YAML parameter names:
 
 Pre Reaper 1.0 | Post Reaper 1.0
 ---|---
@@ -151,11 +151,20 @@ Allows Reaper to establish an encrypted connection when establishing a connectio
 
 The Docker environment variables listed in this section map directly to H2/Postgres backend specific settings in the *cassandra-reaper.yaml* configuration file. The following table below lists the Docker environment variables, their associated H2/Postgres backend specific setting in the *cassandra-reaper.yaml* configuration file, and the default value assigned by the Docker container (if any). Definitions for each Docker environment variable can be found via the link to the associated setting.
 
-In order to use the following settings, `REAPER_STORAGE_TYPE` must be set to `database`.
+In order to use the following settings, `REAPER_STORAGE_TYPE` must be set to `h2` or `postgres`.
 
 Environment Variable | Configuration Setting | Default Value
 ---|---|---
-<code class="codeLarge">REAPER_DB_DRIVER_CLASS</code> | <a href="../backend_specific#driverclass">driverClass</a> | org.h2.Driver
 <code class="codeLarge">REAPER_DB_URL</code> | <a href="../backend_specific#url">url</a> | jdbc:h2:/var/lib/cassandra-reaper/db;MODE=PostgreSQL
 <code class="codeLarge">REAPER_DB_USERNAME</code> | <a href="../backend_specific#user">user</a> |
 <code class="codeLarge">REAPER_DB_PASSWORD</code> | <a href="../backend_specific#password-1">password</a> |
+
+<br/>
+
+**Note:**
+
+Some variable names have changed between the release of Docker-support and Reaper for Apache Cassandra 1.0. The following Reaper specific variable name changes have occurred in an effort to match closely with the YAML parameter names:
+
+Pre Reaper 1.0 | Post Reaper 1.0
+---|---
+`REAPER_DB_DRIVER_CLASS` | N/A - The associated parameter has been deprecated

--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -332,7 +332,7 @@ Note that to bind the service to all interfaces use value **0.0.0.0** or leave t
 
 Type: *String*
 
-Whether to use database or memory based storage for storing the system state. The value must be either **cassandra**, **database** or **memory**. If the recommended (persistent) storage type **database** or **cassandra** is being used, the database client parameters must be specified in the respective `database` or `cassandra` section in the configuration file. See the example settings in provided the *[src/packaging/resources](https://github.com/thelastpickle/cassandra-reaper/tree/master/src/packaging/resource)* directory of the repository.
+The storage type to use in which Reaper will store its control data. The value must be either **cassandra**, **h2**, **memory**, or **postgres**. If the recommended (persistent) storage type **cassandra**, **h2**, or **postgres** is being used, the database client parameters must be specified in the respective `cassandra`, `h2`, or `postgres` section in the configuration file. See the example settings in provided the *[src/packaging/resources](https://github.com/thelastpickle/cassandra-reaper/tree/master/src/packaging/resource)* directory of the repository.
 
 </br>
 

--- a/src/packaging/resource/cassandra-reaper-h2.yaml
+++ b/src/packaging/resource/cassandra-reaper-h2.yaml
@@ -7,7 +7,7 @@ repairIntensity: 0.9
 scheduleDaysBetween: 7
 repairRunThreadCount: 15
 hangingRepairTimeoutMins: 30
-storageType: database
+storageType: h2
 enableCrossOrigin: true
 incrementalRepair: false
 enableDynamicSeedList: true
@@ -62,9 +62,7 @@ server:
   requestLog:
     appenders: []
 
-database:
-  # H2 JDBC settings
-  driverClass: org.h2.Driver
+h2:
   url: jdbc:h2:~/reaper-db/db;MODE=PostgreSQL
   user:
   password:

--- a/src/packaging/resource/cassandra-reaper-postgres.yaml
+++ b/src/packaging/resource/cassandra-reaper-postgres.yaml
@@ -7,7 +7,7 @@ repairIntensity: 0.9
 scheduleDaysBetween: 7
 repairRunThreadCount: 15
 hangingRepairTimeoutMins: 30
-storageType: database
+storageType: postgres
 enableCrossOrigin: true
 incrementalRepair: false
 enableDynamicSeedList: true
@@ -62,9 +62,7 @@ server:
   requestLog:
     appenders: []
 
-database:
-  # PostgreSQL JDBC settings
-  driverClass: org.postgresql.Driver
+postgres:
   user: postgres
   password: 
   url: jdbc:postgresql://127.0.0.1/reaper

--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -41,7 +41,6 @@ ENV REAPER_SEGMENT_COUNT=200 \
     REAPER_CASS_AUTH_USERNAME="cassandra" \
     REAPER_CASS_AUTH_PASSWORD="cassandra" \
     REAPER_CASS_NATIVE_PROTOCOL_SSL_ENCRYPTION_ENABLED="false" \
-    REAPER_DB_DRIVER_CLASS="org.h2.Driver" \
     REAPER_DB_URL="jdbc:h2:/var/lib/cassandra-reaper/db;MODE=PostgreSQL" \
     REAPER_DB_USERNAME="" \
     REAPER_DB_PASSWORD="" \

--- a/src/server/src/main/docker/configure-persistence.sh
+++ b/src/server/src/main/docker/configure-persistence.sh
@@ -39,16 +39,27 @@ fi
 # END cassandra persistence options
 
     ;;
-    "database")
+    "postgres")
 
-# BEGIN database persistence options
+# BEGIN postgres persistence options
 cat <<EOT >> /etc/cassandra-reaper.yml
-database:
-  driverClass: ${REAPER_DB_DRIVER_CLASS}
+postgres:
   url: ${REAPER_DB_URL}
   user: ${REAPER_DB_USERNAME}
   password: ${REAPER_DB_PASSWORD}
 EOT
-# END database persistence options
+# END postgres persistence options
+
+    ;;
+    "h2")
+
+# BEGIN h2 persistence options
+cat <<EOT >> /etc/cassandra-reaper.yml
+h2:
+  url: ${REAPER_DB_URL}
+  user: ${REAPER_DB_USERNAME}
+  password: ${REAPER_DB_PASSWORD}
+EOT
+# END h2 persistence options
 
 esac

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -50,6 +50,7 @@ import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
+import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -59,7 +60,6 @@ import io.prometheus.client.exporter.MetricsServlet;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.flywaydb.core.Flyway;
 import org.joda.time.DateTimeZone;
-import org.skife.jdbi.v2.DBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sun.misc.Signal;
@@ -229,18 +229,17 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
   private IStorage initializeStorage(ReaperApplicationConfiguration config, Environment environment)
       throws ReaperException {
     IStorage storage;
+
     if ("memory".equalsIgnoreCase(config.getStorageType())) {
       storage = new MemoryStorage();
     } else if ("cassandra".equalsIgnoreCase(config.getStorageType())) {
       storage = new CassandraStorage(config, environment);
-    } else if ("database".equalsIgnoreCase(config.getStorageType())) {
+    } else if ("postgres".equalsIgnoreCase(config.getStorageType()) || "h2".equalsIgnoreCase(config.getStorageType())) {
       // create DBI instance
-      DBI jdbi;
       final DBIFactory factory = new DBIFactory();
-      jdbi = factory.build(environment, config.getDataSourceFactory(), "postgresql");
 
       // instanciate store
-      storage = new PostgresStorage(jdbi);
+      storage = new PostgresStorage(factory.build(environment, config.getDataSourceFactory(), "postgresql"));
       initDatabase(config);
 
     } else {
@@ -278,15 +277,13 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
 
   private void initDatabase(ReaperApplicationConfiguration config) throws ReaperException {
     Flyway flyway = new Flyway();
+    DataSourceFactory dsfactory = config.getDataSourceFactory();
     flyway.setDataSource(
-        config.getDataSourceFactory().getUrl(),
-        config.getDataSourceFactory().getUser(),
-        config.getDataSourceFactory().getPassword());
-    if ("org.h2.Driver".equals(config.getDataSourceFactory().getDriverClass())) {
-      flyway.setLocations("/db/h2");
-    } else {
-      flyway.setLocations("/db/postgres");
-    }
+        dsfactory.getUrl(),
+        dsfactory.getUser(),
+        dsfactory.getPassword());
+
+    flyway.setLocations("/db/".concat(config.getStorageType().toLowerCase()));
     flyway.setBaselineOnMigrate(true);
     flyway.repair();
     flyway.migrate();

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -77,9 +77,6 @@ public final class ReaperApplicationConfiguration extends Configuration {
   private String enableCrossOrigin;
 
   @JsonProperty
-  private DataSourceFactory database = new DataSourceFactory();
-
-  @JsonProperty
   private Map<String, Integer> jmxPorts;
 
   @JsonProperty
@@ -115,6 +112,8 @@ public final class ReaperApplicationConfiguration extends Configuration {
   private DatacenterAvailability datacenterAvailability;
 
   private CassandraFactory cassandra = new CassandraFactory();
+
+  private DataSourceFactory relationalDb = new DataSourceFactory();
 
   public int getSegmentCount() {
     return segmentCount;
@@ -193,11 +192,27 @@ public final class ReaperApplicationConfiguration extends Configuration {
   }
 
   public DataSourceFactory getDataSourceFactory() {
-    return database;
+    return relationalDb;
   }
 
-  public void setDataSourceFactory(DataSourceFactory database) {
-    this.database = database;
+  @JsonProperty("h2")
+  public DataSourceFactory getH2DataSourceFactory() {
+    return relationalDb;
+  }
+
+  @JsonProperty("h2")
+  public void setH2DataSourceFactory(DataSourceFactory h2) {
+    this.relationalDb = h2;
+  }
+
+  @JsonProperty("postgres")
+  public DataSourceFactory getPostgresDataSourceFactory() {
+    return relationalDb;
+  }
+
+  @JsonProperty("postgres")
+  public void setPostgresDataSourceFactory(DataSourceFactory postgres) {
+    this.relationalDb = postgres;
   }
 
   public int getRepairManagerSchedulingIntervalSeconds() {

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -113,6 +113,10 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   private CassandraFactory cassandra = new CassandraFactory();
 
+  @Deprecated
+  @JsonProperty
+  private DataSourceFactory database;
+
   private DataSourceFactory relationalDb = new DataSourceFactory();
 
   public int getSegmentCount() {
@@ -192,7 +196,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
   }
 
   public DataSourceFactory getDataSourceFactory() {
-    return relationalDb;
+    return database != null ? database : relationalDb;
   }
 
   @JsonProperty("h2")

--- a/src/server/src/test/java/io/cassandrareaper/ReaperApplicationConfigurationTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/ReaperApplicationConfigurationTest.java
@@ -46,7 +46,7 @@ public final class ReaperApplicationConfigurationTest {
     CassandraFactory cassandraFactory = new CassandraFactory();
     cassandraFactory.setContactPoints(new String[]{"127.0.0.1"});
     config.setCassandraFactory(cassandraFactory);
-    config.setDataSourceFactory(dataSourceFactory);
+    config.setPostgresDataSourceFactory(dataSourceFactory);
     config.setHangingRepairTimeoutMins(1);
     config.setRepairParallelism(RepairParallelism.DATACENTER_AWARE);
     config.setRepairRunThreadCount(1);

--- a/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
@@ -37,10 +37,8 @@ jmxPorts:
   127.0.0.7: 7700
   127.0.0.8: 7800
 
-# database section will be ignored if storageType is set to "memory"
-database:
-  # H2 JDBC settings
-  driverClass: org.h2.Driver
+# database section will be ignored if storageType is set to "cassandra"
+h2:
   url: jdbc:h2:mem:reaper-db;MODE=PostgreSQL
   user:
   password:

--- a/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
@@ -6,7 +6,7 @@ repairIntensity: 0.95
 scheduleDaysBetween: 7
 repairRunThreadCount: 15
 hangingRepairTimeoutMins: 1
-storageType: h2
+storageType: database
 incrementalRepair: false
 jmxConnectionTimeoutInSeconds: 300
 
@@ -40,9 +40,16 @@ jmxPorts:
   127.0.0.8: 7800
 
 # database section will be ignored if storageType is set to "memory"
-h2:
+#h2:
   # H2 JDBC settings
-  url: jdbc:h2:/tmp/reaper-db;MODE=PostgreSQL
+#  url: jdbc:h2:/tmp/reaper-db;MODE=PostgreSQL
+#  user:
+#  password:
+
+database:
+  # H2 JDBC settings
+  driverClass: org.h2.Driver
+  url: jdbc:h2:/tmp/reaper-db/db;MODE=PostgreSQL
   user:
   password:
 

--- a/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
@@ -6,7 +6,7 @@ repairIntensity: 0.95
 scheduleDaysBetween: 7
 repairRunThreadCount: 15
 hangingRepairTimeoutMins: 1
-storageType: database
+storageType: h2
 incrementalRepair: false
 jmxConnectionTimeoutInSeconds: 300
 
@@ -40,9 +40,8 @@ jmxPorts:
   127.0.0.8: 7800
 
 # database section will be ignored if storageType is set to "memory"
-database:
+h2:
   # H2 JDBC settings
-  driverClass: org.h2.Driver
   url: jdbc:h2:/tmp/reaper-db;MODE=PostgreSQL
   user:
   password:

--- a/src/server/src/test/resources/cassandra-reaper-postgres-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-postgres-at.yaml
@@ -6,7 +6,7 @@ repairIntensity: 0.95
 scheduleDaysBetween: 7
 repairRunThreadCount: 15
 hangingRepairTimeoutMins: 1
-storageType: database
+storageType: postgres
 incrementalRepair: false
 jmxConnectionTimeoutInSeconds: 300
 
@@ -40,9 +40,7 @@ jmxPorts:
   127.0.0.8: 7800
 
 # database section will be ignored if storageType is set to "memory"
-database:
-  # H2 JDBC settings
-  driverClass: org.postgresql.Driver
+postgres:
   user: postgres
   password:
   url: jdbc:postgresql://127.0.0.1/reaper


### PR DESCRIPTION
The changes in this Pull Request fix the naming consistency of the `storageType` setting and the associated JSON objects that are parsed. Specifically, the generic term `database` has been replaced with the specific database technologies that are supported; `h2` and `postgres`. This brings the storage naming in align with the other backend options `cassandra` and `memory`.

- Split 'database' conguration setting into 'h2' and 'postgres'.
- Deprecated 'driverClass' setting.
- Documentation and configuration example updtes.