### PR TITLE
RESTful ClusterResource 

### DIFF
--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -83,6 +83,9 @@ class ReaperCaller(object):
         if not str(r.status_code).startswith("2"):
             print r.text
         r.raise_for_status()
+        if 'Location' in r.headers:
+          # any non 303/307 response with a 'Location' header, is a successful mutation pointing to the resource
+          return self._http_req("GET", r.headers['Location'])
         return r.text
 
     def get(self, endpoint):


### PR DESCRIPTION
Improve REST API to ClusterResource mutations: 

 - idempotence on POST /cluster?seedHost=xxx
    (created 201 if created, ok 200 if node list updated, or no-content 204 if not modified),
 - undeprecate PUT /cluster/<cluster-name>?seedHost=xxx
    it is not the same rest endpoint as the POST,
 - DELETE /cluster/<cluster-name> returns accepted 202,
 - always return an empty body and a location header with where the resource is found, for all the different 200+201+202+204 responses,
 - update spreaper to follow to such location headers whenever specifiec,
 - simplify code in ClusterResource by:
   -- delegating PUT/POST endpoints to the new private method `addOrUpdateCluster(..)`,
   -- adding the private method `connectAny(..)`,
   -- using the safer `uriInfo.getBaseUriBuilder()` builder to generate endpoint locations,
 - in unit tests:
   -- consistently use jetty's `HttpStatus` when checking response codes, for readability,
   -- consistently use `org.junit.Assert.assert*(..)` methods,
   -- use correct uri base,
   -- add separate tests for PUT versus POST variants,
 - in integration tests:
   -- manually redirect to GET location, first asserting PUT/POST contains no response body,
   -- update rest endpoint to update repair run's state, so to avoid the 303 redirect on the legacy deprecated endpoint