### PR TITLE
Add automated purge functions

### DIFF
--- a/src/packaging/resource/cassandra-reaper-cassandra-ssl.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra-ssl.yaml
@@ -14,6 +14,8 @@ repairManagerSchedulingIntervalSeconds: 10
 activateQueryLogger: false
 jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
+# purgeRecordsAfterInDays: 30
+# numberOfRunsToKeepPerUnit: 10
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/packaging/resource/cassandra-reaper-cassandra.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra.yaml
@@ -15,6 +15,8 @@ repairManagerSchedulingIntervalSeconds: 10
 activateQueryLogger: false
 jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
+# purgeRecordsAfterInDays: 30
+# numberOfRunsToKeepPerUnit: 10
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/packaging/resource/cassandra-reaper-h2.yaml
+++ b/src/packaging/resource/cassandra-reaper-h2.yaml
@@ -14,6 +14,8 @@ enableDynamicSeedList: true
 repairManagerSchedulingIntervalSeconds: 10
 jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
+# purgeRecordsAfterInDays: 30
+# numberOfRunsToKeepPerUnit: 10
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/packaging/resource/cassandra-reaper-memory.yaml
+++ b/src/packaging/resource/cassandra-reaper-memory.yaml
@@ -14,6 +14,8 @@ enableDynamicSeedList: true
 repairManagerSchedulingIntervalSeconds: 10
 jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
+# purgeRecordsAfterInDays: 30
+# numberOfRunsToKeepPerUnit: 10
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/packaging/resource/cassandra-reaper-postgres.yaml
+++ b/src/packaging/resource/cassandra-reaper-postgres.yaml
@@ -14,6 +14,8 @@ enableDynamicSeedList: true
 repairManagerSchedulingIntervalSeconds: 10
 jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
+# purgeRecordsAfterInDays: 30
+# numberOfRunsToKeepPerUnit: 10
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/packaging/resource/cassandra-reaper.yaml
+++ b/src/packaging/resource/cassandra-reaper.yaml
@@ -15,6 +15,8 @@ repairManagerSchedulingIntervalSeconds: 10
 activateQueryLogger: false
 jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
+# purgeRecordsAfterInDays: 30
+# numberOfRunsToKeepPerUnit: 10
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/server/src/main/java/io/cassandrareaper/AppContext.java
+++ b/src/server/src/main/java/io/cassandrareaper/AppContext.java
@@ -15,6 +15,7 @@
 package io.cassandrareaper;
 
 import io.cassandrareaper.jmx.JmxConnectionFactory;
+import io.cassandrareaper.service.PurgeManager;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.SnapshotManager;
 import io.cassandrareaper.storage.IStorage;
@@ -46,6 +47,7 @@ public final class AppContext {
   public ReaperApplicationConfiguration config;
   public MetricRegistry metricRegistry = new MetricRegistry();
   public SnapshotManager snapshotManager;
+  public PurgeManager purgeManager;
 
   private static String initialiseInstanceAddress() {
     String reaperInstanceAddress;

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;
@@ -111,6 +112,15 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   @JsonProperty
   private Integer repairThreadCount;
+  /** If set to more than 0, defines how many days of run history should be kept. */
+  @Nullable
+  @JsonProperty
+  private Integer purgeRecordsAfterInDays;
+
+  /** If set to more than 0, defines how many runs to keep per repair unit. */
+  @Nullable
+  @JsonProperty
+  private Integer numberOfRunsToKeepPerUnit;
 
   private CassandraFactory cassandra = new CassandraFactory();
 
@@ -340,6 +350,24 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   public int getRepairThreadCount() {
     return repairThreadCount != null ? repairThreadCount : 1;
+  }
+
+  public Integer getPurgeRecordsAfterInDays() {
+    return purgeRecordsAfterInDays == null ? 0 : purgeRecordsAfterInDays;
+  }
+
+  @JsonProperty("purgeRecordsAfterInDays")
+  public void setPurgeRecordsAfterInDays(Integer purgeRecordsAfterInDays) {
+    this.purgeRecordsAfterInDays = purgeRecordsAfterInDays;
+  }
+
+  public Integer getNumberOfRunsToKeepPerUnit() {
+    return numberOfRunsToKeepPerUnit == null ? 50 : numberOfRunsToKeepPerUnit;
+  }
+
+  @JsonProperty("numberOfRunsToKeepPerUnit")
+  public void setNumberOfRunsToKeepPerUnit(Integer numberOfRunsToKeepPerUnit) {
+    this.numberOfRunsToKeepPerUnit = numberOfRunsToKeepPerUnit;
   }
 
   public static final class JmxCredentials {

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -759,6 +759,14 @@ public final class RepairRunResource {
     return Response.status(Response.Status.NOT_FOUND).entity("Repair run %s" + runId + " not found").build();
   }
 
+  @GET
+  @Path("/purge")
+  public Response purgeRepairRuns() {
+    int purgedRepairs = context.purgeManager.purgeDatabase();
+    return Response.ok().entity(purgedRepairs).build();
+  }
+
+
   private static void checkRepairParallelismString(String repairParallelism) throws ReaperException {
     try {
       RepairParallelism.valueOf(repairParallelism.toUpperCase());

--- a/src/server/src/main/java/io/cassandrareaper/service/PurgeManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/PurgeManager.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.service;
+
+import io.cassandrareaper.AppContext;
+import io.cassandrareaper.core.Cluster;
+import io.cassandrareaper.core.RepairRun;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Optional;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class PurgeManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PurgeManager.class);
+
+  private final AppContext context;
+
+  private PurgeManager(AppContext context) {
+    this.context = context;
+  }
+
+  public static PurgeManager create(AppContext context) {
+    return new PurgeManager(context);
+  }
+
+  public Integer purgeDatabase() {
+    int purgedRuns = 0;
+    if (context.config.getNumberOfRunsToKeepPerUnit() != 0
+        || context.config.getPurgeRecordsAfterInDays() != 0) {
+      // List clusters
+      Collection<Cluster> clusters = context.storage.getClusters();
+
+      // List repair runs
+      for (Cluster cluster : clusters) {
+        Collection<RepairRun> repairRuns =
+            context.storage.getRepairRunsForCluster(cluster.getName(), Optional.absent());
+        if (context.config.getPurgeRecordsAfterInDays() > 0) {
+          // Purge all runs that are older than threshold
+          purgedRuns += purgeRepairRunsByDate(repairRuns);
+        }
+
+        if (context.config.getNumberOfRunsToKeepPerUnit() > 0) {
+          // Purge units that have more runs than the threshold
+          purgedRuns += purgeRepairRunsByHistoryDepth(repairRuns);
+        }
+      }
+    }
+    return purgedRuns;
+  }
+
+  /**
+   * Purges all the repair runs that exceed the required number to keep per repair unit. Runs
+   * provided as argument will be grouped by repair unit and the purge will be applied by unit.
+   *
+   * @param repairRuns the existing repair runs
+   * @return the number of purged runs
+   */
+  private int purgeRepairRunsByHistoryDepth(Collection<RepairRun> repairRuns) {
+    int purgedRuns = 0;
+    Map<UUID, List<RepairRun>> repairRunsByRepairUnit =
+        repairRuns
+            .stream()
+            .filter(run -> run.getRunState().isTerminated()) // only delete terminated runs
+            .collect(Collectors.groupingBy(RepairRun::getRepairUnitId));
+    for (Entry<UUID, List<RepairRun>> repairUnit : repairRunsByRepairUnit.entrySet()) {
+      List<RepairRun> repairRunsForUnit = repairUnit.getValue();
+      repairRunsForUnit.sort(
+          (RepairRun r1, RepairRun r2) -> r2.getEndTime().compareTo(r1.getEndTime()));
+      for (int i = context.config.getNumberOfRunsToKeepPerUnit();
+          i < repairRunsForUnit.size();
+          i++) {
+        context.storage.deleteRepairRun(repairRunsForUnit.get(i).getId());
+        purgedRuns++;
+      }
+    }
+
+    return purgedRuns;
+  }
+
+  /**
+   * Purges all repair runs that are older than the required history depth in days.
+   *
+   * @param repairRuns the list of existing repair runs
+   * @return the number of purged runs
+   */
+  private int purgeRepairRunsByDate(Collection<RepairRun> repairRuns) {
+    AtomicInteger purgedRuns = new AtomicInteger(0);
+    repairRuns
+        .stream()
+        .filter(run -> run.getRunState().isTerminated()) // only delete terminated runs
+        .filter(
+            run ->
+                run.getEndTime()
+                    .isBefore(
+                        DateTime.now()
+                            .minusDays(
+                                context.config.getPurgeRecordsAfterInDays()))) // filter by date
+        .forEach(
+            run -> {
+              context.storage.deleteRepairRun(run.getId());
+              purgedRuns.incrementAndGet();
+            });
+
+    return purgedRuns.get();
+  }
+}

--- a/src/server/src/test/java/io/cassandrareaper/service/PurgeManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/PurgeManagerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.service;
+
+import io.cassandrareaper.AppContext;
+import io.cassandrareaper.ReaperApplicationConfiguration;
+import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.Cluster;
+import io.cassandrareaper.core.RepairRun;
+import io.cassandrareaper.core.RepairRun.RunState;
+import io.cassandrareaper.storage.IStorage;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.Lists;
+import org.apache.cassandra.repair.RepairParallelism;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class PurgeManagerTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PurgeManagerTest.class);
+  private static final String CLUSTER_NAME = "test";
+
+  @Test
+  public void testPurgeByDate() throws InterruptedException, ReaperException {
+    AppContext context = new AppContext();
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setPurgeRecordsAfterInDays(1);
+    context.purgeManager = PurgeManager.create(context);
+
+    // Create storage mock
+    context.storage = mock(IStorage.class);
+
+    List<Cluster> clusters = Arrays.asList(new Cluster(CLUSTER_NAME, "", Collections.EMPTY_SET));
+    when(context.storage.getClusters()).thenReturn(clusters);
+
+    // Add repair runs to the mock
+    List<RepairRun> repairRuns = Lists.newArrayList();
+    DateTime currentDate = DateTime.now();
+    for (int i = 0; i < 10; i++) {
+      UUID repairUnitId = UUIDs.timeBased();
+      DateTime startTime = currentDate.minusDays(i).minusHours(1);
+      repairRuns.add(
+          new RepairRun.Builder(
+                  CLUSTER_NAME,
+                  repairUnitId,
+                  startTime,
+                  0.9,
+                  10,
+                  RepairParallelism.DATACENTER_AWARE)
+              .endTime(startTime.plusSeconds(1))
+              .runState(RunState.DONE)
+              .build(UUIDs.timeBased()));
+    }
+
+    when(context.storage.getRepairRunsForCluster(anyString(), any())).thenReturn(repairRuns);
+
+    // Invoke the purge manager
+    int purged = context.purgeManager.purgeDatabase();
+
+    // Check that runs were removed
+    assertEquals(9, purged);
+  }
+
+  @Test
+  public void testPurgeByHistoryDepth() throws InterruptedException, ReaperException {
+    AppContext context = new AppContext();
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setNumberOfRunsToKeepPerUnit(5);
+    context.purgeManager = PurgeManager.create(context);
+
+    // Create storage mock
+    context.storage = mock(IStorage.class);
+
+    List<Cluster> clusters = Arrays.asList(new Cluster(CLUSTER_NAME, "", Collections.EMPTY_SET));
+    when(context.storage.getClusters()).thenReturn(clusters);
+
+    // Add repair runs to the mock
+    List<RepairRun> repairRuns = Lists.newArrayList();
+    DateTime currentDate = DateTime.now();
+    UUID repairUnitId = UUIDs.timeBased();
+    for (int i = 0; i < 20; i++) {
+      DateTime startTime = currentDate.minusDays(i).minusHours(1);
+      repairRuns.add(
+          new RepairRun.Builder(
+                  CLUSTER_NAME,
+                  repairUnitId,
+                  startTime,
+                  0.9,
+                  10,
+                  RepairParallelism.DATACENTER_AWARE)
+              .endTime(startTime.plusSeconds(1))
+              .runState(RunState.DONE)
+              .build(UUIDs.timeBased()));
+    }
+
+    when(context.storage.getRepairRunsForCluster(anyString(), any())).thenReturn(repairRuns);
+
+    // Invoke the purge manager
+    int purged = context.purgeManager.purgeDatabase();
+
+    // Check that runs were removed
+    assertEquals(15, purged);
+  }
+
+  @Test
+  public void testSkipPurgeOngoingRuns() throws InterruptedException, ReaperException {
+    AppContext context = new AppContext();
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setPurgeRecordsAfterInDays(1);
+    context.purgeManager = PurgeManager.create(context);
+
+    // Create storage mock
+    context.storage = mock(IStorage.class);
+
+    List<Cluster> clusters = Arrays.asList(new Cluster(CLUSTER_NAME, "", Collections.EMPTY_SET));
+    when(context.storage.getClusters()).thenReturn(clusters);
+
+    // Add repair runs to the mock
+    List<RepairRun> repairRuns = Lists.newArrayList();
+    DateTime currentDate = DateTime.now();
+    for (int i = 0; i < 10; i++) {
+      UUID repairUnitId = UUIDs.timeBased();
+      DateTime startTime = currentDate.minusDays(i).minusHours(1);
+      repairRuns.add(
+          new RepairRun.Builder(
+                  CLUSTER_NAME,
+                  repairUnitId,
+                  startTime,
+                  0.9,
+                  10,
+                  RepairParallelism.DATACENTER_AWARE)
+              .endTime(startTime.plusSeconds(1))
+              .runState(RunState.PAUSED)
+              .build(UUIDs.timeBased()));
+    }
+
+    when(context.storage.getRepairRunsForCluster(anyString(), any())).thenReturn(repairRuns);
+
+    // Invoke the purge manager
+    int purged = context.purgeManager.purgeDatabase();
+
+    // Check that runs were removed
+    assertEquals(0, purged);
+  }
+
+}


### PR DESCRIPTION
This commit creates 2 new config elements to control the depth of the repair run history as old runs get read often, especially through the UI.
Runs can be purged based on a time based depth (purge everything that's more than 30 days old for example) and/or based on a number of runs to keep per repair unit (keep the last 10 runs for each repair unit, for example).
The purge manager is scheduled to run every hour (the value is hardcoded).