### PR TITLE
Fix issue with upgrades on postgres and h2 when coming from pre-0.8 

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
@@ -54,11 +54,23 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
     RepairParallelism repairParallelism = RepairParallelism.fromName(
         rs.getString("repair_parallelism").toLowerCase().replace("datacenter_aware", "dc_parallel"));
 
-    Collection<String> nodes = ImmutableSet.copyOf(getStringArray(rs.getArray("nodes").getArray()));
+    Collection<String> nodes =
+        ImmutableSet.copyOf(
+            rs.getArray("nodes") == null
+                ? new String[] {}
+                : getStringArray(rs.getArray("nodes").getArray()));
     Collection<String> datacenters =
-        ImmutableSet.copyOf(getStringArray(rs.getArray("datacenters").getArray()));
+        ImmutableSet.copyOf(
+            getStringArray(
+                rs.getArray("datacenters") == null
+                    ? new String[] {}
+                    : rs.getArray("datacenters").getArray()));
     Collection<String> blacklistedTables =
-        ImmutableSet.copyOf(getStringArray(rs.getArray("blacklisted_tables").getArray()));
+        ImmutableSet.copyOf(
+            getStringArray(
+                rs.getArray("blacklisted_tables") == null
+                    ? new String[] {}
+                    : rs.getArray("blacklisted_tables").getArray()));
 
     return new RepairRunStatus(
         UuidUtil.fromSequenceId(runId),

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -50,9 +50,18 @@ public final class RepairScheduleStatusMapper implements ResultSetMapper<RepairS
                 .toLowerCase()
                 .replace("datacenter_aware", "dc_parallel")),
         rs.getInt("days_between"),
-        ImmutableSet.copyOf(getStringArray(rs.getArray("nodes").getArray())),
-        ImmutableSet.copyOf(getStringArray(rs.getArray("datacenters").getArray())),
-        ImmutableSet.copyOf(getStringArray(rs.getArray("blacklisted_tables").getArray())),
+        ImmutableSet.copyOf(
+            rs.getArray("nodes") == null
+                ? new String[] {}
+                : getStringArray(rs.getArray("nodes").getArray())),
+        ImmutableSet.copyOf(
+            rs.getArray("datacenters") == null
+                ? new String[] {}
+                : getStringArray(rs.getArray("datacenters").getArray())),
+        ImmutableSet.copyOf(
+            rs.getArray("blacklisted_tables") == null
+                ? new String[] {}
+                : getStringArray(rs.getArray("blacklisted_tables").getArray())),
         rs.getInt("segment_count_per_node"));
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
@@ -30,9 +30,18 @@ public final class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
   public RepairUnit map(int index, ResultSet rs, StatementContext ctx) throws SQLException {
 
     String[] columnFamilies = parseStringArray(rs.getArray("column_families").getArray());
-    String[] nodes = parseStringArray(rs.getArray("nodes").getArray());
-    String[] datacenters = parseStringArray(rs.getArray("datacenters").getArray());
-    String[] blacklistedTables = parseStringArray(rs.getArray("blacklisted_tables").getArray());
+    String[] nodes =
+        rs.getArray("nodes") == null
+            ? new String[] {}
+            : parseStringArray(rs.getArray("nodes").getArray());
+    String[] datacenters =
+        rs.getArray("datacenters") == null
+            ? new String[] {}
+            : parseStringArray(rs.getArray("datacenters").getArray());
+    String[] blacklistedTables =
+        rs.getArray("blacklisted_tables") == null
+            ? new String[] {}
+            : parseStringArray(rs.getArray("blacklisted_tables").getArray());
 
     RepairUnit.Builder builder =
         new RepairUnit.Builder(


### PR DESCRIPTION
This PR fixes #255 by handling null values in newly added arrays in the repair_schedule table. 