### PR TITLE
Prefer absolute URLs in webui (html)

### DIFF
--- a/src/server/src/main/resources/assets/index.html
+++ b/src/server/src/main/resources/assets/index.html
@@ -11,6 +11,8 @@
 
     <title>Cassandra Reaper - Clusters</title>
 
+    <base href="/webui/">
+
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/src/server/src/main/resources/assets/repair.html
+++ b/src/server/src/main/resources/assets/repair.html
@@ -11,6 +11,8 @@
 
     <title>Cassandra Reaper - Repair</title>
 
+    <base href="/webui/">
+
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/src/server/src/main/resources/assets/schedules.html
+++ b/src/server/src/main/resources/assets/schedules.html
@@ -11,6 +11,8 @@
 
     <title>Cassandra Reaper - Schedules</title>
 
+    <base href="/webui/">
+
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/src/ui/app/html_template.ejs
+++ b/src/ui/app/html_template.ejs
@@ -11,6 +11,8 @@
 
     <title>Cassandra Reaper<%= htmlWebpackPlugin.options.title %></title>
 
+    <base href="/webui/">
+
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
Today, the webui is not correctly displayed when we use an URL
with no ending slash. It is because JS links are relative.
- works:         http://server:port/webui/
- does not work: http://server:port/webui
I want to make both URLs work.
In this patch, I suggest to hardcode the base URL for all relative URLs
Alternatively, we could replace relative URL by absolute ones
In my opinion, we should use JSP (${pageContext.request.contextPath})
to not hardcode '/webui/' twice (it is already hardcoded in Java), but
I do not want to make a so big change (it can be a further improvment)