### PR TITLE
Fix `spreaper resume-run`, `spreaper pause-run`, `spreaper abort-run`

### DIFF
--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -518,7 +518,7 @@ class ReaperCLI(object):
         printq("# Repair run with id={0} created".format(repair_run.get('id')))
         if not args.dont_start_repair:
             printq("# Starting repair run with id={0}".format(repair_run.get('id')))
-            reply = reaper.put("repair_run/{0}".format(repair_run.get('id')), state="RUNNING")
+            reply = reaper.put("repair_run/{0}/state/{1}".format(repair_run.get('id'), "RUNNING"))
             repair_run = json.loads(reply)
             print json.dumps(repair_run, indent=2, sort_keys=True)
 
@@ -582,7 +582,7 @@ class ReaperCLI(object):
             extra_arguments=_arguments_for_resume_repair
         )
         printq("# Resuming a repair run with id: {0}".format(args.run_id))
-        reaper.put("repair_run/{0}".format(args.run_id), state="RUNNING")
+        reaper.put("repair_run/{0}/state/{1}".format(args.run_id, "RUNNING"))
         printq("# Run '{0}' resumed".format(args.run_id))
 
     def pause_repair(self):
@@ -592,7 +592,7 @@ class ReaperCLI(object):
             extra_arguments=_arguments_for_pause_repair
         )
         printq("# Pausing a repair run with id: {0}".format(args.run_id))
-        reaper.put("repair_run/{0}".format(args.run_id), state="PAUSED")
+        reaper.put("repair_run/{0}/state/{1}".format(args.run_id, "PAUSED"))
         printq("# Repair run '{0}' paused".format(args.run_id))
 
     def abort_repair(self):
@@ -602,7 +602,7 @@ class ReaperCLI(object):
             extra_arguments=_arguments_for_abort_repair
         )
         printq("# Aborting a repair run with id: {0}".format(args.run_id))
-        reaper.put("repair_run/{0}".format(args.run_id), state="ABORTED")
+        reaper.put("repair_run/{0}/state/{1}".format(args.run_id, "ABORTED"))
         printq("# Repair run '{0}' aborted".format(args.run_id))
 
     def abort_segment(self):

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -322,8 +322,8 @@ public final class RepairRunResource {
    *
    * <p>Currently supports NOT_STARTED|PAUSED to RUNNING and RUNNING to PAUSED.
    *
-   * @return OK if all goes well NOT_MODIFIED if new state is the same as the old one, and 501
-   *     (NOT_IMPLEMENTED) if transition is not supported.
+   * @return OK if all goes well NOT_MODIFIED if new state is the same as the old one, and 409
+   *     (CONFLICT) if transition is not supported.
    */
   @PUT
   @Path("/{id}/state/{state}")
@@ -384,12 +384,10 @@ public final class RepairRunResource {
   }
 
   /**
-   * Modifies a state of the repair run.
+   * Modifies the intensity of the repair run.
    *
-   * <p>Currently supports NOT_STARTED|PAUSED to RUNNING and RUNNING to PAUSED.
-   *
-   * @return OK if all goes well NOT_MODIFIED if new state is the same as the old one, and 501
-   *     (NOT_IMPLEMENTED) if transition is not supported.
+   * @return OK if all goes well NOT_MODIFIED if new state is the same as the old one, and 409
+   *     (CONFLICT) if transition is not supported.
    */
   @PUT
   @Path("/{id}/intensity/{intensity}")
@@ -418,7 +416,7 @@ public final class RepairRunResource {
         return Response.status(Response.Status.NOT_FOUND).entity(errMsg).build();
       }
 
-      if (RunState.PAUSED != repairRun.get().getRunState()) {
+      if (RunState.PAUSED != repairRun.get().getRunState() && RunState.NOT_STARTED != repairRun.get().getRunState()) {
         return Response.status(Status.CONFLICT).entity("repair run must first be paused").build();
       }
 
@@ -668,7 +666,10 @@ public final class RepairRunResource {
     }
   }
 
-  private List<RepairRunStatus> getRunStatuses(Collection<RepairRun> runs, Set desiredStates) throws ReaperException {
+  private List<RepairRunStatus> getRunStatuses(
+      Collection<RepairRun> runs,
+      Set<String> desiredStates) throws ReaperException {
+
     final List<RepairRunStatus> runStatuses = Lists.newArrayList();
     for (final RepairRun run : runs) {
       if (!desiredStates.isEmpty() && !desiredStates.contains(run.getRunState().name())) {


### PR DESCRIPTION
Fix `spreaper resume-run`, `spreaper pause-run`, `spreaper abort-run`.

All were broken since: 6f71b67 – Implemented PUT method for change intensity
 as the existing endpoint was changed to return a redirect to a new url.
 The spreaper python script was handling the redirect, but maintaining the PUT http method over onto the new url.

The fix was to get spreaper to use the new endpoints, avoiding the redirect.
The commit also
 - fixes the modifyRunIntensity endpoint (that was introduced in 6f71b67) so that it can be used when the repair run is in NOT_STARTED state, as well as PAUSED state, and
 - correct some of the apidoc in RepairRunResource.