### PR TITLE
Stop throwing errors on a keyspace with RF=1

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -271,7 +271,13 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
           if (commandId == 0) {
             LOG.info("Nothing to repair for keyspace {}", keyspace);
             context.storage.updateRepairSegment(
-                segment.with().coordinatorHost(coordinator.getHost()).state(RepairSegment.State.DONE).build(segmentId));
+                segment
+                    .with()
+                    .coordinatorHost(coordinator.getHost())
+                    .startTime(DateTime.now())
+                    .endTime(DateTime.now())
+                    .state(RepairSegment.State.DONE)
+                    .build(segmentId));
             SEGMENT_RUNNERS.remove(segment.getId());
             closeJmxConnection(Optional.fromNullable(coordinator));
             return true;


### PR DESCRIPTION
There may be a more elegant way you want to handle this scenario (e.g. skip the entire repair - I don't understand the commandId=0 scenarios well enough), but this worked for me. :)
