### PR TITLE
Fix issue #291 with out of order JMX notifications

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -23,8 +23,11 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class RepairSegment {
+  private static final Logger LOG = LoggerFactory.getLogger(RepairSegment.class);
 
   private final UUID id;
   private final UUID runId;
@@ -109,6 +112,24 @@ public final class RepairSegment {
     DONE
   }
 
+  public boolean isValid() {
+    if (null == startTime && null != endTime) {
+      LOG.debug("Invalid repair segment {} : startTime is null but endTime is not", this.id);
+      return false;
+    }
+    if (null != endTime && State.DONE != state) {
+      LOG.debug("Invalid repair segment {} : endTime is not null but state is not DONE", this.id);
+      return false;
+    }
+    if (null == startTime && State.NOT_STARTED != state) {
+      LOG.debug(
+          "Invalid repair segment {} : startTime is null but state is not NOT_STARTED", this.id);
+      return false;
+    }
+
+    return true;
+  }
+
   public static final class Builder {
 
     public final RingRange tokenRange;
@@ -171,7 +192,7 @@ public final class RepairSegment {
       return this;
     }
 
-    public Builder endTime(DateTime endTime) {
+    public Builder endTime(@Nullable DateTime endTime) {
       this.endTime = endTime;
       return this;
     }
@@ -179,19 +200,5 @@ public final class RepairSegment {
     public RepairSegment build(@Nullable UUID segmentId) {
       return new RepairSegment(this, segmentId);
     }
-  }
-
-  public boolean isConsistentOnTimesAndState() {
-    if (null == startTime && null != endTime) {
-      return false;
-    }
-    if (null != endTime && State.DONE != state) {
-      return false;
-    }
-    if (null == startTime && State.NOT_STARTED != state) {
-      return false;
-    }
-
-    return true;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -172,29 +172,26 @@ public final class RepairSegment {
     }
 
     public Builder endTime(DateTime endTime) {
-      Preconditions.checkNotNull(endTime);
       this.endTime = endTime;
       return this;
     }
 
     public RepairSegment build(@Nullable UUID segmentId) {
-      // a null segmentId is a special case where the storage uses a sequence for it
-      Preconditions.checkNotNull(runId);
-      //Preconditions.checkState(null != startTime || null == endTime, "if endTime is set, so must startTime be set");
-      //Preconditions.checkState(null == endTime || State.DONE == state, "endTime can only be set if segment is DONE");
-      /* Preconditions.checkState(
-      null != startTime || State.NOT_STARTED == state,
-      "startTime must be set if segment is RUNNING or DONE"); */
-
-      if (null != endTime && State.DONE != state) {
-        endTime = null;
-      }
-
-      if (startTime == null && endTime != null) {
-        startTime = endTime.minusSeconds(1);
-      }
-
       return new RepairSegment(this, segmentId);
     }
+  }
+
+  public boolean isConsistentOnTimesAndState() {
+    if (null == startTime && null != endTime) {
+      return false;
+    }
+    if (null != endTime && State.DONE != state) {
+      return false;
+    }
+    if (null == startTime && State.NOT_STARTED != state) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -625,9 +625,13 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     BatchStatement updateRepairSegmentBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
 
     RepairSegment segment = originalSegment;
-    if (!segment.isConsistentOnTimesAndState()) {
+    if (!segment.isValid()) {
       // if endTime is not null but startTime is, then we ran into a race condition.
       // We'll reset the segment so it can get reprocessed.
+      LOG.warn(
+          "Resetting segment {} of repair run {} because start time, end time and state were inconsistent",
+          segment.getId(),
+          segment.getRunId());
       segment =
           originalSegment
               .with()

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -612,14 +612,36 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   }
 
   @Override
-  public boolean updateRepairSegment(RepairSegment segment) {
+  public boolean updateRepairSegment(RepairSegment originalSegment) {
 
-    assert hasLeadOnSegment(segment.getId())
-        || (hasLeadOnSegment(segment.getRunId())
-          && getRepairUnit(segment.getRepairUnitId()).get().getIncrementalRepair())
-        : "non-leader trying to update repair segment " + segment.getId() + " of run " + segment.getRunId();
+    assert hasLeadOnSegment(originalSegment.getId())
+            || (hasLeadOnSegment(originalSegment.getRunId())
+                && getRepairUnit(originalSegment.getRepairUnitId()).get().getIncrementalRepair())
+        : "non-leader trying to update repair segment "
+            + originalSegment.getId()
+            + " of run "
+            + originalSegment.getRunId();
 
     BatchStatement updateRepairSegmentBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
+
+    RepairSegment segment = originalSegment;
+    if (!segment.isConsistentOnTimesAndState()) {
+      // if endTime is not null but startTime is, then we ran into a race condition.
+      // We'll reset the segment so it can get reprocessed.
+      segment =
+          originalSegment
+              .with()
+              .state(State.NOT_STARTED)
+              .startTime(null)
+              .endTime(null)
+              .build(segment.getId());
+
+      updateRepairSegmentBatch.add(
+          insertRepairSegmentEndTimePrepStmt.bind(
+              segment.getRunId(),
+              segment.getId(),
+              null)); //endTime
+    }
 
     updateRepairSegmentBatch.add(
         updateRepairSegmentPrepStmt.bind(
@@ -630,7 +652,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
             null != segment.getStartTime() ? segment.getStartTime().toDate() : null,
             segment.getFailCount()));
 
-    if (null != segment.getEndTime()) {
+    if (null != segment.getEndTime() && null != segment.getStartTime()) {
       assert RepairSegment.State.DONE == segment.getState();
 
       updateRepairSegmentBatch.add(

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -18,6 +18,7 @@ import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairSegment;
+import io.cassandrareaper.core.RepairSegment.State;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
@@ -257,9 +258,22 @@ public final class MemoryStorage implements IStorage {
     if (getRepairSegment(newRepairSegment.getRunId(), newRepairSegment.getId()) == null) {
       return false;
     } else {
-      repairSegments.put(newRepairSegment.getId(), newRepairSegment);
-      LinkedHashMap<UUID, RepairSegment> updatedSegment = repairSegmentsByRunId.get(newRepairSegment.getRunId());
-      updatedSegment.put(newRepairSegment.getId(), newRepairSegment);
+      RepairSegment segment = newRepairSegment;
+      if (!segment.isConsistentOnTimesAndState()) {
+        // if endTime is not null but startTime is then we ran into a race condition.
+        // We'll reset the segment so it can get reprocessed.
+        segment =
+            newRepairSegment
+                .with()
+                .state(State.NOT_STARTED)
+                .startTime(null)
+                .endTime(null)
+                .build(segment.getId());
+      }
+      repairSegments.put(segment.getId(), segment);
+      LinkedHashMap<UUID, RepairSegment> updatedSegment =
+          repairSegmentsByRunId.get(segment.getRunId());
+      updatedSegment.put(segment.getId(), segment);
       return true;
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -18,6 +18,7 @@ import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairSegment;
+import io.cassandrareaper.core.RepairSegment.State;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
@@ -304,9 +305,21 @@ public final class PostgresStorage implements IStorage {
   public boolean updateRepairSegment(RepairSegment repairSegment) {
     boolean result = false;
     try (Handle h = jdbi.open()) {
-      int rowsAdded = getPostgresStorage(h).updateRepairSegment(repairSegment);
+      RepairSegment segment = repairSegment;
+      if (!segment.isConsistentOnTimesAndState()) {
+        // if endTime is not null but startTime is then we ran into a race condition.
+        // We'll reset the segment so it can get reprocessed.
+        segment =
+            repairSegment
+                .with()
+                .state(State.NOT_STARTED)
+                .startTime(null)
+                .endTime(null)
+                .build(segment.getId());
+      }
+      int rowsAdded = getPostgresStorage(h).updateRepairSegment(segment);
       if (rowsAdded < 1) {
-        LOG.warn("failed updating repair segment with id: {}", repairSegment.getId());
+        LOG.warn("failed updating repair segment with id: {}", segment.getId());
       } else {
         result = true;
       }

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -306,9 +306,13 @@ public final class PostgresStorage implements IStorage {
     boolean result = false;
     try (Handle h = jdbi.open()) {
       RepairSegment segment = repairSegment;
-      if (!segment.isConsistentOnTimesAndState()) {
+      if (!segment.isValid()) {
         // if endTime is not null but startTime is then we ran into a race condition.
         // We'll reset the segment so it can get reprocessed.
+        LOG.warn(
+            "Resetting segment {} of repair run {} because start time, end time and state were inconsistent",
+            segment.getId(),
+            segment.getRunId());
         segment =
             repairSegment
                 .with()

--- a/src/server/src/test/java/io/cassandrareaper/core/RepairSegmentTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/core/RepairSegmentTest.java
@@ -36,7 +36,7 @@ public class RepairSegmentTest {
             .state(State.NOT_STARTED)
             .build(UUID.randomUUID());
 
-    assertEquals(true, segment.isConsistentOnTimesAndState());
+    assertEquals(true, segment.isValid());
   }
 
   @Test
@@ -49,7 +49,7 @@ public class RepairSegmentTest {
             .state(State.DONE)
             .build(UUID.randomUUID());
 
-    assertEquals(true, segment.isConsistentOnTimesAndState());
+    assertEquals(true, segment.isValid());
   }
 
   @Test
@@ -62,7 +62,7 @@ public class RepairSegmentTest {
             .state(State.DONE)
             .build(UUID.randomUUID());
 
-    assertEquals(false, segment.isConsistentOnTimesAndState());
+    assertEquals(false, segment.isValid());
   }
 
   @Test
@@ -75,7 +75,7 @@ public class RepairSegmentTest {
             .state(State.RUNNING)
             .build(UUID.randomUUID());
 
-    assertEquals(false, segment.isConsistentOnTimesAndState());
+    assertEquals(false, segment.isValid());
   }
 
   @Test
@@ -88,7 +88,7 @@ public class RepairSegmentTest {
             .state(State.RUNNING)
             .build(UUID.randomUUID());
 
-    assertEquals(false, segment.isConsistentOnTimesAndState());
+    assertEquals(false, segment.isValid());
   }
 
 

--- a/src/server/src/test/java/io/cassandrareaper/core/RepairSegmentTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/core/RepairSegmentTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import io.cassandrareaper.core.RepairSegment.State;
+import io.cassandrareaper.service.RingRange;
+
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RepairSegmentTest {
+
+  @Test
+  public void startAndEndTimeAndStateAreConsistent1() {
+    RepairSegment segment =
+        RepairSegment.builder(new RingRange("1", "10"), UUID.randomUUID())
+            .withRunId(UUID.randomUUID())
+            .startTime(DateTime.now())
+            .endTime(null)
+            .state(State.NOT_STARTED)
+            .build(UUID.randomUUID());
+
+    assertEquals(true, segment.isConsistentOnTimesAndState());
+  }
+
+  @Test
+  public void startAndEndTimeAndStateAreConsistent2() {
+    RepairSegment segment =
+        RepairSegment.builder(new RingRange("1", "10"), UUID.randomUUID())
+            .withRunId(UUID.randomUUID())
+            .startTime(DateTime.now())
+            .endTime(DateTime.now())
+            .state(State.DONE)
+            .build(UUID.randomUUID());
+
+    assertEquals(true, segment.isConsistentOnTimesAndState());
+  }
+
+  @Test
+  public void startAndEndTimeAndStateAreNotConsistent1() {
+    RepairSegment segment =
+        RepairSegment.builder(new RingRange("1", "10"), UUID.randomUUID())
+            .withRunId(UUID.randomUUID())
+            .startTime(null)
+            .endTime(DateTime.now())
+            .state(State.DONE)
+            .build(UUID.randomUUID());
+
+    assertEquals(false, segment.isConsistentOnTimesAndState());
+  }
+
+  @Test
+  public void startAndEndTimeAndStateAreNotConsistent2() {
+    RepairSegment segment =
+        RepairSegment.builder(new RingRange("1", "10"), UUID.randomUUID())
+            .withRunId(UUID.randomUUID())
+            .startTime(DateTime.now())
+            .endTime(DateTime.now())
+            .state(State.RUNNING)
+            .build(UUID.randomUUID());
+
+    assertEquals(false, segment.isConsistentOnTimesAndState());
+  }
+
+  @Test
+  public void startAndEndTimeAndStateAreNotConsistent3() {
+    RepairSegment segment =
+        RepairSegment.builder(new RingRange("1", "10"), UUID.randomUUID())
+            .withRunId(UUID.randomUUID())
+            .startTime(null)
+            .endTime(null)
+            .state(State.RUNNING)
+            .build(UUID.randomUUID());
+
+    assertEquals(false, segment.isConsistentOnTimesAndState());
+  }
+
+
+}

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -24,9 +24,6 @@ import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.jmx.RepairStatusHandler;
-import io.cassandrareaper.service.RepairRunner;
-import io.cassandrareaper.service.RingRange;
-import io.cassandrareaper.service.SegmentRunner;
 import io.cassandrareaper.storage.IStorage;
 import io.cassandrareaper.storage.MemoryStorage;
 
@@ -275,6 +272,141 @@ public final class SegmentRunnerTest {
 
     assertEquals(RepairSegment.State.DONE, storage.getRepairSegment(runId, segmentId).get().getState());
     assertEquals(0, storage.getRepairSegment(runId, segmentId).get().getFailCount());
+  }
+
+  @Test
+  public void disorderedNotificationsTest()
+      throws InterruptedException, ReaperException, ExecutionException {
+    final IStorage storage = new MemoryStorage();
+    RepairUnit cf =
+        storage.addRepairUnit(
+            new RepairUnit.Builder(
+                "reaper",
+                "reaper",
+                Sets.newHashSet("reaper"),
+                false,
+                Sets.newHashSet("127.0.0.1"),
+                Collections.emptySet(),
+                Collections.emptySet()));
+    RepairRun run =
+        storage.addRepairRun(
+            new RepairRun.Builder(
+                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+            Collections.singleton(
+                RepairSegment.builder(new RingRange(BigInteger.ONE, BigInteger.ZERO), cf.getId())));
+    final UUID runId = run.getId();
+    final UUID segmentId =
+        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final MutableObject<Future<?>> future = new MutableObject<>();
+
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = Mockito.mock(ReaperApplicationConfiguration.class);
+    when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
+    when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
+
+    context.jmxConnectionFactory =
+        new JmxConnectionFactory() {
+          @Override
+          protected JmxProxy connect(
+              final Optional<RepairStatusHandler> handler, String host, int connectionTimeout)
+              throws ReaperException {
+
+            JmxProxy jmx = mock(JmxProxy.class);
+            when(jmx.getClusterName()).thenReturn("reaper");
+            when(jmx.isConnectionAlive()).thenReturn(true);
+            when(jmx.tokenRangeToEndpoint(anyString(), any(RingRange.class)))
+                .thenReturn(Lists.newArrayList(""));
+            when(jmx.getDataCenter()).thenReturn("dc1");
+            when(jmx.getDataCenter(anyString())).thenReturn("dc1");
+
+            when(jmx.triggerRepair(
+                    any(BigInteger.class),
+                    any(BigInteger.class),
+                    any(),
+                    any(RepairParallelism.class),
+                    any(),
+                    anyBoolean(),
+                    any()))
+                .then(
+                    invocation -> {
+                      assertEquals(
+                          RepairSegment.State.NOT_STARTED,
+                          storage.getRepairSegment(runId, segmentId).get().getState());
+
+                      future.setValue(
+                          executor.submit(
+                              () -> {
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.STARTED),
+                                        Optional.absent(),
+                                        "Repair command 1 has started");
+
+                                assertEquals(
+                                    RepairSegment.State.RUNNING,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+
+                                // We should not get FINISHED now, but SESSION_SUCCESS instead
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.FINISHED),
+                                        Optional.absent(),
+                                        "Repair command 1 has finished");
+
+                                assertEquals(
+                                    RepairSegment.State.RUNNING,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                                        Optional.absent(),
+                                        "Repair session succeeded in command 1");
+
+                                // Order of notification was wrong so Reaper should reset the segment state
+                                assertEquals(
+                                    RepairSegment.State.NOT_STARTED,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+                              }));
+                      return 1;
+                    });
+
+            return jmx;
+          }
+        };
+    RepairRunner rr = mock(RepairRunner.class);
+    RepairUnit ru = mock(RepairUnit.class);
+
+    SegmentRunner sr =
+        new SegmentRunner(
+            context,
+            segmentId,
+            Collections.singleton(""),
+            5000,
+            0.5,
+            RepairParallelism.PARALLEL,
+            "reaper",
+            ru,
+            rr);
+
+    sr.run();
+
+    future.getValue().get();
+    executor.shutdown();
+
+    assertEquals(
+        RepairSegment.State.NOT_STARTED,
+        storage.getRepairSegment(runId, segmentId).get().getState());
+    assertEquals(1, storage.getRepairSegment(runId, segmentId).get().getFailCount());
   }
 
   @Test


### PR DESCRIPTION
Instead of allowing to write segments with inconsistent startTime, endTime and state, we now reset any segment with that kind issue so that it gets reprocessed later.
This allows us to remove the precondition checks in the RepairSegment builder.