### PR TITLE
Fix spreaper add schedule function

### DIFF
--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -670,7 +670,7 @@ class ReaperCLI(object):
                 args.schedule_days_between, args.schedule_trigger_time))
             reply = reaper.post("repair_schedule", clusterName=args.cluster_name,
                                 keyspace=args.keyspace_name, tables=args.tables,
-                                owner=args.owner, segmentCount=args.segment_count,
+                                owner=args.owner, segmentCountPerNode=args.segment_count,
                                 repairParallelism=args.repair_parallelism,
                                 intensity=args.intensity,
                                 scheduleDaysBetween=args.schedule_days_between,
@@ -687,7 +687,7 @@ class ReaperCLI(object):
                 args.schedule_days_between, args.schedule_trigger_time))
             reply = reaper.post("repair_schedule", clusterName=args.cluster_name,
                                 keyspace=args.keyspace_name, owner=args.owner,
-                                segmentCount=args.segment_count,
+                                segmentCountPerNode=args.segment_count,
                                 repairParallelism=args.repair_parallelism,
                                 intensity=args.intensity,
                                 scheduleDaysBetween=args.schedule_days_between,


### PR DESCRIPTION
fixes #421 

spreaper hasn't been properly updated when we moved to a segment count per node, and still tried to update the global segment count which is now ignored by the backend.
This commit fixes this and the segment count per node is now properly set by spreaper.