### PR TITLE
Push all packages to Bintray on the master branch (beta) and tags (releases)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
               mvn surefire:test -DsurefireArgLine="-Xmx1g" -Dtest=ReaperCassandraIT -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
 
       - store_test_results:
-          path: target/surefire-reports
+          path: src/server/target/surefire-reports
 
 
 notify:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,29 @@ language: java
 jdk:
   - oraclejdk8
 
+branches:
+  except:
+    - /^untagged-.*$/
+    - /^master-snapshot.*$/
+
 env:
   global:
     - LOCAL_JMX=no
     - TEST=""
   matrix:
-      # 2.1.18 runs all tests together because it's also for sonar reporting, see below
-    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.18
-    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.18 GRIM_MIN=2 GRIM_MAX=2
-    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.18 GRIM_MIN=2 GRIM_MAX=4
-    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=1 GRIM_MAX=1
-    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=2
-    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=4
-    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.10 GRIM_MIN=1 GRIM_MAX=1
-    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=2
-    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=4
-    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.0 GRIM_MIN=1 GRIM_MAX=1
-    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=2
-    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=4
+      # 2.1.19 runs all tests together because it's also for sonar reporting, see below
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.19
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.19 GRIM_MIN=2 GRIM_MAX=2
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.1.19 GRIM_MIN=2 GRIM_MAX=4
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.11 GRIM_MIN=1 GRIM_MAX=1
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.11 GRIM_MIN=2 GRIM_MAX=2
+    - TEST_TYPE=ccm CASSANDRA_VERSION=2.2.11 GRIM_MIN=2 GRIM_MAX=4
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.15 GRIM_MIN=1 GRIM_MAX=1
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.15 GRIM_MIN=2 GRIM_MAX=2
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.0.15 GRIM_MIN=2 GRIM_MAX=4
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.1 GRIM_MIN=1 GRIM_MAX=1
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.1 GRIM_MIN=2 GRIM_MAX=2
+    - TEST_TYPE=ccm CASSANDRA_VERSION=3.11.1 GRIM_MIN=2 GRIM_MAX=4
     - TEST_TYPE=docker
 
 matrix:
@@ -28,9 +33,9 @@ matrix:
   allow_failures:
   - env: TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=2
   - env: TEST_TYPE=ccm CASSANDRA_VERSION=2.2.10 GRIM_MIN=2 GRIM_MAX=4
-  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=2
-  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.0.14 GRIM_MIN=2 GRIM_MAX=4
-  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.11.0 GRIM_MIN=2 GRIM_MAX=4
+  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.0.15 GRIM_MIN=2 GRIM_MAX=2
+  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.0.15 GRIM_MIN=2 GRIM_MAX=4
+  - env: TEST_TYPE=ccm CASSANDRA_VERSION=3.11.1 GRIM_MIN=2 GRIM_MAX=4
   - env: TEST_TYPE=docker
 
 services:
@@ -52,16 +57,71 @@ after_failure: ./src/ci/after_failure.sh
 before_deploy: ./src/ci/before_deploy.sh
 
 deploy:
-  provider: releases
-  api_key: $GITHUB_TOKEN
-  file_glob: true
-  file:
-    - "cassandra-reaper-${TRAVIS_TAG}-release.tar.gz"
-    - "src/packages/reaper-*-1.x86_64.rpm"
-    - "src/packages/reaper_*_amd64.deb"
-  skip_cleanup: true
-  on:
-    tags: true
+  - provider: releases
+    api_key: $GITHUB_TOKEN
+    file_glob: true
+    file:
+      - "src/packages/cassandra-reaper-${TRAVIS_TAG}-release.tar.gz"
+      - "src/packages/reaper-*-1.x86_64.rpm"
+      - "src/packages/reaper_*_amd64.deb"
+    skip_cleanup: true
+    on:
+      tags: true
+  - provider: bintray
+    file: "src/ci/descriptor-rpm-beta.json"
+    user: "adejanovski"
+    key: $BINTRAY_API_KEY
+    dry-run: false
+    skip_cleanup: true
+    on:
+      branch: "master"
+      condition: $CASSANDRA_VERSION = "2.1.19" &&  "x${GRIM_MIN}" = "x"
+  - provider: bintray
+    file: "src/ci/descriptor-deb-beta.json"
+    user: "adejanovski"
+    key: $BINTRAY_API_KEY
+    dry-run: false
+    skip_cleanup: true
+    on:
+      branch: "master"
+      condition: $CASSANDRA_VERSION = "2.1.19" &&  "x${GRIM_MIN}" = "x"
+  - provider: bintray
+    file: "src/ci/descriptor-tarball-beta.json"
+    user: "adejanovski"
+    key: $BINTRAY_API_KEY
+    dry-run: false
+    skip_cleanup: true
+    on:
+      branch: "master"
+      condition: $CASSANDRA_VERSION = "2.1.19" &&  "x${GRIM_MIN}" = "x"
+  - provider: bintray
+    file: "src/ci/descriptor-rpm.json"
+    user: "adejanovski"
+    key: $BINTRAY_API_KEY
+    dry-run: false
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: $CASSANDRA_VERSION = "2.1.19" &&  "x${GRIM_MIN}" = "x"
+  - provider: bintray
+    file: "src/ci/descriptor-deb.json"
+    user: "adejanovski"
+    key: $BINTRAY_API_KEY
+    dry-run: false
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: $CASSANDRA_VERSION = "2.1.19" &&  "x${GRIM_MIN}" = "x"
+  - provider: bintray
+    file: "src/ci/descriptor-tarball.json"
+    user: "adejanovski"
+    key: $BINTRAY_API_KEY
+    dry-run: false
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: $CASSANDRA_VERSION = "2.1.19" &&  "x${GRIM_MIN}" = "x"
+
 
 notifications:
   webhooks:

--- a/src/ci/after_success.sh
+++ b/src/ci/after_success.sh
@@ -10,10 +10,10 @@ case "${TEST_TYPE}" in
         exit 1
         ;;
     "ccm")
-        if [ "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_BRANCH}" = "master" -a "${CASSANDRA_VERSION}" = "2.1.18" ]
+        if [ "${TRAVIS_PULL_REQUEST}" = "false" -a "${TRAVIS_BRANCH}" = "master" -a "${CASSANDRA_VERSION}" = "2.1.19" ]
         then
             mvn sonar:sonar \
-                -Dsonar.host.url=https://sonarqube.com \
+                -Dsonar.host.url=https://sonarcloud.io \
                 -Dsonar.login=${SONAR_TOKEN} \
                 -Dsonar.projectKey=tlp-cassandra-reaper \
                 -Dsonar.github.oauth=${GITHUB_TOKEN} \

--- a/src/ci/before_deploy.sh
+++ b/src/ci/before_deploy.sh
@@ -4,12 +4,51 @@ echo "Starting Before Deploy step..."
 
 set -xe
 
-mkdir cassandra-reaper-${TRAVIS_TAG}
-mkdir cassandra-reaper-${TRAVIS_TAG}/server
-mkdir cassandra-reaper-${TRAVIS_TAG}/server/target
-cp -R src/packaging/bin cassandra-reaper-${TRAVIS_TAG}/
-cp src/server/target/cassandra-reaper-*.jar cassandra-reaper-${TRAVIS_TAG}/server/target
-cp -R src/packaging/resource cassandra-reaper-${TRAVIS_TAG}/
-tar czf cassandra-reaper-${TRAVIS_TAG}-release.tar.gz cassandra-reaper-${TRAVIS_TAG}/
-docker-compose -f src/packaging/docker-build/docker-compose.yml build > /dev/null
-docker-compose -f src/packaging/docker-build/docker-compose.yml run build > /dev/null
+if [ "${CASSANDRA_VERSION}" = "2.1.19" -a "x${GRIM_MIN}" = "x" ]
+then
+    if [ "${TRAVIS_BRANCH}" = "master" -a ! -d "cassandra-reaper-master" ]
+    then
+        VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
+        DATE=$(date +"%Y%m%d")
+        RELEASEDATE=$(date +"%Y-%m-%d")
+        RPM_VERSION=$(echo "${VERSION}-${DATE}" | sed "s/-/_/")
+        # Update Bintray descriptor files with appropriate version numbers and release dates
+        sed -i "s/VERSION/${VERSION}-${DATE}/" src/ci/descriptor-rpm-beta.json
+        sed -i "s/RELEASEDATE/${RELEASEDATE}/" src/ci/descriptor-rpm-beta.json
+        sed -i "s/VERSION/${VERSION}-${DATE}/" src/ci/descriptor-deb-beta.json
+        sed -i "s/RELEASEDATE/${RELEASEDATE}/" src/ci/descriptor-deb-beta.json
+        sed -i "s/VERSION/${VERSION}-${DATE}/" src/ci/descriptor-tarball-beta.json
+        sed -i "s/RELEASEDATE/${RELEASEDATE}/" src/ci/descriptor-tarball-beta.json
+        mkdir -p cassandra-reaper-master/server/target
+        cp -R src/packaging/bin cassandra-reaper-master/
+        cp src/server/target/cassandra-reaper-*.jar cassandra-reaper-master/server/target
+        cp -R src/packaging/resource cassandra-reaper-master/
+        tar czf cassandra-reaper-${VERSION}-${DATE}.tar.gz cassandra-reaper-master/
+        docker-compose -f src/packaging/docker-build/docker-compose.yml build > /dev/null
+        docker-compose -f src/packaging/docker-build/docker-compose.yml run build > /dev/null
+        # Renaming the packages to avoid conflicts in Bintray
+        sudo mv cassandra-reaper-${VERSION}-${DATE}.tar.gz src/packages/
+        sudo mv src/packages/reaper_${VERSION}_amd64.deb src/packages/reaper_${VERSION}-${DATE}_amd64.deb
+        sudo mv src/packages/reaper-*.x86_64.rpm src/packages/reaper-${RPM_VERSION}.x86_64.rpm
+    fi
+    if [ "x${TRAVIS_TAG}" != "x" -a ! -d "cassandra-reaper-${TRAVIS_TAG}" ]
+    then
+        VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
+        RELEASEDATE=$(date +"%Y-%m-%d")
+        # Update Bintray descriptor files with appropriate version numbers and release dates
+        sed -i "s/VERSION/${VERSION}/" src/ci/descriptor-rpm.json
+        sed -i "s/RELEASEDATE/${RELEASEDATE}/" src/ci/descriptor-rpm.json
+        sed -i "s/VERSION/${VERSION}/" src/ci/descriptor-deb.json
+        sed -i "s/RELEASEDATE/${RELEASEDATE}/" src/ci/descriptor-deb.json
+        sed -i "s/VERSION/${VERSION}/" src/ci/descriptor-tarball.json
+        sed -i "s/RELEASEDATE/${RELEASEDATE}/" src/ci/descriptor-tarball.json
+        mkdir -p cassandra-reaper-${TRAVIS_TAG}/server/target
+        cp -R src/packaging/bin cassandra-reaper-${TRAVIS_TAG}/
+        cp src/server/target/cassandra-reaper-*.jar cassandra-reaper-${TRAVIS_TAG}/server/target
+        cp -R src/packaging/resource cassandra-reaper-${TRAVIS_TAG}/
+        tar czf cassandra-reaper-${TRAVIS_TAG}-release.tar.gz cassandra-reaper-${TRAVIS_TAG}/
+        sudo mv cassandra-reaper-${TRAVIS_TAG}-release.tar.gz src/packages/
+        docker-compose -f src/packaging/docker-build/docker-compose.yml build > /dev/null
+        docker-compose -f src/packaging/docker-build/docker-compose.yml run build > /dev/null
+    fi
+fi

--- a/src/ci/before_script.sh
+++ b/src/ci/before_script.sh
@@ -4,6 +4,11 @@ echo "Starting Before Script step..."
 
 set -xe
 
+if [ "x${GRIM_MIN}" = "x" ]
+then
+    npm install -g bower > /dev/null
+fi
+
 case "${TEST_TYPE}" in
     "")
         echo "ERROR: Environment variable TEST_TYPE is unspecified."

--- a/src/ci/descriptor-deb-beta.json
+++ b/src/ci/descriptor-deb-beta.json
@@ -1,0 +1,39 @@
+{
+    "package": {
+        "name": "cassandra-reaper-beta", // Bintray package name
+        "repo": "reaper-deb-beta", // Bintray repository name
+        "subject": "thelastpickle", // Bintray subject (user or organization)
+        "desc": "Apache Cassandra Reaper snapshot releases",
+        "website_url": "cassandra-reaper.io",
+        "issue_tracker_url": "https://github.com/thelastpickle/cassandra-reaper/issues",
+        "vcs_url": "https://github.com/thelastpickle/cassandra-reaper.git",
+        "github_use_tag_release_notes": false,
+        "github_release_notes_file": "RELEASE.txt",
+        "licenses": ["Apache-2.0"],
+        "labels": ["cassandra", "reaper"],
+        "public_download_numbers": true,
+        "public_stats": true,
+        "attributes": []
+    },
+
+    "version": {
+        "name": "VERSION",
+        "desc": "VERSION",
+        "released": "RELEASEDATE",
+        "vcs_tag": "VERSION",
+        "attributes": [],
+        "gpgSign": false
+    },
+    "files":
+        [
+        {"includePattern": "src/packages/(.*\\.deb)", "uploadPattern": "/$1",
+         "matrixParams": { 
+            "override": 1 ,
+            "deb_distribution": "wheezy,jessie,stretch",
+            "deb_component": "main",
+            "deb_architecture": "i386,amd64"
+            }
+        }
+        ],
+    "publish": true
+}

--- a/src/ci/descriptor-deb.json
+++ b/src/ci/descriptor-deb.json
@@ -1,0 +1,39 @@
+{
+    "package": {
+        "name": "cassandra-reaper", // Bintray package name
+        "repo": "reaper-deb", // Bintray repository name
+        "subject": "thelastpickle", // Bintray subject (user or organization)
+        "desc": "Apache Cassandra Reaper stable releases",
+        "website_url": "cassandra-reaper.io",
+        "issue_tracker_url": "https://github.com/thelastpickle/cassandra-reaper/issues",
+        "vcs_url": "https://github.com/thelastpickle/cassandra-reaper.git",
+        "github_use_tag_release_notes": false,
+        "github_release_notes_file": "RELEASE.txt",
+        "licenses": ["Apache-2.0"],
+        "labels": ["cassandra", "reaper"],
+        "public_download_numbers": true,
+        "public_stats": true,
+        "attributes": []
+    },
+
+    "version": {
+        "name": "VERSION",
+        "desc": "VERSION",
+        "released": "RELEASEDATE",
+        "vcs_tag": "VERSION",
+        "attributes": [],
+        "gpgSign": false
+    },
+    "files":
+        [
+        {"includePattern": "src/packages/(.*\\.deb)", "uploadPattern": "/$1",
+         "matrixParams": { 
+            "override": 1 ,
+            "deb_distribution": "wheezy,jessie,stretch",
+            "deb_component": "main",
+            "deb_architecture": "i386,amd64"
+            }
+        }
+        ],
+    "publish": true
+}

--- a/src/ci/descriptor-rpm-beta.json
+++ b/src/ci/descriptor-rpm-beta.json
@@ -1,0 +1,34 @@
+{
+    "package": {
+        "name": "cassandra-reaper-beta", // Bintray package name
+        "repo": "reaper-rpm-beta", // Bintray repository name
+        "subject": "thelastpickle", // Bintray subject (user or organization)
+        "desc": "Apache Cassandra Reaper snapshot releases",
+        "website_url": "cassandra-reaper.io",
+        "issue_tracker_url": "https://github.com/thelastpickle/cassandra-reaper/issues",
+        "vcs_url": "https://github.com/thelastpickle/cassandra-reaper.git",
+        "github_use_tag_release_notes": false,
+        "github_release_notes_file": "RELEASE.txt",
+        "licenses": ["Apache-2.0"],
+        "labels": ["cassandra", "reaper"],
+        "public_download_numbers": true,
+        "public_stats": true,
+        "attributes": []
+    },
+
+    "version": {
+        "name": "VERSION",
+        "desc": "VERSION",
+        "released": "RELEASEDATE",
+        "vcs_tag": "VERSION",
+        "attributes": [],
+        "gpgSign": false
+    },
+    "files":
+        [
+        {"includePattern": "src/packages/(.*\\.rpm)", "uploadPattern": "/$1",
+         "matrixParams": { "override": 1 }
+        }
+        ],
+    "publish": true
+}

--- a/src/ci/descriptor-rpm.json
+++ b/src/ci/descriptor-rpm.json
@@ -1,0 +1,34 @@
+{
+    "package": {
+        "name": "cassandra-reaper", // Bintray package name
+        "repo": "reaper-rpm", // Bintray repository name
+        "subject": "thelastpickle", // Bintray subject (user or organization)
+        "desc": "Apache Cassandra Reaper stable releases",
+        "website_url": "cassandra-reaper.io",
+        "issue_tracker_url": "https://github.com/thelastpickle/cassandra-reaper/issues",
+        "vcs_url": "https://github.com/thelastpickle/cassandra-reaper.git",
+        "github_use_tag_release_notes": false,
+        "github_release_notes_file": "RELEASE.txt",
+        "licenses": ["Apache-2.0"],
+        "labels": ["cassandra", "reaper"],
+        "public_download_numbers": true,
+        "public_stats": true,
+        "attributes": []
+    },
+
+    "version": {
+        "name": "VERSION",
+        "desc": "VERSION",
+        "released": "RELEASEDATE",
+        "vcs_tag": "VERSION",
+        "attributes": [],
+        "gpgSign": false
+    },
+    "files":
+        [
+        {"includePattern": "src/packages/(.*\\.rpm)", "uploadPattern": "/$1",
+         "matrixParams": { "override": 1 }
+        }
+        ],
+    "publish": true
+}

--- a/src/ci/descriptor-tarball-beta.json
+++ b/src/ci/descriptor-tarball-beta.json
@@ -1,0 +1,34 @@
+{
+    "package": {
+        "name": "cassandra-reaper-beta", // Bintray package name
+        "repo": "reaper-tarball-beta", // Bintray repository name
+        "subject": "thelastpickle", // Bintray subject (user or organization)
+        "desc": "Apache Cassandra Reaper snapshot releases",
+        "website_url": "cassandra-reaper.io",
+        "issue_tracker_url": "https://github.com/thelastpickle/cassandra-reaper/issues",
+        "vcs_url": "https://github.com/thelastpickle/cassandra-reaper.git",
+        "github_use_tag_release_notes": false,
+        "github_release_notes_file": "RELEASE.txt",
+        "licenses": ["Apache-2.0"],
+        "labels": ["cassandra", "reaper"],
+        "public_download_numbers": true,
+        "public_stats": true,
+        "attributes": []
+    },
+
+    "version": {
+        "name": "VERSION",
+        "desc": "VERSION",
+        "released": "RELEASEDATE",
+        "vcs_tag": "VERSION",
+        "attributes": [],
+        "gpgSign": false
+    },
+    "files":
+        [
+        {"includePattern": "src/packages/(.*\\.gz)", "uploadPattern": "/$1",
+         "matrixParams": { "override": 1 }
+        }
+        ],
+    "publish": true
+}

--- a/src/ci/descriptor-tarball.json
+++ b/src/ci/descriptor-tarball.json
@@ -1,0 +1,34 @@
+{
+    "package": {
+        "name": "cassandra-reaper", // Bintray package name
+        "repo": "reaper-tarball", // Bintray repository name
+        "subject": "thelastpickle", // Bintray subject (user or organization)
+        "desc": "Apache Cassandra Reaper stable releases",
+        "website_url": "cassandra-reaper.io",
+        "issue_tracker_url": "https://github.com/thelastpickle/cassandra-reaper/issues",
+        "vcs_url": "https://github.com/thelastpickle/cassandra-reaper.git",
+        "github_use_tag_release_notes": false,
+        "github_release_notes_file": "RELEASE.txt",
+        "licenses": ["Apache-2.0"],
+        "labels": ["cassandra", "reaper"],
+        "public_download_numbers": true,
+        "public_stats": true,
+        "attributes": []
+    },
+
+    "version": {
+        "name": "VERSION",
+        "desc": "VERSION",
+        "released": "RELEASEDATE",
+        "vcs_tag": "VERSION",
+        "attributes": [],
+        "gpgSign": false
+    },
+    "files":
+        [
+        {"includePattern": "src/packages/(.*\\.gz)", "uploadPattern": "/$1",
+         "matrixParams": { "override": 1 }
+        }
+        ],
+    "publish": true
+}

--- a/src/ci/script.sh
+++ b/src/ci/script.sh
@@ -14,8 +14,23 @@ case "${TEST_TYPE}" in
         sleep 30
         ccm status
         ccm node1 nodetool status
+        if [ "${TRAVIS_BRANCH}" = "master" ]
+            then
+                VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
+                DATE=$(date +"%Y%m%d")
+                # Bintray doesn't like snapshots, but accepts betas :)
+                BETA_VERSION=$(echo $VERSION | sed "s/SNAPSHOT/BETA/")
+                mvn versions:set "-DnewVersion=${BETA_VERSION}-${DATE}"
+        fi
+        
+        if [ "x${GRIM_MIN}" = "x" ]
+        then
+            # Rebuild the UI to get the right version number there
+            MAVEN_OPTS="-Xmx1g" mvn clean generate-sources -Pbuild-ui > /dev/null
+        fi
 
         MAVEN_OPTS="-Xmx1g" mvn clean install
+
         if [ "x${GRIM_MIN}" = "x" ]
         then
             mvn surefire:test -Dtest=ReaperIT


### PR DESCRIPTION
Updates to the Travis CI scripts : 
* Tested Cassandra versions are current
* Use the correct sonarcloud URL
* Master builds are packaged as beta releases and pushed to Bintray
* Tagged builds are packaged as stable releases and pushed to Bintray

From now on, it will be possible to install Reaper using yum and apt-get.