### PR TITLE
dawdle duckling to "Another fix for `IllegalStateException: startTime must be set if segment is RUNNING or DONE`"

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -204,7 +204,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
 
   private boolean runRepair() {
     LOG.debug("Run repair for segment #{}", segmentId);
-    final RepairSegment segment = context.storage.getRepairSegment(repairRunner.getRepairRunId(), segmentId).get();
+    RepairSegment segment = context.storage.getRepairSegment(repairRunner.getRepairRunId(), segmentId).get();
     Thread.currentThread().setName(clusterName + ":" + segment.getRunId() + ":" + segmentId);
 
     try (Timer.Context cxt = context.metricRegistry.timer(metricNameForRunRepair(segment)).time();
@@ -261,8 +261,8 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
           LOG.debug("Enter synchronized section with segment ID {}", segmentId);
           synchronized (condition) {
 
-            context.storage.updateRepairSegment(
-                segment.with().coordinatorHost(coordinator.getHost()).startTime(DateTime.now()).build(segmentId));
+            segment = segment.with().coordinatorHost(coordinator.getHost()).startTime(DateTime.now()).build(segmentId);
+            context.storage.updateRepairSegment(segment);
 
             commandId = coordinator.triggerRepair(
                 segment.getStartToken(),


### PR DESCRIPTION


 ninja fix: the local variable 'segment' must also be updated.

 ref: https://github.com/thelastpickle/cassandra-reaper/commit/67d67210b23e36c95733cceafbe55c8fe1d62a3c#commitcomment-27160303