### PR TITLE
issue 291  start time end time bug

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -104,6 +104,23 @@ public final class RepairSegment {
     return new Builder(this);
   }
 
+  public boolean hasStartTime() {
+    return null != startTime;
+  }
+
+  public boolean hasEndTime() {
+    return null != endTime;
+  }
+
+  /** Reset to NOT_STARTED state, with nulled startTime and endTime. */
+  public Builder reset() {
+    Builder builder = new Builder(this);
+    builder.state = State.NOT_STARTED;
+    builder.startTime = null;
+    builder.endTime = null;
+    return builder;
+  }
+
   public enum State {
     NOT_STARTED,
     RUNNING,
@@ -163,7 +180,7 @@ public final class RepairSegment {
       return this;
     }
 
-    public Builder startTime(@Nullable DateTime startTime) {
+    public Builder startTime(DateTime startTime) {
       Preconditions.checkState(
           null != startTime || null == endTime,
           "unsetting startTime only permitted if endTime unset");

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -18,13 +18,14 @@ import io.cassandrareaper.service.RingRange;
 
 import java.math.BigInteger;
 import java.util.UUID;
-
 import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 import org.joda.time.DateTime;
 
 public final class RepairSegment {
+
+  private static final boolean STRICT = !Boolean.getBoolean("reaper.disableSegmentChecks");
 
   private final UUID id;
   private final UUID runId;
@@ -180,18 +181,20 @@ public final class RepairSegment {
     public RepairSegment build(@Nullable UUID segmentId) {
       // a null segmentId is a special case where the storage uses a sequence for it
       Preconditions.checkNotNull(runId);
-      //Preconditions.checkState(null != startTime || null == endTime, "if endTime is set, so must startTime be set");
-      //Preconditions.checkState(null == endTime || State.DONE == state, "endTime can only be set if segment is DONE");
-      /* Preconditions.checkState(
-      null != startTime || State.NOT_STARTED == state,
-      "startTime must be set if segment is RUNNING or DONE"); */
+      if (STRICT) {
+        Preconditions.checkState(null != startTime || null == endTime, "if endTime is set, so must startTime be set");
+        Preconditions.checkState(null == endTime || State.DONE == state, "endTime can only be set if segment is DONE");
 
-      if (null != endTime && State.DONE != state) {
-        endTime = null;
-      }
-
-      if (startTime == null && endTime != null) {
-        startTime = endTime.minusSeconds(1);
+        Preconditions.checkState(
+            null != startTime || State.NOT_STARTED == state,
+            "startTime must be set if segment is RUNNING or DONE");
+      } else {
+        if (null != endTime && State.DONE != state) {
+          endTime = null;
+        }
+        if (null == startTime && null != endTime) {
+          startTime = endTime.minusSeconds(1);
+        }
       }
 
       return new RepairSegment(this, segmentId);

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -149,13 +149,11 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
     try {
       context.storage.updateRepairSegment(
           segment
-              .with()
-              .state(RepairSegment.State.NOT_STARTED)
+              .reset()
               .coordinatorHost(
                   repairUnit.isPresent() && repairUnit.get().getIncrementalRepair()
                   ? segment.getCoordinatorHost()
                   : null) // set coordinator host to null only for full repairs
-              .startTime(null)
               .failCount(segment.getFailCount() + 1)
               .build(segment.getId()));
     } finally {

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration012.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration012.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cassandra;
+
+
+import com.datastax.driver.core.Session;
+
+public final class Migration012 {
+
+  private Migration012() {
+  }
+
+  /**
+   * fix segment start and end times in the repair_run table.
+   *  delegates to Migration009 as that does everything already.
+   */
+  public static void migrate(Session session) {
+    Migration009.migrate(session);
+  }
+}

--- a/src/server/src/main/resources/db/cassandra/012_fix_start_times.cql
+++ b/src/server/src/main/resources/db/cassandra/012_fix_start_times.cql
@@ -1,0 +1,4 @@
+--
+-- Intentionally blank
+--
+-- Placeholder for Migration012

--- a/src/server/src/main/resources/db/h2/V7_0_0__fix_repair_segment_table.sql
+++ b/src/server/src/main/resources/db/h2/V7_0_0__fix_repair_segment_table.sql
@@ -1,0 +1,10 @@
+--
+-- fix segment start and end times in the repair_run table
+--
+
+UPDATE repair_segment
+SET start_time = end_time
+WHERE start_time is NULL
+AND   end_time IS NOT NULL;
+
+

--- a/src/server/src/main/resources/db/postgres/V7_0_0__fix_repair_segment_table.sql
+++ b/src/server/src/main/resources/db/postgres/V7_0_0__fix_repair_segment_table.sql
@@ -1,0 +1,10 @@
+--
+-- fix segment start and end times in the repair_run table
+--
+
+UPDATE repair_segment
+SET start_time = end_time
+WHERE start_time is NULL
+AND   end_time IS NOT NULL;
+
+


### PR DESCRIPTION
Fix #291 if endTime is set, so must startTime be set (v1.0.1) 

Commit d6e5a10 created the fault.
When the `updateRepairSegmentPrepStmt` statement was split into two, creating `insertRepairSegmentEndTimePrepStmt`,
it meant that calls to `SegmentRunner.postponse(..)` were no longer nulling endTime when resetting the RepairSegment to NOT_STARTED state.

The fix here is to

 - use `insertRepairSegmentEndTimePrepStmt` to null the endTime if state is NOT_STARTED (and live with tombstones created),
 - add method `RepairSegment.reset()` for the explicit purpose of resetting a segment to NOT_STARTED state with null startTime and endTime,
 - not permit nulls passed into `RepairSegment.Builder.startTime(..)`
 - add migration scripts (one more time) to fix any nulls in storage