### PR TITLE
Fix travis build

### DIFF
--- a/docs/docs/download/index.html
+++ b/docs/docs/download/index.html
@@ -277,12 +277,20 @@
 
 <h1 id="downloads-and-installation">Downloads and Installation</h1>
 
-<p>The current stable version is <a href="https://github.com/thelastpickle/cassandra-reaper/releases/tag/1.0.2">1.0.2</a></p>
+<p>The current stable version can be downloaded in the following packaging formats :</p>
 
 <ul>
-<li><a href="https://github.com/thelastpickle/cassandra-reaper/releases/download/1.0.2/reaper_1.0.2_amd64.deb">Deb Package</a></li>
-<li><a href="https://github.com/thelastpickle/cassandra-reaper/releases/download/1.0.2/reaper-1.0.2-1.x86_64.rpm">RPM</a></li>
-<li><a href="https://github.com/thelastpickle/cassandra-reaper/releases/download/1.0.2/cassandra-reaper-1.0.2-release.tar.gz">Tarball</a></li>
+<li><a href="https://bintray.com/thelastpickle/reaper-deb/cassandra-reaper/_latestVersion"> <img src="https://api.bintray.com/packages/thelastpickle/reaper-deb/cassandra-reaper/images/download.svg" alt="Deb package" /> </a> Deb package</li>
+<li><a href="https://bintray.com/thelastpickle/reaper-rpm/cassandra-reaper/_latestVersion"> <img src="https://api.bintray.com/packages/thelastpickle/reaper-rpm/cassandra-reaper/images/download.svg" alt="RPM" /> </a> RPM</li>
+<li><a href="https://bintray.com/thelastpickle/reaper-tarball/cassandra-reaper/_latestVersion"> <img src="https://api.bintray.com/packages/thelastpickle/reaper-tarball/cassandra-reaper/images/download.svg" alt="Tarball" /> </a> Tarball</li>
+</ul>
+
+<p>The current development version can be downloaded in the following packaging formats :</p>
+
+<ul>
+<li><a href="https://bintray.com/thelastpickle/reaper-deb-beta/cassandra-reaper-beta/_latestVersion"> <img src="https://api.bintray.com/packages/thelastpickle/reaper-deb-beta/cassandra-reaper-beta/images/download.svg" alt="Deb package" /> </a> Deb package</li>
+<li><a href="https://bintray.com/thelastpickle/reaper-rpm-beta/cassandra-reaper-beta/_latestVersion"> <img src="https://api.bintray.com/packages/thelastpickle/reaper-rpm-beta/cassandra-reaper-beta/images/download.svg" alt="RPM" /> </a> RPM</li>
+<li><a href="https://bintray.com/thelastpickle/reaper-tarball-beta/cassandra-reaper-beta/_latestVersion"> <img src="https://api.bintray.com/packages/thelastpickle/reaper-tarball-beta/cassandra-reaper-beta/images/download.svg" alt="Tarball" /> </a> Tarball</li>
 </ul>
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/0dub29BgwPI" frameborder="0" gesture="media" allowfullscreen></iframe>

--- a/docs/docs/download/index.xml
+++ b/docs/docs/download/index.xml
@@ -43,7 +43,7 @@ To build the JAR and other packages which are then placed in the src/packages di
       <description>Running Reaper After modifying the resource/cassandra-reaper.yaml config file, Reaper can be started using the following command line :
 java -jar target/cassandra-reaper-X.X.X.jar server resource/cassandra-reaper.yaml  Once started, the UI can be accessed through : http://127.0.0.1:8080/webui/
 Reaper can also be accessed using the REST API exposed on port 8080, or using the command line tool bin/spreaper
-Installing and Running as a Service We provide prebuilt packages for reaper on the GitHub release page.</description>
+Installing and Running as a Service We provide prebuilt packages for reaper on the Bintray.</description>
     </item>
     
   </channel>

--- a/docs/docs/download/install/index.html
+++ b/docs/docs/download/install/index.html
@@ -292,7 +292,7 @@
 
 <h2 id="installing-and-running-as-a-service">Installing and Running as a Service</h2>
 
-<p>We provide prebuilt packages for reaper on the <a href="https://github.com/thelastpickle/cassandra-reaper/releases">GitHub release page</a>.  We&rsquo;ve linked the recommended versions above for convenience.</p>
+<p>We provide prebuilt packages for reaper on the <a href="https://bintray.com/thelastpickle">Bintray</a>.</p>
 
 <h3 id="rpm-install-centos-fedora-rhek">RPM Install (CentOS, Fedora, RHEK)</h3>
 
@@ -301,11 +301,103 @@
 <pre><code class="language-bash">sudo rpm -ivh reaper-*.*.*.x86_64.rpm
 </code></pre>
 
+<h4 id="using-yum-stable-releases">Using yum (stable releases)</h4>
+
+<p>1/ Run the following to get a generated .repo file:</p>
+
+<pre><code>wget https://bintray.com/thelastpickle/reaper-rpm/rpm -O bintray-thelastpickle-reaper-rpm.repo
+</code></pre>
+
+<p>or - Copy this text into a &lsquo;bintray-thelastpickle-reaper-rpm.repo&rsquo; file on your Linux machine:</p>
+
+<pre><code>#bintraybintray-thelastpickle-reaper-rpm - packages by thelastpickle from Bintray
+[bintraybintray-thelastpickle-reaper-rpm]
+name=bintray-thelastpickle-reaper-rpm
+baseurl=https://dl.bintray.com/thelastpickle/reaper-rpm
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+</code></pre>
+
+<p>2/ Run the following command :</p>
+
+<pre><code>sudo mv bintray-thelastpickle-reaper-rpm.repo /etc/yum.repos.d/
+</code></pre>
+
+<p>3/ Install reaper :</p>
+
+<pre><code>sudo yum install reaper
+</code></pre>
+
+<h4 id="using-yum-development-builds">Using yum (development builds)</h4>
+
+<p>1/ Run the following to get a generated .repo file:</p>
+
+<pre><code>wget https://bintray.com/thelastpickle/reaper-rpm-beta/rpm -O bintray-thelastpickle-reaper-rpm-beta.repo
+</code></pre>
+
+<p>or - Copy this text into a &lsquo;bintray-thelastpickle-reaper-rpm-beta.repo&rsquo; file on your Linux machine:</p>
+
+<pre><code>#bintraybintray-thelastpickle-reaper-rpm-beta - packages by thelastpickle from Bintray
+[bintraybintray-thelastpickle-reaper-rpm-beta]
+name=bintray-thelastpickle-reaper-rpm-beta
+baseurl=https://dl.bintray.com/thelastpickle/reaper-rpm-beta
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+</code></pre>
+
+<p>2/ Run the following command :</p>
+
+<pre><code>sudo mv bintray-thelastpickle-reaper-rpm-beta.repo /etc/yum.repos.d/
+</code></pre>
+
+<p>3/ Install reaper :</p>
+
+<pre><code>sudo yum install reaper
+</code></pre>
+
 <h3 id="deb-debian-based-distros-like-ubuntu">DEB (Debian based distros like Ubuntu)</h3>
 
 <p>After downloading the DEB package, install using the <code>dpkg</code> command:</p>
 
 <pre><code class="language-bash">sudo dpkg -i reaper_*.*.*_amd64.deb
+</code></pre>
+
+<h4 id="using-apt-get-stable-releases">Using apt-get (stable releases)</h4>
+
+<p>1/ Using the command line, add the following to your /etc/apt/sources.list system config file:</p>
+
+<pre><code>echo &quot;deb https://dl.bintray.com/thelastpickle/reaper-deb wheezy main&quot; | sudo tee -a /etc/apt/sources.list
+</code></pre>
+
+<p>Or, add the repository URLs using the &ldquo;Software Sources&rdquo; admin UI:</p>
+
+<pre><code>deb https://dl.bintray.com/thelastpickle/reaper-deb wheezy main
+</code></pre>
+
+<p>2/ Install reaper :</p>
+
+<pre><code>sudo apt-get update
+sudo apt-get install reaper
+</code></pre>
+
+<h4 id="using-apt-get-development-builds">Using apt-get (development builds)</h4>
+
+<p>1/ Using the command line, add the following to your /etc/apt/sources.list system config file:</p>
+
+<pre><code>echo &quot;deb https://dl.bintray.com/thelastpickle/reaper-deb-beta wheezy main&quot; | sudo tee -a /etc/apt/sources.list
+</code></pre>
+
+<p>Or, add the repository URLs using the &ldquo;Software Sources&rdquo; admin UI:</p>
+
+<pre><code>deb https://dl.bintray.com/thelastpickle/reaper-deb-beta wheezy main
+</code></pre>
+
+<p>2/ Install reaper :</p>
+
+<pre><code>sudo apt-get update
+sudo apt-get install reaper
 </code></pre>
 
 <h2 id="service-configuration">Service Configuration</h2>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -139,7 +139,7 @@ To build the JAR and other packages which are then placed in the src/packages di
       <description>Running Reaper After modifying the resource/cassandra-reaper.yaml config file, Reaper can be started using the following command line :
 java -jar target/cassandra-reaper-X.X.X.jar server resource/cassandra-reaper.yaml  Once started, the UI can be accessed through : http://127.0.0.1:8080/webui/
 Reaper can also be accessed using the REST API exposed on port 8080, or using the command line tool bin/spreaper
-Installing and Running as a Service We provide prebuilt packages for reaper on the GitHub release page.</description>
+Installing and Running as a Service We provide prebuilt packages for reaper on the Bintray.</description>
     </item>
     
     <item>

--- a/src/docs/content/docs/download/_index.md
+++ b/src/docs/content/docs/download/_index.md
@@ -8,12 +8,18 @@ identifier = "download"
 
 # Downloads and Installation
 
-The current stable version is [1.0.2](https://github.com/thelastpickle/cassandra-reaper/releases/tag/1.0.2)
+The current stable version can be downloaded in the following packaging formats : 
 
-* [Deb Package](https://github.com/thelastpickle/cassandra-reaper/releases/download/1.0.2/reaper_1.0.2_amd64.deb)
-* [RPM](https://github.com/thelastpickle/cassandra-reaper/releases/download/1.0.2/reaper-1.0.2-1.x86_64.rpm)
-* [Tarball](https://github.com/thelastpickle/cassandra-reaper/releases/download/1.0.2/cassandra-reaper-1.0.2-release.tar.gz)
+* [ ![Deb package](https://api.bintray.com/packages/thelastpickle/reaper-deb/cassandra-reaper/images/download.svg) ](https://bintray.com/thelastpickle/reaper-deb/cassandra-reaper/_latestVersion) Deb package
+* [ ![RPM](https://api.bintray.com/packages/thelastpickle/reaper-rpm/cassandra-reaper/images/download.svg) ](https://bintray.com/thelastpickle/reaper-rpm/cassandra-reaper/_latestVersion) RPM
+* [ ![Tarball](https://api.bintray.com/packages/thelastpickle/reaper-tarball/cassandra-reaper/images/download.svg) ](https://bintray.com/thelastpickle/reaper-tarball/cassandra-reaper/_latestVersion) Tarball
 
+
+The current development version can be downloaded in the following packaging formats : 
+
+* [ ![Deb package](https://api.bintray.com/packages/thelastpickle/reaper-deb-beta/cassandra-reaper-beta/images/download.svg) ](https://bintray.com/thelastpickle/reaper-deb-beta/cassandra-reaper-beta/_latestVersion) Deb package
+* [ ![RPM](https://api.bintray.com/packages/thelastpickle/reaper-rpm-beta/cassandra-reaper-beta/images/download.svg) ](https://bintray.com/thelastpickle/reaper-rpm-beta/cassandra-reaper-beta/_latestVersion) RPM
+* [ ![Tarball](https://api.bintray.com/packages/thelastpickle/reaper-tarball-beta/cassandra-reaper-beta/images/download.svg) ](https://bintray.com/thelastpickle/reaper-tarball-beta/cassandra-reaper-beta/_latestVersion) Tarball
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/0dub29BgwPI" frameborder="0" gesture="media" allowfullscreen></iframe>
 

--- a/src/docs/content/docs/download/install.md
+++ b/src/docs/content/docs/download/install.md
@@ -23,7 +23,7 @@ Reaper can also be accessed using the REST API exposed on port 8080, or using th
 
 ## Installing and Running as a Service
 
-We provide prebuilt packages for reaper on the [GitHub release page](https://github.com/thelastpickle/cassandra-reaper/releases).  We've linked the recommended versions above for convenience.
+We provide prebuilt packages for reaper on the [Bintray](https://bintray.com/thelastpickle).
 
 
 ### RPM Install (CentOS, Fedora, RHEK)
@@ -34,6 +34,67 @@ Grab the RPM from GitHub and install using the `rpm` command:
 sudo rpm -ivh reaper-*.*.*.x86_64.rpm
 ```
 
+#### Using yum (stable releases)
+
+1/ Run the following to get a generated .repo file:
+```
+wget https://bintray.com/thelastpickle/reaper-rpm/rpm -O bintray-thelastpickle-reaper-rpm.repo
+```
+
+or - Copy this text into a 'bintray-thelastpickle-reaper-rpm.repo' file on your Linux machine:
+
+```
+#bintraybintray-thelastpickle-reaper-rpm - packages by thelastpickle from Bintray
+[bintraybintray-thelastpickle-reaper-rpm]
+name=bintray-thelastpickle-reaper-rpm
+baseurl=https://dl.bintray.com/thelastpickle/reaper-rpm
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+``` 
+
+2/ Run the following command : 
+```
+sudo mv bintray-thelastpickle-reaper-rpm.repo /etc/yum.repos.d/
+```
+
+3/ Install reaper : 
+
+```
+sudo yum install reaper
+```
+
+#### Using yum (development builds)
+
+1/ Run the following to get a generated .repo file:
+```
+wget https://bintray.com/thelastpickle/reaper-rpm-beta/rpm -O bintray-thelastpickle-reaper-rpm-beta.repo
+```
+
+or - Copy this text into a 'bintray-thelastpickle-reaper-rpm-beta.repo' file on your Linux machine:
+
+```
+#bintraybintray-thelastpickle-reaper-rpm-beta - packages by thelastpickle from Bintray
+[bintraybintray-thelastpickle-reaper-rpm-beta]
+name=bintray-thelastpickle-reaper-rpm-beta
+baseurl=https://dl.bintray.com/thelastpickle/reaper-rpm-beta
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+```  
+
+2/ Run the following command : 
+```
+sudo mv bintray-thelastpickle-reaper-rpm-beta.repo /etc/yum.repos.d/
+```
+
+3/ Install reaper : 
+
+```
+sudo yum install reaper
+```
+
+
 ### DEB (Debian based distros like Ubuntu)
 
 After downloading the DEB package, install using the `dpkg` command: 
@@ -41,6 +102,47 @@ After downloading the DEB package, install using the `dpkg` command:
 ```bash
 sudo dpkg -i reaper_*.*.*_amd64.deb
 ```
+
+#### Using apt-get (stable releases)
+
+1/ Using the command line, add the following to your /etc/apt/sources.list system config file: 
+```
+echo "deb https://dl.bintray.com/thelastpickle/reaper-deb wheezy main" | sudo tee -a /etc/apt/sources.list
+```
+
+Or, add the repository URLs using the "Software Sources" admin UI:
+
+```
+deb https://dl.bintray.com/thelastpickle/reaper-deb wheezy main
+```
+
+2/ Install reaper :
+
+```
+sudo apt-get update
+sudo apt-get install reaper
+```
+
+#### Using apt-get (development builds)
+
+1/ Using the command line, add the following to your /etc/apt/sources.list system config file:
+```
+echo "deb https://dl.bintray.com/thelastpickle/reaper-deb-beta wheezy main" | sudo tee -a /etc/apt/sources.list
+```
+
+Or, add the repository URLs using the "Software Sources" admin UI:
+
+```
+deb https://dl.bintray.com/thelastpickle/reaper-deb-beta wheezy main
+```
+
+2/ Install reaper :
+
+```
+sudo apt-get update
+sudo apt-get install reaper
+```
+
 
 ## Service Configuration
 


### PR DESCRIPTION
Fix Travis build when creating deb/rpm packages.
Docker based build stopped working on Travis so fall back to running fpm commands.

Updated the docs to point to Bintray for releases.