### PR TITLE
RESTful RepairRunResource & SnapshotResource

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
@@ -44,11 +44,9 @@ public interface JmxProxy extends NotificationListener {
    */
   void cancelAllRepairs();
 
-  void clearSnapshot(String repairId, String keyspaceName) throws ReaperException;
+  void clearSnapshot(String repairId, String keyspaceName);
 
-  void clearSnapshot(String snapshotName) throws ReaperException;
-
-  void clearAllSnapshots() throws ReaperException;
+  void clearSnapshot(String snapshotName);
 
   String getAllEndpointsState();
 

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
@@ -979,37 +979,28 @@ final class JmxProxyImpl implements JmxProxy {
   }
 
   @Override
-  public void clearSnapshot(String repairId, String keyspaceName) throws ReaperException {
-    if (repairId == null || ("").equals(repairId)) {
+  public void clearSnapshot(String repairId, String keyspaceName) {
+    if (null == repairId || repairId.isEmpty()) {
       // Passing in null or empty string will clear all snapshots on the hos
       throw new IllegalArgumentException("repairId cannot be null or empty string");
     }
     try {
       ((StorageServiceMBean) ssProxy).clearSnapshot(repairId, keyspaceName);
-    } catch (IOException e) {
-      throw new ReaperException(e);
+    } catch (AssertionError | IOException e) {
+      LOG.error("failed to clear snapshot " + repairId + " in keyspace " + keyspaceName, e);
     }
   }
 
   @Override
-  public void clearSnapshot(String snapshotName) throws ReaperException {
-    if (snapshotName == null || ("").equals(snapshotName)) {
+  public void clearSnapshot(String snapshotName) {
+    if (null == snapshotName || snapshotName.isEmpty()) {
       // Passing in null or empty string will clear all snapshots on the hos
       throw new IllegalArgumentException("snapshotName cannot be null or empty string");
     }
     try {
       ((StorageServiceMBean) ssProxy).clearSnapshot(snapshotName);
-    } catch (IOException e) {
-      throw new ReaperException(e);
-    }
-  }
-
-  @Override
-  public void clearAllSnapshots() throws ReaperException {
-    try {
-      ((StorageServiceMBean) ssProxy).clearSnapshot("");
-    } catch (IOException e) {
-      throw new ReaperException(e);
+    } catch (AssertionError | IOException e) {
+      LOG.error("failed to clear snapshot " + snapshotName, e);
     }
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/SnapshotResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/SnapshotResource.java
@@ -138,12 +138,13 @@ public final class SnapshotResource {
   @GET
   @Path("/{clusterName}/{host}")
   public Response listSnapshots(
-      @PathParam("clusterName") String clusterName, @PathParam("host") String host) {
-    Map<String, List<Snapshot>> snapshots;
+      @PathParam("clusterName") String clusterName,
+      @PathParam("host") String host) {
+
     try {
-      snapshots =
-          context.snapshotManager.listSnapshotsGroupedByName(
-              Node.builder().withClusterName(clusterName).withHostname(host).build());
+      Map<String, List<Snapshot>> snapshots = context.snapshotManager
+          .listSnapshotsGroupedByName(Node.builder().withClusterName(clusterName).withHostname(host).build());
+
       return Response.ok().entity(snapshots).build();
     } catch (ReaperException e) {
       LOG.error(e.getMessage(), e);


### PR DESCRIPTION
 This pull request completes the work on improving the REST API to Reaper, from https://github.com/thelastpickle/cassandra-reaper/pull/404 and https://github.com/thelastpickle/cassandra-reaper/pull/401 , bringing the whole REST API to a more cohesive and consistent place.

 - on POST/PUT: detect existing schedules and return no-content 204 if matching, otherwise conflict 409,
 - DELETE  returns accepted 202 (instead of ok 200), return conflict 409 instead of 403 forbidden,
 - DELETEs on snapshots may return 404 not_found if already visibly deleted, otherwise 202 accepted,
 - always return an empty body and a location header with where the resource is found, for all the different 200+201+202+204 responses,
 - JmxProxy's clearSnapshot() methods no longer throw ReaperException, and the unused clearAllSnapshots() methods removed,
 - the AssertionError thrown by StorageService.clearSnapshot(..) when the snapshot can't be found is now logged as an error without throwing the ReaperException,
 - clean code applied a bit eagerly to SnapshotResource and SnapshotManager,
