### PR TITLE
Update the list of nodes for a cluster at the start of each repair run.

### DIFF
--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -292,22 +292,27 @@ public final class BasicSteps {
     synchronized (BasicSteps.class) {
       final StringBuffer responseData = new StringBuffer();
 
-      RUNNERS.parallelStream().forEach(runner -> {
-        Map<String, String> params = Maps.newHashMap();
-        params.put("seedHost", TestContext.SEED_HOST);
-        Response response = runner.callReaper("POST", "/cluster", Optional.of(params));
+      RUNNERS
+          .parallelStream()
+          .forEach(
+              runner -> {
+                Map<String, String> params = Maps.newHashMap();
+                params.put("seedHost", TestContext.SEED_HOST);
+                Response response = runner.callReaper("POST", "/cluster", Optional.of(params));
 
-        Assertions.assertThat(ImmutableList.of(
-              Response.Status.CREATED.getStatusCode(),
-              Response.Status.FORBIDDEN.getStatusCode()))
-            .contains(response.getStatus());
+                Assertions.assertThat(
+                        ImmutableList.of(
+                            Response.Status.CREATED.getStatusCode(),
+                            Response.Status.NOT_MODIFIED.getStatusCode()))
+                    .contains(response.getStatus());
 
-        if (Response.Status.CREATED.getStatusCode() == response.getStatus()) {
-          responseData.append(response.readEntity(String.class));
-          Map<String, Object> cluster = SimpleReaperClient.parseClusterStatusJSON(responseData.toString());
-          TestContext.TEST_CLUSTER = (String) cluster.get("name");
-        }
-      });
+                if (Response.Status.CREATED.getStatusCode() == response.getStatus()) {
+                  responseData.append(response.readEntity(String.class));
+                  Map<String, Object> cluster =
+                      SimpleReaperClient.parseClusterStatusJSON(responseData.toString());
+                  TestContext.TEST_CLUSTER = (String) cluster.get("name");
+                }
+              });
 
       Assertions.assertThat(responseData).isNotEmpty();
 

--- a/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
@@ -35,6 +35,7 @@ import javax.ws.rs.core.UriInfo;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -87,10 +88,9 @@ public final class ClusterResourceTest {
 
     ClusterResource clusterResource = new ClusterResource(mocks.context);
     Response response = clusterResource.addCluster(mocks.uriInfo, Optional.of(SEED_HOST));
-    assertEquals(403, response.getStatus());
+    assertEquals(HttpStatus.NOT_MODIFIED_304, response.getStatus());
     assertTrue(response.getEntity() instanceof String);
     String msg = response.getEntity().toString();
-    assertTrue(msg.contains("already exists"));
     assertEquals(1, mocks.context.storage.getClusters().size());
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -67,7 +67,7 @@ public final class RepairRunResourceTest {
 
   private static final String CLUSTER_NAME = "testcluster";
   private static final String PARTITIONER = "org.apache.cassandra.dht.RandomPartitioner";
-  private static final String SEED_HOST = "TestHost";
+  private static final String SEED_HOST = "127.0.0.1";
   private static final String KEYSPACE = "testKeyspace";
   private static final Boolean INCREMENTAL = false;
   private static final Set<String> TABLES = Sets.newHashSet("testTable");

--- a/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
@@ -10,7 +10,7 @@ storageType: cassandra
 incrementalRepair: false
 jmxConnectionTimeoutInSeconds: 300
 activateQueryLogger: true
-datacenterAvailability: EACH
+datacenterAvailability: LOCAL
 
 logging:
   level: WARN


### PR DESCRIPTION
This commit also allows to update the node list easily with the addCluster operation.
If a cluster is added but already exists, its node list will be updated with the current list of live nodes.