### PR TITLE
Remove unnecessary postpones and randomize next segment in postgres

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -131,23 +131,26 @@ public interface IStoragePostgreSql {
       + "JOIN repair_run ON run_id = repair_run.id "
       + "JOIN repair_unit ON repair_run.repair_unit_id = repair_unit.id "
       + "WHERE repair_segment.state = 1 AND repair_unit.cluster_name = :clusterName";
-  String SQL_GET_NEXT_FREE_REPAIR_SEGMENT = "SELECT "
-      + SQL_REPAIR_SEGMENT_ALL_FIELDS
-      + " FROM repair_segment WHERE run_id = :runId "
-      + "AND state = 0 ORDER BY fail_count ASC, start_token ASC LIMIT 1";
-  String SQL_GET_NEXT_FREE_REPAIR_SEGMENT_IN_NON_WRAPPING_RANGE = "SELECT "
-      + SQL_REPAIR_SEGMENT_ALL_FIELDS
-      + " FROM repair_segment WHERE "
-      + "run_id = :runId AND state = 0 AND start_token < end_token AND "
-      + "(start_token >= :startToken AND end_token <= :endToken) "
-      + "ORDER BY fail_count ASC, start_token ASC LIMIT 1";
-  String SQL_GET_NEXT_FREE_REPAIR_SEGMENT_IN_WRAPPING_RANGE = "SELECT "
-      + SQL_REPAIR_SEGMENT_ALL_FIELDS
-      + " FROM repair_segment WHERE "
-      + "run_id = :runId AND state = 0 AND "
-      + "((start_token < end_token AND (start_token >= :startToken OR end_token <= :endToken)) OR "
-      + "(start_token >= :startToken AND end_token <= :endToken)) "
-      + "ORDER BY fail_count ASC, start_token ASC LIMIT 1";
+  String SQL_GET_NEXT_FREE_REPAIR_SEGMENT =
+      "SELECT "
+          + SQL_REPAIR_SEGMENT_ALL_FIELDS
+          + " FROM repair_segment WHERE run_id = :runId "
+          + "AND state = 0 ORDER BY random() LIMIT 1";
+  String SQL_GET_NEXT_FREE_REPAIR_SEGMENT_IN_NON_WRAPPING_RANGE =
+      "SELECT "
+          + SQL_REPAIR_SEGMENT_ALL_FIELDS
+          + " FROM repair_segment WHERE "
+          + "run_id = :runId AND state = 0 AND start_token < end_token AND "
+          + "(start_token >= :startToken AND end_token <= :endToken) "
+          + "ORDER BY random() LIMIT 1";
+  String SQL_GET_NEXT_FREE_REPAIR_SEGMENT_IN_WRAPPING_RANGE =
+      "SELECT "
+          + SQL_REPAIR_SEGMENT_ALL_FIELDS
+          + " FROM repair_segment WHERE "
+          + "run_id = :runId AND state = 0 AND "
+          + "((start_token < end_token AND (start_token >= :startToken OR end_token <= :endToken)) OR "
+          + "(start_token >= :startToken AND end_token <= :endToken)) "
+          + "ORDER BY random() LIMIT 1";
   String SQL_DELETE_REPAIR_SEGMENTS_FOR_RUN = "DELETE FROM repair_segment WHERE run_id = :runId";
 
   // RepairSchedule


### PR DESCRIPTION
Postpone is not necessary when a segment is denied to run by `canRepair()`.
I've added randomization when picking the next segment with the postgres backend to avoid cycling on the same one all the time, which is already what we did with Cassandra.

I know for a fact that there are some exceptions we do not catch which can lead to a segment runner ending up stuck in `SEGMENT_RUNNERS`. I've added a catch for `RuntimeException` so that we don't miss them and clean up the map correctly.
I've also changed the two step check/add to `SEGMENT_RUNNER` that was done with `.contains()` then `.put()` with a single `.putIfAbsent()` operation.

This way, we will only increment the fail count for segments that actually fail during repair and we will prevent the creation of loads of tombstones in the Cassandra backend.