### PR TITLE
allow EC2 multiregion address translation for custom domains

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -15,6 +15,7 @@
 package io.cassandrareaper;
 
 import io.cassandrareaper.ReaperApplicationConfiguration.JmxCredentials;
+import io.cassandrareaper.jmx.CustomEC2MultiRegionAddressTranslator;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxConnectionsInitializer;
 import io.cassandrareaper.resources.ClusterResource;
@@ -42,7 +43,6 @@ import javax.servlet.FilterRegistration;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -154,7 +154,9 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
       }
 
       if (config.useAddressTranslator()) {
-        context.jmxConnectionFactory.setAddressTranslator(new EC2MultiRegionAddressTranslator());
+        context.jmxConnectionFactory.setAddressTranslator(
+            new CustomEC2MultiRegionAddressTranslator(config.addressTranslatorRemoveDomain())
+        );
       }
 
       JmxCredentials jmxAuth = config.getJmxAuth();

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -64,6 +64,9 @@ public final class ReaperApplicationConfiguration extends Configuration {
   private Boolean useAddressTranslator;
 
   @JsonProperty
+  private String addressTranslatorRemoveDomain;
+
+  @JsonProperty
   @NotNull
   private Integer repairRunThreadCount;
 
@@ -272,6 +275,14 @@ public final class ReaperApplicationConfiguration extends Configuration {
     return this.useAddressTranslator != null ? useAddressTranslator : false;
   }
 
+  public void setAddressTranslatorRemoveDomain(String addressTranslatorRemoveDomain) {
+    this.addressTranslatorRemoveDomain = addressTranslatorRemoveDomain;
+  }
+
+  public String addressTranslatorRemoveDomain() {
+    return this.addressTranslatorRemoveDomain;
+  }
+
   @JsonProperty("cassandra")
   public CassandraFactory getCassandraFactory() {
     return cassandra;
@@ -325,6 +336,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
       return password;
     }
   }
+
 
   public static final class AutoSchedulingConfiguration {
 

--- a/src/server/src/main/java/io/cassandrareaper/jmx/CustomEC2MultiRegionAddressTranslator.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/CustomEC2MultiRegionAddressTranslator.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.jmx;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Enumeration;
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AddressTranslator implementation for a multi-region EC2 deployment <b>where clients are also deployed in EC2</b>.
+ * <p/>
+ * Its distinctive feature is that it translates addresses according to the location of the Cassandra host:
+ * <ul>
+ * <li>addresses in different EC2 regions (than the client) are unchanged;</li>
+ * <li>addresses in the same EC2 region are <b>translated to private IPs</b>.</li>
+ * </ul>
+ * This optimizes network costs, because Amazon charges more for communication over public IPs.
+ * <p/>
+ * <p/>
+ * Implementation note: this class performs a reverse DNS lookup of the origin address,
+ * to find the domain name of the target instance. Then it performs a forward DNS lookup of the domain name;
+ * the EC2 DNS does the private/public switch automatically based on location.
+ * <p/>
+ * the code is based on EC2MultiRegionAddressTranslatorTest.java from Datastax java-driver
+ */
+
+
+public class CustomEC2MultiRegionAddressTranslator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CustomEC2MultiRegionAddressTranslator.class);
+  private final DirContext ctx;
+  private String addressTranslatorRemoveDomain;
+
+  public CustomEC2MultiRegionAddressTranslator(String addressTranslatorRemoveDomain) throws NamingException {
+    Hashtable<Object, Object> env = new Hashtable<Object, Object>();
+    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+    this.addressTranslatorRemoveDomain = addressTranslatorRemoveDomain;
+
+    ctx = new InitialDirContext(env);
+  }
+
+  // Builds the "reversed" domain name in the ARPA domain to perform the reverse lookup
+  @VisibleForTesting
+  static String reverse(InetAddress address) {
+    byte[] bytes = address.getAddress();
+    if (bytes.length == 4) {
+      return reverseIpv4(bytes);
+    } else {
+      return reverseIpv6(bytes);
+    }
+  }
+
+  private static String reverseIpv4(byte[] bytes) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = bytes.length - 1; i >= 0; i--) {
+      builder.append(bytes[i] & 0xFF).append('.');
+    }
+    builder.append("in-addr.arpa");
+    return builder.toString();
+  }
+
+  private static String reverseIpv6(byte[] bytes) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = bytes.length - 1; i >= 0; i--) {
+      byte currentByte = bytes[i];
+      int lowNibble = currentByte & 0x0F;
+      int highNibble = currentByte >> 4 & 0x0F;
+      builder.append(Integer.toHexString(lowNibble)).append('.')
+          .append(Integer.toHexString(highNibble)).append('.');
+    }
+    builder.append("ip6.arpa");
+    return builder.toString();
+  }
+
+  public InetSocketAddress translate(InetSocketAddress socketAddress) {
+    InetAddress address = socketAddress.getAddress();
+    try {
+      // InetAddress#getHostName() is supposed to perform a reverse DNS lookup, but for some reason it doesn't work
+      // within the same EC2 region (it returns the IP address itself).
+      // We use an alternate implementation:
+      String domainName = lookupPtrRecord(reverse(address));
+      if (domainName == null) {
+        LOG.warn("Found no domain name for {}, returning it as-is", address);
+        return socketAddress;
+      }
+
+      // Waze - remove .pub$ from domain name, by Sasha <sashagl@google.com>
+      if (addressTranslatorRemoveDomain != null) {
+        int sufIndex = domainName.lastIndexOf(addressTranslatorRemoveDomain);
+        if (sufIndex > 0) {
+          domainName = domainName.substring(0, sufIndex);
+        }
+      }
+
+      InetAddress translatedAddress = InetAddress.getByName(domainName);
+      LOG.debug("Resolved {} to {}", address, translatedAddress);
+      return new InetSocketAddress(translatedAddress, socketAddress.getPort());
+    } catch (IllegalArgumentException
+        | SecurityException
+        | java.net.UnknownHostException
+        | javax.naming.NamingException e) {
+      LOG.warn("Error resolving " + address + ", returning it as-is", e);
+      return socketAddress;
+    }
+  }
+
+  private String lookupPtrRecord(String reversedDomain) throws javax.naming.NamingException {
+    Attributes attrs = ctx.getAttributes(reversedDomain, new String[]{"PTR"});
+    for (NamingEnumeration ae = attrs.getAll(); ae.hasMoreElements(); ) {
+      Attribute attr = (Attribute) ae.next();
+      for (Enumeration<?> vals = attr.getAll(); vals.hasMoreElements(); ) {
+        return vals.nextElement().toString();
+      }
+    }
+    return null;
+  }
+
+  public void close() {
+    try {
+      ctx.close();
+    } catch (NamingException e) {
+      LOG.warn("Error closing translator", e);
+    }
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.codahale.metrics.MetricRegistry;
-import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -41,7 +40,7 @@ public class JmxConnectionFactory {
   private final HostConnectionCounters hostConnectionCounters;
   private Map<String, Integer> jmxPorts;
   private JmxCredentials jmxAuth;
-  private EC2MultiRegionAddressTranslator addressTranslator;
+  private CustomEC2MultiRegionAddressTranslator addressTranslator;
 
   @VisibleForTesting
   public JmxConnectionFactory() {
@@ -126,7 +125,7 @@ public class JmxConnectionFactory {
     this.jmxAuth = jmxAuth;
   }
 
-  public final void setAddressTranslator(EC2MultiRegionAddressTranslator addressTranslator) {
+  public final void setAddressTranslator(CustomEC2MultiRegionAddressTranslator addressTranslator) {
     this.addressTranslator = addressTranslator;
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
@@ -58,7 +58,6 @@ import javax.management.remote.JMXServiceURL;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
 import javax.validation.constraints.NotNull;
 
-import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
 import com.google.common.base.Optional;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
@@ -141,14 +140,14 @@ final class JmxProxyImpl implements JmxProxy {
   }
 
   /**
-   * @see JmxProxy#connect(Optional, String, int, String, String, EC2MultiRegionAddressTranslator)
+   * @see JmxProxy#connect(Optional, String, int, String, String, CustomEC2MultiRegionAddressTranslator)
    */
   static JmxProxy connect(
       Optional<RepairStatusHandler> handler,
       String host,
       String username,
       String password,
-      final EC2MultiRegionAddressTranslator addressTranslator,
+      final CustomEC2MultiRegionAddressTranslator addressTranslator,
       int connectionTimeout)
       throws ReaperException, InterruptedException {
 
@@ -174,7 +173,7 @@ final class JmxProxyImpl implements JmxProxy {
    * @param port port number to use for JMX connection
    * @param username username to use for JMX authentication
    * @param password password to use for JMX authentication
-   * @param addressTranslator if EC2MultiRegionAddressTranslator isn't null it will be used to
+   * @param addressTranslator if CustomEC2MultiRegionAddressTranslator isn't null it will be used to
    *     translate addresses
    */
   private static JmxProxy connect(
@@ -183,7 +182,7 @@ final class JmxProxyImpl implements JmxProxy {
       int port,
       String username,
       String password,
-      final EC2MultiRegionAddressTranslator addressTranslator,
+      final CustomEC2MultiRegionAddressTranslator addressTranslator,
       int connectionTimeout)
       throws ReaperException, InterruptedException {
 


### PR DESCRIPTION
We have a custom DNS setup allowing cross-cloud communication.

The problem is that having custom DNS prevents current implementation of AddressTranslator from working correctly.

I have made a patch to the code which solves the problem without breaking any existing functionality:

1) copied the code of com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator from datastax driver to io.cassandrareaper.jmx.CustomEC2MultiRegionAddressTranslator and replaced the references to it.

2) added code to remove the custom domain name part (defined by new config parameter String addressTranslatorRemoveDomain )

Example config:
useAddressTranslator: true
addressTranslatorRemoveDomain: .custom.pub

I think this patch would be useful for any cloud users that have custom domains defined.
