### PR TITLE
Avoid the NPE in Heart.beat when shutting down

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -46,7 +46,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class RepairManager {
+public final class RepairManager implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(RepairManager.class);
 
@@ -371,5 +371,11 @@ public final class RepairManager {
         ((IDistributedStorage) context.storage).releaseLead(leaderElectionId);
       }
     }
+  }
+
+  @Override
+  public void close() {
+    heart.close();
+    executor.shutdownNow();
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/ReaperTestJettyRunner.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/ReaperTestJettyRunner.java
@@ -104,6 +104,7 @@ public final class ReaperTestJettyRunner {
 
     @Override
     public void after() {
+      context.repairManager.close();
       context.isRunning.set(false);
       try {
         Thread.sleep(100);


### PR DESCRIPTION
Often when running the integration tests, during shutdown, a `NullPointerException` is thrown from the inner forkJoin in the `updateRequestedNodeMetrics()` method.

This fix allows the RepairManager to be closed, which in turns closes the Heart instance before the shutdown otherwise initiates.