### PR TITLE
Minimal fix for test failure when repair run is created in duplicate

### DIFF
--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/basic_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/basic_reaper_functionality.feature
@@ -63,7 +63,7 @@ Feature: Using Reaper to launch repairs
     And deleting cluster called "other_cluster" fails
     When the last added schedule is deleted for cluster called "other_cluster"
     And a new repair is added for "other_cluster" and keyspace "system"
-    Then reaper has 1 repairs for cluster called "other_cluster"
+    Then reaper has 1 started or done repairs for cluster called "other_cluster"
     And deleting cluster called "other_cluster" fails
     When the last added repair run is deleted
     And cluster called "other_cluster" is deleted

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -39,7 +39,7 @@ Feature: Using Reaper to launch repairs and schedule them
     And deleting the last added cluster fails
     When we wait for a scheduled repair run has started for cluster "test_cluster"
     And we wait for at least 1 segments to be repaired
-    Then reaper has 1 repairs for the last added cluster
+    Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
     And the last added repair run is deleted
     And deleting the last added cluster fails
@@ -58,7 +58,7 @@ Feature: Using Reaper to launch repairs and schedule them
     And deleting the last added cluster fails
     And the last added repair is activated
     And we wait for at least 1 segments to be repaired
-    Then reaper has 1 repairs for the last added cluster
+    Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
     And the last added repair run is deleted
     And the last added cluster is deleted
@@ -74,7 +74,7 @@ Feature: Using Reaper to launch repairs and schedule them
     And deleting the last added cluster fails
     And the last added repair is activated
     And we wait for at least 1 segments to be repaired
-    Then reaper has 1 repairs for the last added cluster
+    Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
     And the last added repair run is deleted
     And the last added cluster is deleted


### PR DESCRIPTION
background: explained in more depth in https://github.com/thelastpickle/cassandra-reaper/issues/266