### PR TITLE
Prevent crashing the scheduler for RepairManager.resumePendingRepairRuns() in case of unexpected exception.

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -144,7 +144,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
     }
   }
 
-  private static void postpone(AppContext context, RepairSegment segment, Optional<RepairUnit> repairUnit) {
+  static void postpone(AppContext context, RepairSegment segment, Optional<RepairUnit> repairUnit) {
     LOG.info("Postponing segment {}", segment.getId());
     try {
       context.storage.updateRepairSegment(

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -98,7 +98,9 @@ public final class RepairManagerTest {
 
     context.repairManager.repairRunners.put(run.getId(), mock(RepairRunner.class));
 
-    Mockito.doNothing().when(context.repairManager).abortSegments(any(), any());
+    Mockito.doNothing()
+        .when(context.repairManager)
+        .abortSegments(any(), any(), Mockito.anyBoolean());
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
@@ -108,7 +110,8 @@ public final class RepairManagerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked is at least one segment, meaning abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(1))
+        .abortSegments(Mockito.argThat(new NotEmptyList()), any(), Mockito.anyBoolean());
   }
 
   /**
@@ -164,6 +167,9 @@ public final class RepairManagerTest {
     context.repairManager.repairRunners.put(run.getId(), mock(RepairRunner.class));
 
     Mockito.doNothing().when(context.repairManager).abortSegments(any(), any());
+    Mockito.doNothing()
+        .when(context.repairManager)
+        .abortSegments(any(), any(), Mockito.anyBoolean());
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
@@ -173,7 +179,8 @@ public final class RepairManagerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked with an empty list, meaning no abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new EmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(1))
+        .abortSegments(Mockito.argThat(new EmptyList()), any(), Mockito.anyBoolean());
   }
 
   /**
@@ -226,7 +233,9 @@ public final class RepairManagerTest {
 
     context.repairManager.repairRunners.put(run.getId(), mock(RepairRunner.class));
 
-    Mockito.doNothing().when(context.repairManager).abortSegments(any(), any());
+    Mockito.doNothing()
+        .when(context.repairManager)
+        .abortSegments(any(), any(), Mockito.anyBoolean());
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
@@ -235,7 +244,8 @@ public final class RepairManagerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was not invoked at all, meaning no abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(0)).abortSegments(any(), any());
+    Mockito.verify(context.repairManager, Mockito.times(0))
+        .abortSegments(any(), any(), Mockito.anyBoolean());
   }
 
   /**
@@ -286,7 +296,9 @@ public final class RepairManagerTest {
             .withRunId(run.getId())
             .build(UUIDs.timeBased());
 
-    Mockito.doNothing().when(context.repairManager).abortSegments(any(), any());
+    Mockito.doNothing()
+        .when(context.repairManager)
+        .abortSegments(any(), any(), Mockito.anyBoolean());
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
@@ -295,7 +307,8 @@ public final class RepairManagerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked with an non empty list, meaning abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(1))
+        .abortSegments(Mockito.argThat(new NotEmptyList()), any(), Mockito.anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
Fixes #320 

The scheduler can crash in case any exception different than ReaperException triggers during the execution
of RepairManager.resumePendingRepairRuns().
This can happen anytime one of the queries sent to the backend fails due to timeout or unavailability of nodes, for example.
Any RuntimeException that can happen is now wrapped into a ReaperException and dealt with accordingly.
As orphaned segments are very likely not to be running on the cluster, aborting it will only postpone the segment in the database and
not send a cancellation request on the coordinator node (which could be dealing with another segment at that time).