### PR TITLE
Preconfigured clusters

### DIFF
--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -392,4 +392,15 @@ accessControl:
     iniConfigs: ["file:/path/to/shiro.ini"]
 ```
 
+### `preconfiguredClusters`
 
+Type: *Object*
+
+Optional mapping of Cluster names to contact point that reaper will automatically add as clusters being repaired. Useful with autoScheduling.
+
+```
+preconfiguredClusters:
+  my-cluster: 192.168.0.123
+  your-cluster: 10.0.0.123
+```
+<br/>

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -279,6 +279,17 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
       context.repairManager.resumeRunningRepairRuns();
     }
     LOG.info("Initialization complete!");
+
+    // Automatically add any preconfigured clusters in the yaml file for repairs after reaper has started,
+    // if there are none configured this is an empty map
+    for (Map.Entry<String, String> entry: config.getPreconfiguredClusters().entrySet()) {
+      try {
+        LOG.info("Automatically configuring {} via {}", entry.getKey(), entry.getValue());
+        addClusterResource.manualAddOrUpdateCluster(entry.getKey(), entry.getValue());
+      } catch (ReaperException e) {
+        LOG.warn("Could not add cluster {} with contact point {}", entry.getKey(), entry.getValue(), e);
+      }
+    }
     LOG.warn("Reaper is ready to get things done!");
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -72,6 +72,10 @@ public final class ReaperApplicationConfiguration extends Configuration {
   @NotNull
   private Integer hangingRepairTimeoutMins;
 
+  @JsonProperty
+  @NotNull
+  private Map<String, String> preconfiguredClusters = Collections.emptyMap();
+
   @NotEmpty
   private String storageType;
 
@@ -333,6 +337,14 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   public boolean isAccessControlEnabled() {
     return getAccessControl() != null;
+  }
+
+  public Map<String, String> getPreconfiguredClusters() {
+    return preconfiguredClusters;
+  }
+
+  public void setPreconfiguredClusters(Map<String, String> preconfiguredClusters) {
+    this.preconfiguredClusters = preconfiguredClusters;
   }
 
 

--- a/src/server/src/test/java/io/cassandrareaper/ReaperApplicationConfigurationTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/ReaperApplicationConfigurationTest.java
@@ -24,8 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 import systems.composable.dropwizard.cassandra.CassandraFactory;
 
-import java.util.Collections;
-
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public final class ReaperApplicationConfigurationTest {
@@ -56,7 +54,6 @@ public final class ReaperApplicationConfigurationTest {
     config.setScheduleDaysBetween(7);
     config.setStorageType("foo");
     config.setIncrementalRepair(false);
-    config.setPreconfiguredClusters(Collections.emptyMap());
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/ReaperApplicationConfigurationTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/ReaperApplicationConfigurationTest.java
@@ -24,6 +24,8 @@ import org.junit.Before;
 import org.junit.Test;
 import systems.composable.dropwizard.cassandra.CassandraFactory;
 
+import java.util.Collections;
+
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public final class ReaperApplicationConfigurationTest {
@@ -54,6 +56,7 @@ public final class ReaperApplicationConfigurationTest {
     config.setScheduleDaysBetween(7);
     config.setStorageType("foo");
     config.setIncrementalRepair(false);
+    config.setPreconfiguredClusters(Collections.emptyMap());
   }
 
   @Test


### PR DESCRIPTION
Allow reaper to setup clusters that are predefined in the yaml file.

If we already know the cluster we want to manage repairs on, we can preconfigure in the yaml file and don't have to resort to scripts that poll/wait for reaper to come up before configuring via API. 

Note there are two style checks failing. One appears unrelated to this change, one appears to be silly... LMK if these need to be addressed. 
