### PR TITLE
Fix spelling of "parallelism"

### DIFF
--- a/docs/docs/usage/single/index.html
+++ b/docs/docs/usage/single/index.html
@@ -414,7 +414,7 @@
 
 <tr>
 <td><strong>Incremental</strong></td>
-<td>This boolean value is only supported when the Parallism is set to Parallel.</td>
+<td>This boolean value is only supported when the Parallelism is set to Parallel.</td>
 </tr>
 </tbody>
 </table>

--- a/src/docs/content/docs/usage/single.md
+++ b/src/docs/content/docs/usage/single.md
@@ -36,4 +36,4 @@ Enter values for the keyspace, tables, owner and other fields and click the *Rep
 **Parallelism** | Options are: <br/> - `Sequential`: Used in cases where data center aware repairs are not yet supported (pre-2.0.12). <br/> - `Parallel`: Executes repairs across all nodes in parallel. <br/> - `DC-Aware`: Executes repairs across all nodes in a data center, one data center at a time. This is the safest option as it restricts extreme load to a specific data center, rather than impacting the full cluster.
 **Repair intensity** | A value between 0.0 and 1.0, where 1.0 ensures that no sleeping occurs between repair sessions and 0.5 ensures that equal amounts of time while the repair task is running, will be spent sleeping and repairing.
 **Cause** | Any string is accepted for this field which acts as a way to include notes in cases where many users have access to Reaper.
-**Incremental** | This boolean value is only supported when the Parallism is set to Parallel.
+**Incremental** | This boolean value is only supported when the Parallelism is set to Parallel.

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -18,7 +18,7 @@ const repairForm = React.createClass({
     return {
       addRepairResultMsg: null, clusterNames: [], submitEnabled: false,
       clusterName: this.props.currentCluster!="all"?this.props.currentCluster:this.props.clusterNames[0], keyspace: "", tables: "", owner: null, segments: null,
-      parallism: null, intensity: null, cause: null, incrementalRepair: null, formCollapsed: true, nodes: "", datacenters: "", blacklistedTables: "",
+      parallelism: null, intensity: null, cause: null, incrementalRepair: null, formCollapsed: true, nodes: "", datacenters: "", blacklistedTables: "",
       nodeList: [], datacenterList: [], clusterStatus: {}, urlPrefix: URL_PREFIX, nodeSuggestions: [], datacenterSuggestions: [], tableSuggestions: [], 
       clusterTables: {}, blacklistSuggestions: [], tableList: [], blacklistList: [], keyspaceList: [], keyspaceSuggestions: [],
       blacklistReadOnly: false, tablelistReadOnly: false, advancedFormCollapsed: true
@@ -99,7 +99,7 @@ const repairForm = React.createClass({
     };
     if(this.state.tables) repair.tables = this.state.tables;
     if(this.state.segments) repair.segmentCount = this.state.segments;
-    if(this.state.parallism) repair.repairParallelism = this.state.parallism;
+    if(this.state.parallelism) repair.repairParallelism = this.state.parallelism;
     if(this.state.intensity) repair.intensity = this.state.intensity;
     if(this.state.cause) repair.cause = this.state.cause;
     if(this.state.incrementalRepair) repair.incrementalRepair = this.state.incrementalRepair;
@@ -480,10 +480,10 @@ const repairForm = React.createClass({
                       </div>
                     </div>
                     <div className="form-group">
-                      <label htmlFor="in_parallism" className="col-sm-3 control-label">Parallism</label>
+                      <label htmlFor="in_parallelism" className="col-sm-3 control-label">Parallelism</label>
                       <div className="col-sm-14 col-md-12 col-lg-9">
-                        <select className="form-control" id="in_parallism"
-                          onChange={this._handleChange} value={this.state.parallism}>
+                        <select className="form-control" id="in_parallelism"
+                          onChange={this._handleChange} value={this.state.parallelism}>
                           <option value=""></option>
                           <option value="SEQUENTIAL">Sequential</option>
                           <option value="PARALLEL">Parallel</option>

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -190,7 +190,7 @@ const TableRowDetails = React.createClass({
                     <td>{intensity}</td>
                 </tr>
                 <tr>
-                    <td>Repair parallism</td>
+                    <td>Repair parallelism</td>
                     <td>{this.props.row.repair_parallelism}</td>
                 </tr>
                 <tr>

--- a/src/ui/app/jsx/schedule-form.jsx
+++ b/src/ui/app/jsx/schedule-form.jsx
@@ -19,7 +19,7 @@ const scheduleForm = React.createClass({
     return {
       addScheduleResultMsg: null, clusterNames: [], submitEnabled: false,
       clusterName: this.props.currentCluster!="all"?this.props.currentCluster:this.props.clusterNames[0], keyspace: "", tables: "", owner: null, segments: null,
-      parallism: null, intensity: null, startTime: null, intervalDays: null, incrementalRepair: null, formCollapsed: true, nodes: null, datacenters: null, 
+      parallelism: null, intensity: null, startTime: null, intervalDays: null, incrementalRepair: null, formCollapsed: true, nodes: null, datacenters: null,
       nodes: "", datacenters: "", blacklistedTables: "", nodeList: [], datacenterList: [], clusterStatus: {}, urlPrefix: URL_PREFIX, nodeSuggestions: [], datacenterSuggestions: [],
       clusterTables: {}, tableSuggestions: [], blacklistSuggestions: [], tableList: [], blacklistList: [], keyspaceList: [], keyspaceSuggestions: [], 
       blacklistReadOnly: false, tablelistReadOnly: false, advancedFormCollapsed: true
@@ -99,7 +99,7 @@ const scheduleForm = React.createClass({
     };
     if(this.state.tables) schedule.tables = this.state.tables;
     if(this.state.segments) schedule.segmentCountPerNode = this.state.segments;
-    if(this.state.parallism) schedule.repairParallelism = this.state.parallism;
+    if(this.state.parallelism) schedule.repairParallelism = this.state.parallelism;
     if(this.state.intensity) schedule.intensity = this.state.intensity;
     if(this.state.incrementalRepair){
       schedule.incrementalRepair = this.state.incrementalRepair;
@@ -487,10 +487,10 @@ const scheduleForm = React.createClass({
                       </div>
                     </div>
                     <div className="form-group">
-                      <label htmlFor="in_parallism" className="col-sm-3 control-label">Parallelism</label>
+                      <label htmlFor="in_parallelism" className="col-sm-3 control-label">Parallelism</label>
                       <div className="col-sm-14 col-md-12 col-lg-9">
-                        <select className="form-control" id="in_parallism"
-                          onChange={this._handleChange} value={this.state.parallism}>
+                        <select className="form-control" id="in_parallelism"
+                          onChange={this._handleChange} value={this.state.parallelism}>
                           <option value=""></option>
                           <option value="SEQUENTIAL">Sequential</option>
                           <option value="PARALLEL">Parallel</option>

--- a/src/ui/app/jsx/schedule-list.jsx
+++ b/src/ui/app/jsx/schedule-list.jsx
@@ -86,7 +86,7 @@ const TableRowDetails = React.createClass({
                     <td>{this.props.row.intensity}</td>
                 </tr>
                 <tr>
-                    <td>Repair parallism</td>
+                    <td>Repair parallelism</td>
                     <td>{this.props.row.repair_parallelism}</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Fix spelling of "parallelism" in docs and UI, as well in javascript internal
properties.  The actual "repairParallelism" property was already spelled
correctly.