### PR TITLE
Remove pre-conditions that break node metrics requests

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/NodeMetrics.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/NodeMetrics.java
@@ -56,17 +56,14 @@ public final class NodeMetrics {
   }
 
   public int getPendingCompactions() {
-    Preconditions.checkState(!requested, "cant get metrics on requested NodeMetrics instance");
     return pendingCompactions;
   }
 
   public boolean hasRepairRunning() {
-    Preconditions.checkState(!requested, "cant get metrics on requested NodeMetrics instance");
     return hasRepairRunning;
   }
 
   public int getActiveAnticompactions() {
-    Preconditions.checkState(!requested, "cant get metrics on requested NodeMetrics instance" );
     return activeAnticompactions;
   }
 


### PR DESCRIPTION
Node metrics requests in `datacenterAvailability == EACH` clusters was broken by unnecessary preconditions checks in `NodeMetrics.java`.