### PR TITLE
Switch to re-usable JMX connections instead of re-creating one each time it's needed

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionsInitializer.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionsInitializer.java
@@ -64,8 +64,13 @@ public final class JmxConnectionsInitializer implements AutoCloseable {
 
   private Callable<Optional<String>> connectToJmx(List<String> endpoints) {
     return () -> {
-      try (JmxProxy jmxProxy = context.jmxConnectionFactory
-              .connectAny(Optional.absent(), endpoints, (int) JmxProxy.DEFAULT_JMX_CONNECTION_TIMEOUT.getSeconds())) {
+      try {
+
+        JmxProxy jmxProxy =
+            context.jmxConnectionFactory.connectAny(
+                Optional.absent(),
+                endpoints,
+                (int) JmxProxy.DEFAULT_JMX_CONNECTION_TIMEOUT.getSeconds());
 
         return Optional.of(endpoints.get(0));
 

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.management.AttributeNotFoundException;
 import javax.management.MBeanException;
 import javax.management.NotificationListener;
@@ -32,7 +33,7 @@ import javax.validation.constraints.NotNull;
 import org.apache.cassandra.repair.RepairParallelism;
 
 
-public interface JmxProxy extends AutoCloseable, NotificationListener {
+public interface JmxProxy extends NotificationListener {
 
   Duration DEFAULT_JMX_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
 
@@ -111,9 +112,9 @@ public interface JmxProxy extends AutoCloseable, NotificationListener {
   List<String> tokenRangeToEndpoint(String keyspace, RingRange tokenRange);
 
   /**
-   * Triggers a repair of range (beginToken, endToken] for given keyspace and column family. The repair is triggered by
-   * {@link org.apache.cassandra.service.StorageServiceMBean#forceRepairRangeAsync} For time being, we don't allow local
-   * nor snapshot repairs.
+   * Triggers a repair of range (beginToken, endToken] for given keyspace and column family. The
+   * repair is triggered by {@link org.apache.cassandra.service.StorageServiceMBean#forceRepairRangeAsync}
+   * For time being, we don't allow local nor snapshot repairs.
    *
    * @return Repair command number, or 0 if nothing to repair
    */
@@ -124,9 +125,12 @@ public interface JmxProxy extends AutoCloseable, NotificationListener {
       RepairParallelism repairParallelism,
       Collection<String> columnFamilies,
       boolean fullRepair,
-      Collection<String> datacenters) throws ReaperException;
+      Collection<String> datacenters,
+      RepairStatusHandler repairStatusHandler)
+      throws ReaperException;
 
-  @Override
   void close();
+
+  void removeRepairStatusHandler(int commandId);
 
 }

--- a/src/server/src/main/java/io/cassandrareaper/jmx/RepairStatusHandler.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/RepairStatusHandler.java
@@ -24,8 +24,8 @@ public interface RepairStatusHandler {
   /**
    * Handle an event representing a change in the state of a running repair.
    *
-   * <p>
-   * Implementation of this method is intended to persist the repair state change in Reaper's state.
+   * <p>Implementation of this method is intended to persist the repair state change in Reaper's
+   * state.
    *
    * @param repairNumber repair sequence number, obtained when triggering a repair
    * @param status new status of the repair (old API)
@@ -36,5 +36,6 @@ public interface RepairStatusHandler {
       int repairNumber,
       Optional<ActiveRepairService.Status> status,
       Optional<ProgressEventType> progress,
-      String message);
+      String message,
+      JmxProxy jmxProxy);
 }

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -134,8 +134,10 @@ public final class ClusterRepairScheduler {
   }
 
   private boolean keyspaceHasNoTable(AppContext context, Cluster cluster, String keyspace) {
-    try (JmxProxy jmxProxy
-        = context.jmxConnectionFactory.connectAny(cluster, context.config.getJmxConnectionTimeoutInSeconds())) {
+    try {
+      JmxProxy jmxProxy =
+          context.jmxConnectionFactory.connectAny(
+              cluster, context.config.getJmxConnectionTimeoutInSeconds());
 
       Set<String> tables = jmxProxy.getTableNamesForKeyspace(keyspace);
       return tables.isEmpty();
@@ -186,16 +188,16 @@ public final class ClusterRepairScheduler {
     }
 
     private Set<String> keyspacesInCluster(AppContext context, Cluster cluster) throws ReaperException {
-      try (JmxProxy jmxProxy
-          = context.jmxConnectionFactory.connectAny(cluster, context.config.getJmxConnectionTimeoutInSeconds())) {
-        List<String> keyspaces = jmxProxy.getKeyspaces();
-        if (keyspaces.isEmpty()) {
-          String message = format("No keyspace found in cluster %s", cluster.getName());
-          LOG.debug(message);
-          throw new IllegalArgumentException(message);
-        }
-        return Sets.newHashSet(keyspaces);
+      JmxProxy jmxProxy =
+          context.jmxConnectionFactory.connectAny(
+              cluster, context.config.getJmxConnectionTimeoutInSeconds());
+      List<String> keyspaces = jmxProxy.getKeyspaces();
+      if (keyspaces.isEmpty()) {
+        String message = format("No keyspace found in cluster %s", cluster.getName());
+        LOG.debug(message);
+        throw new IllegalArgumentException(message);
       }
+      return Sets.newHashSet(keyspaces);
     }
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/service/Heart.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/Heart.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+
 import javax.management.JMException;
 
 import com.codahale.metrics.Gauge;
@@ -114,9 +115,8 @@ final class Heart implements AutoCloseable {
 
                         LOG.info("Got metric request for node {} in {}", req.getNode(), req.getCluster());
                         try (Timer.Context t1 = timer(context, req.getCluster(), req.getNode())) {
-
-                          try (JmxProxy nodeProxy
-                              = context.jmxConnectionFactory.connect(req.getNode(), jmxTimeoutSeconds)) {
+                          try {
+                            JmxProxy nodeProxy = context.jmxConnectionFactory.connect(req.getNode(), jmxTimeoutSeconds);
 
                             storage.storeNodeMetrics(
                                 runId,

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -194,8 +194,11 @@ public final class RepairManager {
         // refresh segment once we're inside leader-election
         segment = context.storage.getRepairSegment(repairRun.getId(), segment.getId()).get();
         if (RepairSegment.State.RUNNING == segment.getState()) {
-          try (JmxProxy jmxProxy = context.jmxConnectionFactory.connect(
-              segment.getCoordinatorHost(), context.config.getJmxConnectionTimeoutInSeconds())) {
+          try {
+            JmxProxy jmxProxy =
+                context.jmxConnectionFactory.connect(
+                    segment.getCoordinatorHost(),
+                    context.config.getJmxConnectionTimeoutInSeconds());
             LOG.warn(
                 "Aborting stuck segment {} in repair run {}", segment.getId(), repairRun.getId());
             if (postponeWithoutAborting) {

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -145,8 +145,10 @@ public final class RepairRunService {
       throw new ReaperException(errMsg);
     }
 
-    try (JmxProxy jmxProxy = context.jmxConnectionFactory
-        .connectAny(Optional.absent(), seedHosts, context.config.getJmxConnectionTimeoutInSeconds())) {
+    try {
+      JmxProxy jmxProxy =
+          context.jmxConnectionFactory.connectAny(
+              Optional.absent(), seedHosts, context.config.getJmxConnectionTimeoutInSeconds());
 
       List<BigInteger> tokens = jmxProxy.getTokens();
       Map<List<String>, List<String>> rangeToEndpoint = jmxProxy.getRangeToEndpointMap(repairUnit.getKeyspaceName());
@@ -291,8 +293,10 @@ public final class RepairRunService {
 
     Map<List<String>, List<String>> rangeToEndpoint = Maps.newHashMap();
 
-    try (JmxProxy jmxProxy = context.jmxConnectionFactory
-        .connectAny(Optional.absent(), seedHosts, context.config.getJmxConnectionTimeoutInSeconds())) {
+    try {
+      JmxProxy jmxProxy =
+          context.jmxConnectionFactory.connectAny(
+              Optional.absent(), seedHosts, context.config.getJmxConnectionTimeoutInSeconds());
 
       rangeToEndpoint = jmxProxy.getRangeToEndpointMap(repairUnit.getKeyspaceName());
     } catch (ReaperException e) {
@@ -315,15 +319,17 @@ public final class RepairRunService {
       Optional<String> tableNamesParam) throws ReaperException {
 
     Set<String> knownTables;
-    try (JmxProxy jmxProxy = context.jmxConnectionFactory
-        .connectAny(cluster, context.config.getJmxConnectionTimeoutInSeconds())) {
 
-      knownTables = jmxProxy.getTableNamesForKeyspace(keyspace);
-      if (knownTables.isEmpty()) {
-        LOG.debug("no known tables for keyspace {} in cluster {}", keyspace, cluster.getName());
-        throw new IllegalArgumentException("no column families found for keyspace");
-      }
+    JmxProxy jmxProxy =
+        context.jmxConnectionFactory.connectAny(
+            cluster, context.config.getJmxConnectionTimeoutInSeconds());
+
+    knownTables = jmxProxy.getTableNamesForKeyspace(keyspace);
+    if (knownTables.isEmpty()) {
+      LOG.debug("no known tables for keyspace {} in cluster {}", keyspace, cluster.getName());
+      throw new IllegalArgumentException("no column families found for keyspace");
     }
+
     Set<String> tableNames = Collections.emptySet();
     if (tableNamesParam.isPresent() && !tableNamesParam.get().isEmpty()) {
       tableNames = Sets.newHashSet(COMMA_SEPARATED_LIST_SPLITTER.split(tableNamesParam.get()));
@@ -341,15 +347,17 @@ public final class RepairRunService {
       Optional<String> nodesToRepairParam) throws ReaperException {
 
     Set<String> nodesInCluster;
-    try (JmxProxy jmxProxy
-        = context.jmxConnectionFactory.connectAny(cluster, context.config.getJmxConnectionTimeoutInSeconds())) {
 
-      nodesInCluster = jmxProxy.getEndpointToHostId().keySet();
-      if (nodesInCluster.isEmpty()) {
-        LOG.debug("no nodes found in cluster {}", cluster.getName());
-        throw new IllegalArgumentException("no nodes found in cluster");
-      }
+    JmxProxy jmxProxy =
+        context.jmxConnectionFactory.connectAny(
+            cluster, context.config.getJmxConnectionTimeoutInSeconds());
+
+    nodesInCluster = jmxProxy.getEndpointToHostId().keySet();
+    if (nodesInCluster.isEmpty()) {
+      LOG.debug("no nodes found in cluster {}", cluster.getName());
+      throw new IllegalArgumentException("no nodes found in cluster");
     }
+
     Set<String> nodesToRepair = Collections.emptySet();
     if (nodesToRepairParam.isPresent() && !nodesToRepairParam.get().isEmpty()) {
       nodesToRepair = Sets.newHashSet(COMMA_SEPARATED_LIST_SPLITTER.split(nodesToRepairParam.get()));

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -496,10 +496,6 @@ final class RepairRunner implements Runnable {
 
   void killAndCleanupRunner() {
     context.repairManager.removeRunner(this);
-    if (jmxConnection != null) {
-      jmxConnection.close();
-      jmxConnection = null;
-    }
     Thread.currentThread().interrupt();
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairUnitService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairUnitService.java
@@ -60,11 +60,12 @@ public final class RepairUnitService {
 
     Optional<String> cassandraVersion = Optional.absent();
 
-    try (JmxProxy jmxProxy = context.jmxConnectionFactory
-        .connectAny(
-            Optional.absent(),
-            cluster.getSeedHosts(),
-            context.config.getJmxConnectionTimeoutInSeconds())) {
+    try {
+      JmxProxy jmxProxy =
+          context.jmxConnectionFactory.connectAny(
+              Optional.absent(),
+              cluster.getSeedHosts(),
+              context.config.getJmxConnectionTimeoutInSeconds());
 
       cassandraVersion = Optional.fromNullable(jmxProxy.getCassandraVersion());
     } catch (ReaperException e) {

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -121,8 +121,15 @@ public final class RepairRunResourceTest {
     when(proxy.tokenRangeToEndpoint(anyString(), any(RingRange.class))).thenReturn(
         Collections.singletonList(""));
     when(proxy.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
-    when(proxy.triggerRepair(any(BigInteger.class), any(BigInteger.class), anyString(),
-        any(RepairParallelism.class), anyCollectionOf(String.class), anyBoolean(), anyCollectionOf(String.class)))
+    when(proxy.triggerRepair(
+            any(BigInteger.class),
+            any(BigInteger.class),
+            anyString(),
+            any(RepairParallelism.class),
+            anyCollectionOf(String.class),
+            anyBoolean(),
+            anyCollectionOf(String.class),
+            any()))
         .thenReturn(1);
 
     context.jmxConnectionFactory = new JmxConnectionFactory() {

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -109,6 +109,7 @@ public final class SegmentRunnerTest {
               any(RepairParallelism.class),
               any(),
               anyBoolean(),
+              any(),
               any()))
             .then((invocation) -> {
 
@@ -123,7 +124,8 @@ public final class SegmentRunnerTest {
                       1,
                       Optional.of(ActiveRepairService.Status.STARTED),
                       Optional.absent(),
-                      "Repair command 1 has started");
+                      "Repair command 1 has started",
+                      jmx);
 
                   assertEquals(
                       RepairSegment.State.RUNNING,
@@ -206,6 +208,7 @@ public final class SegmentRunnerTest {
               any(RepairParallelism.class),
               any(),
               anyBoolean(),
+              any(),
               any()))
             .then(invocation -> {
 
@@ -219,7 +222,8 @@ public final class SegmentRunnerTest {
                     1,
                     Optional.of(ActiveRepairService.Status.STARTED),
                     Optional.absent(),
-                    "Repair command 1 has started");
+                    "Repair command 1 has started",
+                    jmx);
 
                 assertEquals(RepairSegment.State.RUNNING, storage.getRepairSegment(runId, segmentId).get().getState());
                 // report about an unrelated repair. Shouldn't affect anything.
@@ -227,13 +231,15 @@ public final class SegmentRunnerTest {
                     2,
                     Optional.of(ActiveRepairService.Status.SESSION_FAILED),
                     Optional.absent(),
-                    "Repair command 2 has failed");
+                    "Repair command 2 has failed",
+                    jmx);
 
                 handler.get().handle(
                     1,
                     Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
                     Optional.absent(),
-                    "Repair session succeeded in command 1");
+                    "Repair session succeeded in command 1",
+                    jmx);
 
                 assertEquals(RepairSegment.State.DONE, storage.getRepairSegment(runId, segmentId).get().getState());
 
@@ -241,7 +247,8 @@ public final class SegmentRunnerTest {
                     1,
                     Optional.of(ActiveRepairService.Status.FINISHED),
                     Optional.absent(),
-                    "Repair command 1 has finished");
+                    "Repair command 1 has finished",
+                    jmx);
 
                 assertEquals(RepairSegment.State.DONE, storage.getRepairSegment(runId, segmentId).get().getState());
               }));
@@ -321,6 +328,7 @@ public final class SegmentRunnerTest {
               any(RepairParallelism.class),
               any(),
               anyBoolean(),
+              any(),
               any()))
             .then((invocation) -> {
 
@@ -334,7 +342,8 @@ public final class SegmentRunnerTest {
                     1,
                     Optional.of(ActiveRepairService.Status.STARTED),
                     Optional.absent(),
-                    "Repair command 1 has started");
+                    "Repair command 1 has started",
+                    jmx);
 
                 assertEquals(RepairSegment.State.RUNNING, storage.getRepairSegment(runId, segmentId).get().getState());
 
@@ -342,7 +351,8 @@ public final class SegmentRunnerTest {
                     1,
                     Optional.of(ActiveRepairService.Status.SESSION_FAILED),
                     Optional.absent(),
-                    "Repair command 1 has failed");
+                    "Repair command 1 has failed",
+                    jmx);
 
                 assertEquals(
                     RepairSegment.State.NOT_STARTED,
@@ -352,7 +362,8 @@ public final class SegmentRunnerTest {
                     1,
                     Optional.of(ActiveRepairService.Status.FINISHED),
                     Optional.absent(),
-                    "Repair command 1 has finished");
+                    "Repair command 1 has finished",
+                    jmx);
 
                 assertEquals(
                     RepairSegment.State.NOT_STARTED,

--- a/src/ui/app/jsx/mixin.jsx
+++ b/src/ui/app/jsx/mixin.jsx
@@ -46,7 +46,7 @@ export const StatusUpdateMixin = {
     if(state == 'ACTIVE' || state == 'RUNNING') {
       toStatus = 'PAUSED';
     } else if(state == 'PAUSED' || state == 'NOT_STARTED') {
-      if(this.props.row.scheduled_days_between) {
+      if(this.props.row.next_activation) {
         toStatus = 'ACTIVE'; // repair schedule
       } else {
         toStatus = 'RUNNING'; // repair run


### PR DESCRIPTION
Reaper is currently leaking threads even though the JmxProxy object implements AutoCloseable
and all connections "seem" to be closed appropriately.
The fact that a new JMX connection is created for each segment and each time Reaper needs one
is a waste of resource though and opens up the possibility of leaks.
This new implementation involves re-uses JMX connections and ties SegmentRunners with JmxProxy objects
to properly handle async repair status notifications.

Thread usage before the patch : 
![capture d ecran 2018-02-13 a 20 21 06](https://user-images.githubusercontent.com/5096002/36173507-9087efb2-1109-11e8-8fbb-94eb6c24e8a9.png)

And after the patch : 
![capture d ecran 2018-02-13 a 20 20 47](https://user-images.githubusercontent.com/5096002/36173513-967d78e2-1109-11e8-9124-b08377bbc48d.png)
