### PR TITLE
Add repair threads support

### DIFF
--- a/docs/docs/api/index.html
+++ b/docs/docs/api/index.html
@@ -463,6 +463,7 @@ or the request will fail. Delete repair runs and schedules first before calling 
 <li><em>nodes</em> : a specific list of nodes whose tokens should be repaired. (Optional)</li>
 <li><em>datacenters</em> : a specific list of datacenters to repair. (Optional)</li>
 <li><em>blacklistedTables</em> : The name of the tables that should not be repaired. Cannot be used in conjunction with the tables parameter. (Optional)</li>
+<li><em>repairThreadCount</em> : Since Cassandra 2.2, repairs can be performed with up to 4 threads in order to parallelize the work on different token ranges. (Optional)</li>
 </ul></li>
 <li>Endpoint used to create a repair run. Does not allow triggering the run.
 Creating a repair run includes generating the repair segments.
@@ -568,6 +569,7 @@ keyspace name. (Optional)</li>
 <li><em>nodes</em> : a specific list of nodes whose tokens should be repaired. (Optional)</li>
 <li><em>datacenters</em> : a specific list of datacenters to repair. (Optional)</li>
 <li><em>blacklistedTables</em> : The name of the tables that should not be repaired. Cannot be used in conjunction with the tables parameter. (Optional)</li>
+<li><em>repairThreadCount</em> : Since Cassandra 2.2, repairs can be performed with up to 4 threads in order to parallelize the work on different token ranges. (Optional)</li>
 </ul></li>
 <li>Create and activate a scheduled repair.
 <br />

--- a/docs/docs/concepts/index.html
+++ b/docs/docs/concepts/index.html
@@ -324,6 +324,9 @@ In Cassandra 2.2, one repair session will be started for each subrange of the se
 
 <p>The maximum number of concurrent repairs is 15 by default and can be modified in the YAML configuration (<em>cassandra-reaper.yaml</em>) file.</p>
 
+<p>Since Cassandra 2.2, repairs are multithreaded in order to process several token ranges concurrently and speed up the process. No more than four threads are authorized by Cassandra. The number of repair threads can be set differently for each repair run/schedule.
+This setting will be ignored for clusters running an older version of Apache Cassandra.</p>
+
 <h2 id="timeout">Timeout</h2>
 
 <p>By default, each segment must complete within 30 minutes. Reaper subscribes to the repair service notifications of Cassandra to monitor completion, and if a segment takes more than 30 minutes it gets cancelled and postponed. This means that if a repair job is subject to frequent segment cancellation, it is necessary to either split it up into more segments or raise the timeout over its default value.</p>

--- a/docs/docs/configuration/reaper_specific/index.html
+++ b/docs/docs/configuration/reaper_specific/index.html
@@ -695,6 +695,14 @@ Deleting or commenting that block from the yaml file will turn off authenticatio
     iniConfigs: [&quot;file:/path/to/shiro.ini&quot;]
 </code></pre>
 
+<h3 id="repairthreadcount"><code>repairThreadCount</code></h3>
+
+<p>Type: <em>Integer</em></p>
+
+<p>Since Cassandra 2.2, repairs are multithreaded in order to process several token ranges concurrently and speed up the process.
+This setting allows to set a default for automatic repair schedules.
+No more than four threads are allowed by Cassandra.</p>
+
                         </div>
 
                     </div>

--- a/docs/docs/usage/single/index.html
+++ b/docs/docs/usage/single/index.html
@@ -393,8 +393,8 @@
 </tr>
 
 <tr>
-<td><strong>Segment count</strong></td>
-<td>The number of segments to create when considering all the token ranges.</td>
+<td><strong>Segments per node</strong></td>
+<td>The number of segments to create per nodes in the cluster.</td>
 </tr>
 
 <tr>
@@ -415,6 +415,21 @@
 <tr>
 <td><strong>Incremental</strong></td>
 <td>This boolean value is only supported when the Parallelism is set to Parallel.</td>
+</tr>
+
+<tr>
+<td><strong>Nodes</strong></td>
+<td>Allows to restrict the repair to token ranges of specific nodes.</td>
+</tr>
+
+<tr>
+<td><strong>Datacenters</strong></td>
+<td>Allows to restrict the repair to specific datacenters.</td>
+</tr>
+
+<tr>
+<td><strong>Repair threads</strong></td>
+<td>(Since Cassandra 2.2) Allows to set a number of threads to process several token ranges concurrently.</td>
 </tr>
 </tbody>
 </table>

--- a/src/docs/content/docs/api.md
+++ b/src/docs/content/docs/api.md
@@ -96,6 +96,7 @@ Source code for all the REST resources can be found from package io.cassandrarea
 	    * *nodes* : a specific list of nodes whose tokens should be repaired. (Optional)
 	    * *datacenters* : a specific list of datacenters to repair. (Optional) 
 	    * *blacklistedTables* : The name of the tables that should not be repaired. Cannot be used in conjunction with the tables parameter. (Optional)
+	    * *repairThreadCount* : Since Cassandra 2.2, repairs can be performed with up to 4 threads in order to parallelize the work on different token ranges. (Optional)
     * Endpoint used to create a repair run. Does not allow triggering the run. 
 Creating a repair run includes generating the repair segments. 
 Notice that query parameter "tables" can be a single String, or a comma-separated list of table names. If the "tables" parameter is omitted, and only the keyspace is defined, then created repair run will target all the tables in the keyspace.
@@ -163,6 +164,7 @@ Returns OK if all goes well NOT_MODIFIED if new state is the same as the old one
  	    * *nodes* : a specific list of nodes whose tokens should be repaired. (Optional)
 	    * *datacenters* : a specific list of datacenters to repair. (Optional) 
 	    * *blacklistedTables* : The name of the tables that should not be repaired. Cannot be used in conjunction with the tables parameter. (Optional)
+	    * *repairThreadCount* : Since Cassandra 2.2, repairs can be performed with up to 4 threads in order to parallelize the work on different token ranges. (Optional)
     * Create and activate a scheduled repair.
   
   

--- a/src/docs/content/docs/concepts.md
+++ b/src/docs/content/docs/concepts.md
@@ -23,6 +23,9 @@ Being a multi threaded service, Reaper will compute how many concurrent repair s
 
 The maximum number of concurrent repairs is 15 by default and can be modified in the YAML configuration (_cassandra-reaper.yaml_) file.
 
+Since Cassandra 2.2, repairs are multithreaded in order to process several token ranges concurrently and speed up the process. No more than four threads are authorized by Cassandra. The number of repair threads can be set differently for each repair run/schedule.
+This setting will be ignored for clusters running an older version of Apache Cassandra.
+
 ## Timeout
 By default, each segment must complete within 30 minutes. Reaper subscribes to the repair service notifications of Cassandra to monitor completion, and if a segment takes more than 30 minutes it gets cancelled and postponed. This means that if a repair job is subject to frequent segment cancellation, it is necessary to either split it up into more segments or raise the timeout over its default value.
 

--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -392,4 +392,11 @@ accessControl:
     iniConfigs: ["file:/path/to/shiro.ini"]
 ```
 
+### `repairThreadCount`
+
+Type: *Integer*
+
+Since Cassandra 2.2, repairs are multithreaded in order to process several token ranges concurrently and speed up the process.
+This setting allows to set a default for automatic repair schedules.
+No more than four threads are allowed by Cassandra.  
 

--- a/src/docs/content/docs/usage/single.md
+++ b/src/docs/content/docs/usage/single.md
@@ -32,8 +32,11 @@ Enter values for the keyspace, tables, owner and other fields and click the *Rep
 **Keyspace** | Restricts the keyspaces that will be repaired by this task.
 **Tables** | A comma-delimited list of tables to repair.
 **Owner** | Any string is accepted for this field which acts as a way to include notes in cases where many users have access to Reaper.
-**Segment count** | The number of segments to create when considering all the token ranges.
+**Segments per node** | The number of segments to create per nodes in the cluster.
 **Parallelism** | Options are: <br/> - `Sequential`: Used in cases where data center aware repairs are not yet supported (pre-2.0.12). <br/> - `Parallel`: Executes repairs across all nodes in parallel. <br/> - `DC-Aware`: Executes repairs across all nodes in a data center, one data center at a time. This is the safest option as it restricts extreme load to a specific data center, rather than impacting the full cluster.
 **Repair intensity** | A value between 0.0 and 1.0, where 1.0 ensures that no sleeping occurs between repair sessions and 0.5 ensures that equal amounts of time while the repair task is running, will be spent sleeping and repairing.
 **Cause** | Any string is accepted for this field which acts as a way to include notes in cases where many users have access to Reaper.
 **Incremental** | This boolean value is only supported when the Parallelism is set to Parallel.
+**Nodes** |  Allows to restrict the repair to token ranges of specific nodes.
+**Datacenters** |  Allows to restrict the repair to specific datacenters.
+**Repair threads** |  (Since Cassandra 2.2) Allows to set a number of threads to process several token ranges concurrently.

--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -222,6 +222,8 @@ def _arguments_for_repair_and_schedule(parser):
     parser.add_argument("--blacklisted-tables", default=None,
                         help=("a comma separated list of tables that must not be repaired "
                               "within the keyspace (do not use spaces after commas)"))
+    parser.add_argument("--repair-threads", default=1,
+                        help=("The number of threads to use in Cassandra to parallelize repair sessions (from 1 to 4)"))
 
 
 def _arguments_for_scheduling(parser):
@@ -619,7 +621,8 @@ class ReaperCLI(object):
                                 incrementalRepair=args.incremental, 
                                 nodes=args.nodes,
                                 datacenters=args.datacenters,
-                                blacklistedTables=args.blacklisted_tables)
+                                blacklistedTables=args.blacklisted_tables,
+                                repairThreadCount=args.repair_threads)
         else:
             if args.blacklisted_tables :
                 printq ("# Registering repair run for cluster '{0}', and keyspace '{1}', "
@@ -638,7 +641,8 @@ class ReaperCLI(object):
                                 incrementalRepair=args.incremental, 
                                 nodes=args.nodes,
                                 datacenters=args.datacenters,
-                                blacklistedTables=args.blacklisted_tables)
+                                blacklistedTables=args.blacklisted_tables,
+                                repairThreadCount=args.repair_threads)
         repair_run = json.loads(reply)
         printq("# Repair run with id={0} created".format(repair_run.get('id')))
         if not args.dont_start_repair:
@@ -678,7 +682,8 @@ class ReaperCLI(object):
                                 incrementalRepair=args.incremental, 
                                 nodes=args.nodes,
                                 datacenters=args.datacenters,
-                                blacklistedTables=args.blacklisted_tables)
+                                blacklistedTables=args.blacklisted_tables,
+                                repairThreadCount=args.repair_threads)
         else:
             printq ("# Registering repair schedule for cluster '{0}', and keyspace '{1}', "
                    "targeting all tables in the keyspace, with scheduled days between "
@@ -695,7 +700,8 @@ class ReaperCLI(object):
                                 incrementalRepair=args.incremental, 
                                 nodes=args.nodes,
                                 datacenters=args.datacenters,
-                                blacklistedTables=args.blacklisted_tables)
+                                blacklistedTables=args.blacklisted_tables,
+                                repairThreadCount=args.repair_threads)
         repair_schedule = json.loads(reply)
         printq("# Repair schedule with id={0} created:".format(repair_schedule.get('id')))
         print json.dumps(repair_schedule, indent=2, sort_keys=True)

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -109,6 +109,9 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   @JsonProperty private AccessControlConfiguration accessControl;
 
+  @JsonProperty
+  private Integer repairThreadCount;
+
   private CassandraFactory cassandra = new CassandraFactory();
 
   @Deprecated
@@ -335,6 +338,9 @@ public final class ReaperApplicationConfiguration extends Configuration {
     return getAccessControl() != null;
   }
 
+  public int getRepairThreadCount() {
+    return repairThreadCount != null ? repairThreadCount : 1;
+  }
 
   public static final class JmxCredentials {
 

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairUnit.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairUnit.java
@@ -28,6 +28,7 @@ public final class RepairUnit {
   private final Set<String> nodes;
   private final Set<String> datacenters;
   private final Set<String> blacklistedTables;
+  private final int repairThreadCount;
 
   private RepairUnit(Builder builder, UUID id) {
     this.id = id;
@@ -38,6 +39,7 @@ public final class RepairUnit {
     this.nodes = builder.nodes;
     this.datacenters = builder.datacenters;
     this.blacklistedTables = builder.blacklistedTables;
+    this.repairThreadCount = builder.repairThreadCount;
   }
 
   public UUID getId() {
@@ -72,6 +74,10 @@ public final class RepairUnit {
     return blacklistedTables;
   }
 
+  public int getRepairThreadCount() {
+    return repairThreadCount;
+  }
+
   public Builder with() {
     return new Builder(this);
   }
@@ -85,6 +91,7 @@ public final class RepairUnit {
     public final Set<String> nodes;
     public final Set<String> datacenters;
     public final Set<String> blacklistedTables;
+    public final int repairThreadCount;
 
     public Builder(
         String clusterName,
@@ -93,7 +100,8 @@ public final class RepairUnit {
         boolean incrementalRepair,
         Set<String> nodes,
         Set<String> datacenters,
-        Set<String> blacklistedTables) {
+        Set<String> blacklistedTables,
+        int repairThreadCount) {
       this.clusterName = clusterName;
       this.keyspaceName = keyspaceName;
       this.columnFamilies = columnFamilies;
@@ -101,6 +109,7 @@ public final class RepairUnit {
       this.nodes = nodes;
       this.datacenters = datacenters;
       this.blacklistedTables = blacklistedTables;
+      this.repairThreadCount = repairThreadCount;
     }
 
     private Builder(RepairUnit original) {
@@ -111,6 +120,7 @@ public final class RepairUnit {
       nodes = original.nodes;
       datacenters = original.datacenters;
       blacklistedTables = original.blacklistedTables;
+      repairThreadCount = original.repairThreadCount;
     }
 
     public RepairUnit build(UUID id) {
@@ -152,7 +162,8 @@ public final class RepairUnit {
           && Objects.equals(this.columnFamilies, ((Builder) obj).columnFamilies)
           && Objects.equals(this.nodes, ((Builder) obj).nodes)
           && Objects.equals(this.datacenters, ((Builder) obj).datacenters)
-          && Objects.equals(this.blacklistedTables, ((Builder) obj).blacklistedTables);
+          && Objects.equals(this.blacklistedTables, ((Builder) obj).blacklistedTables)
+          && Objects.equals(this.repairThreadCount, ((Builder) obj).repairThreadCount);
     }
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
@@ -132,7 +132,8 @@ public interface JmxProxy extends NotificationListener {
       boolean fullRepair,
       Collection<String> datacenters,
       RepairStatusHandler repairStatusHandler,
-      List<RingRange> associatedTokens)
+      List<RingRange> associatedTokens,
+      int repairThreadCount)
       throws ReaperException;
 
   void close();

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
@@ -617,7 +617,8 @@ final class JmxProxyImpl implements JmxProxy {
       boolean fullRepair,
       Collection<String> datacenters,
       RepairStatusHandler repairStatusHandler,
-      List<RingRange> associatedTokens)
+      List<RingRange> associatedTokens,
+      int repairThreadCount)
       throws ReaperException {
 
     checkNotNull(ssProxy, "Looks like the proxy is not connected");
@@ -678,7 +679,8 @@ final class JmxProxyImpl implements JmxProxy {
             cassandraVersion,
             datacenters,
             repairStatusHandler,
-            associatedTokens);
+            associatedTokens,
+            repairThreadCount);
       }
     } catch (RuntimeException e) {
       LOG.error("Segment repair failed", e);
@@ -696,13 +698,14 @@ final class JmxProxyImpl implements JmxProxy {
       String cassandraVersion,
       Collection<String> datacenters,
       RepairStatusHandler repairStatusHandler,
-      List<RingRange> associatedTokens) {
+      List<RingRange> associatedTokens,
+      int repairThreadCount) {
 
     Map<String, String> options = new HashMap<>();
 
     options.put(RepairOption.PARALLELISM_KEY, repairParallelism.getName());
     options.put(RepairOption.INCREMENTAL_KEY, Boolean.toString(!fullRepair));
-    options.put(RepairOption.JOB_THREADS_KEY, Integer.toString(1));
+    options.put(RepairOption.JOB_THREADS_KEY, Integer.toString(repairThreadCount));
     options.put(RepairOption.TRACE_KEY, Boolean.toString(Boolean.FALSE));
     options.put(RepairOption.COLUMNFAMILIES_KEY, StringUtils.join(columnFamilies, ","));
     // options.put(RepairOption.PULL_REPAIR_KEY, Boolean.FALSE);

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
@@ -103,6 +103,9 @@ public final class RepairRunStatus {
   @JsonProperty("blacklisted_tables")
   private Collection<String> blacklistedTables;
 
+  @JsonProperty("repair_thread_count")
+  private int repairThreadCount;
+
   /**
    * Default public constructor Required for Jackson JSON parsing.
    */
@@ -129,7 +132,8 @@ public final class RepairRunStatus {
       RepairParallelism repairParallelism,
       Collection<String> nodes,
       Collection<String> datacenters,
-      Collection<String> blacklistedTables) {
+      Collection<String> blacklistedTables,
+      int repairThreadCount) {
 
     this.id = runId;
     this.cause = cause;
@@ -153,6 +157,7 @@ public final class RepairRunStatus {
     this.nodes = nodes;
     this.datacenters = datacenters;
     this.blacklistedTables = blacklistedTables;
+    this.repairThreadCount = repairThreadCount;
 
     if (startTime == null) {
       duration = null;
@@ -217,7 +222,8 @@ public final class RepairRunStatus {
         repairRun.getRepairParallelism(),
         repairUnit.getNodes(),
         repairUnit.getDatacenters(),
-        repairUnit.getBlacklistedTables());
+        repairUnit.getBlacklistedTables(),
+        repairUnit.getRepairThreadCount());
   }
 
   @JsonProperty("creation_time")
@@ -467,6 +473,15 @@ public final class RepairRunStatus {
 
   public void setBlacklistedTables(Collection<String> blacklistedTables) {
     this.blacklistedTables = blacklistedTables;
+  }
+
+
+  public int getRepairThreadCount() {
+    return repairThreadCount;
+  }
+
+  public void setRepairThreadCount(int repairThreadCount) {
+    this.repairThreadCount = repairThreadCount;
   }
 
   static double roundDoubleNicely(double intensity) {

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
@@ -82,6 +82,9 @@ public final class RepairScheduleStatus {
   @JsonProperty("segment_count_per_node")
   private int segmentCountPerNode;
 
+  @JsonProperty("repair_thread_count")
+  private int repairThreadCount;
+
   /**
    * Default public constructor Required for Jackson JSON parsing.
    */
@@ -106,7 +109,8 @@ public final class RepairScheduleStatus {
       Collection<String> nodes,
       Collection<String> datacenters,
       Collection<String> blacklistedTables,
-      int segmentCountPerNode) {
+      int segmentCountPerNode,
+      int repairThreadCount) {
 
     this.id = id;
     this.owner = owner;
@@ -126,6 +130,7 @@ public final class RepairScheduleStatus {
     this.datacenters = datacenters;
     this.blacklistedTables = blacklistedTables;
     this.segmentCountPerNode = segmentCountPerNode;
+    this.repairThreadCount = repairThreadCount;
   }
 
   public RepairScheduleStatus(RepairSchedule repairSchedule, RepairUnit repairUnit) {
@@ -147,7 +152,8 @@ public final class RepairScheduleStatus {
         repairUnit.getNodes(),
         repairUnit.getDatacenters(),
         repairUnit.getBlacklistedTables(),
-        repairSchedule.getSegmentCountPerNode());
+        repairSchedule.getSegmentCountPerNode(),
+        repairUnit.getRepairThreadCount());
   }
 
   public UUID getId() {
@@ -335,4 +341,15 @@ public final class RepairScheduleStatus {
   public void setSegmentCountPerNode(int segmentCountPerNode) {
     this.segmentCountPerNode = segmentCountPerNode;
   }
+
+  @JsonProperty("repair_thread_count")
+  public int getRepairThreadCount() {
+    return repairThreadCount;
+  }
+
+  public void setRepairThreadCount(int repairThreadCount) {
+    this.repairThreadCount = repairThreadCount;
+  }
+
+
 }

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -108,18 +108,19 @@ public final class ClusterRepairScheduler {
   private void createRepairSchedule(Cluster cluster, String keyspace, DateTime nextActivationTime) {
     boolean incrementalRepair = context.config.getIncrementalRepair();
 
-    RepairUnit.Builder builder
-        = new RepairUnit.Builder(
-                  cluster.getName(),
-                  keyspace,
-                  Collections.emptySet(),
-                  incrementalRepair,
-                  Collections.emptySet(),
-                  Collections.emptySet(),
-                  Collections.emptySet());
+    RepairUnit.Builder builder =
+        new RepairUnit.Builder(
+            cluster.getName(),
+            keyspace,
+            Collections.emptySet(),
+            incrementalRepair,
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Collections.emptySet(),
+            context.config.getRepairThreadCount());
 
-    RepairSchedule repairSchedule
-        = repairScheduleService.storeNewRepairSchedule(
+    RepairSchedule repairSchedule =
+        repairScheduleService.storeNewRepairSchedule(
             cluster,
             repairUnitService.getNewOrExistingRepairUnit(cluster, builder),
             context.config.getScheduleDaysBetween(),

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -305,7 +305,8 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
                     fullRepair,
                     repairUnit.getDatacenters(),
                     this,
-                    segment.getTokenRange().getTokenRanges());
+                    segment.getTokenRange().getTokenRanges(),
+                    repairUnit.getRepairThreadCount());
 
             if (0 != commandId) {
               processTriggeredSegment(segment, coordinator, commandId);

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -445,7 +445,8 @@ public final class MemoryStorage implements IStorage {
                 run.getRepairParallelism(),
                 unit.getNodes(),
                 unit.getDatacenters(),
-                unit.getBlacklistedTables()));
+                unit.getBlacklistedTables(),
+                unit.getRepairThreadCount()));
       }
       return runStatuses;
     }

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -282,13 +282,15 @@ public final class PostgresStorage implements IStorage {
     try (Handle h = jdbi.open()) {
       IStoragePostgreSql storage = getPostgresStorage(h);
 
-      result = storage.getRepairUnitByClusterAndTables(
-          params.clusterName,
-          params.keyspaceName,
-          params.columnFamilies,
-          params.nodes,
-          params.datacenters,
-          params.blacklistedTables);
+      result =
+          storage.getRepairUnitByClusterAndTables(
+              params.clusterName,
+              params.keyspaceName,
+              params.columnFamilies,
+              params.nodes,
+              params.datacenters,
+              params.blacklistedTables,
+              params.repairThreadCount);
     }
     return Optional.fromNullable(result);
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -86,14 +86,14 @@ public interface IStoragePostgreSql {
   //
   String SQL_REPAIR_UNIT_ALL_FIELDS_NO_ID =
       "cluster_name, keyspace_name, column_families, "
-          + "incremental_repair, nodes, datacenters, blacklisted_tables";
+          + "incremental_repair, nodes, datacenters, blacklisted_tables, repair_thread_count";
   String SQL_REPAIR_UNIT_ALL_FIELDS = "repair_unit.id, " + SQL_REPAIR_UNIT_ALL_FIELDS_NO_ID;
   String SQL_INSERT_REPAIR_UNIT =
       "INSERT INTO repair_unit ("
           + SQL_REPAIR_UNIT_ALL_FIELDS_NO_ID
           + ") VALUES "
           + "(:clusterName, :keyspaceName, :columnFamilies, "
-          + ":incrementalRepair, :nodes, :datacenters, :blacklistedTables)";
+          + ":incrementalRepair, :nodes, :datacenters, :blacklistedTables, :repairThreadCount)";
   String SQL_GET_REPAIR_UNIT = "SELECT " + SQL_REPAIR_UNIT_ALL_FIELDS + " FROM repair_unit WHERE id = :id";
 
   String SQL_GET_REPAIR_UNIT_BY_CLUSTER_AND_TABLES =
@@ -102,7 +102,7 @@ public interface IStoragePostgreSql {
           + " FROM repair_unit "
           + "WHERE cluster_name = :clusterName AND keyspace_name = :keyspaceName "
           + "AND column_families = :columnFamilies AND nodes = :nodes AND datacenters = :datacenters "
-          + "AND blackListed_tables = :blacklisted_tables";
+          + "AND blackListed_tables = :blacklisted_tables AND repair_thread_count = :repairThreadCount";
 
   String SQL_DELETE_REPAIR_UNIT = "DELETE FROM repair_unit WHERE id = :id";
 
@@ -310,7 +310,8 @@ public interface IStoragePostgreSql {
       @Bind("columnFamilies") Collection<String> columnFamilies,
       @Bind("nodes") Collection<String> nodes,
       @Bind("datacenters") Collection<String> datacenters,
-      @Bind("blacklisted_tables") Collection<String> blacklistedTables);
+      @Bind("blacklisted_tables") Collection<String> blacklistedTables,
+      @Bind("repairThreadCount") int repairThreadCount);
 
   @SqlUpdate(SQL_INSERT_REPAIR_UNIT)
   @GetGeneratedKeys

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
@@ -72,6 +72,8 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
                     ? new String[] {}
                     : rs.getArray("blacklisted_tables").getArray()));
 
+    int repairThreadCount = rs.getInt("repair_thread_count");
+
     return new RepairRunStatus(
         UuidUtil.fromSequenceId(runId),
         clusterName,
@@ -92,7 +94,8 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
         repairParallelism,
         nodes,
         datacenters,
-        blacklistedTables);
+        blacklistedTables,
+        repairThreadCount);
   }
 
   private String[] getStringArray(Object array) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -62,7 +62,8 @@ public final class RepairScheduleStatusMapper implements ResultSetMapper<RepairS
             rs.getArray("blacklisted_tables") == null
                 ? new String[] {}
                 : getStringArray(rs.getArray("blacklisted_tables").getArray())),
-        rs.getInt("segment_count_per_node"));
+        rs.getInt("segment_count_per_node"),
+        rs.getInt("repair_thread_count"));
   }
 
   private String[] getStringArray(Object array) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
@@ -51,7 +51,8 @@ public final class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
             rs.getBoolean("incremental_repair"),
             Sets.newHashSet(nodes),
             Sets.newHashSet(datacenters),
-            Sets.newHashSet(blacklistedTables));
+            Sets.newHashSet(blacklistedTables),
+            rs.getInt("repair_thread_count"));
 
     return builder.build(UuidUtil.fromSequenceId(rs.getLong("id")));
   }

--- a/src/server/src/main/resources/db/cassandra/013_multithreaded_repair.cql
+++ b/src/server/src/main/resources/db/cassandra/013_multithreaded_repair.cql
@@ -1,0 +1,4 @@
+--
+-- Upgrade to allow segments to contain several token ranges
+
+ALTER TABLE repair_unit_v1 ADD repair_thread_count int;

--- a/src/server/src/main/resources/db/h2/V8_0_0__multithreaded_repair.sql
+++ b/src/server/src/main/resources/db/h2/V8_0_0__multithreaded_repair.sql
@@ -1,0 +1,8 @@
+--
+-- Support for segment coalescing
+--
+
+ALTER TABLE repair_unit 
+ADD repair_thread_count INT;
+
+

--- a/src/server/src/main/resources/db/postgres/V8_0_0__repair_thread_count.sql
+++ b/src/server/src/main/resources/db/postgres/V8_0_0__repair_thread_count.sql
@@ -1,0 +1,8 @@
+--
+-- Support for segment coalescing
+--
+
+ALTER TABLE "repair_unit" 
+ADD "repair_thread_count" INT;
+
+

--- a/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
@@ -74,7 +74,8 @@ public final class RepairRunStatusTest {
             RepairParallelism.PARALLEL, // repairParellelism
             Collections.EMPTY_LIST, // nodes
             Collections.EMPTY_LIST, // datacenters
-            Collections.EMPTY_LIST); // blacklist
+            Collections.EMPTY_LIST, // blacklist
+            1); // repair thread count
 
     assertEquals("1 minute 0 seconds", repairStatus.getDuration());
   }
@@ -102,7 +103,8 @@ public final class RepairRunStatusTest {
             RepairParallelism.PARALLEL, // repairParellelism
             Collections.EMPTY_LIST, // nodes
             Collections.EMPTY_LIST, // datacenters
-            Collections.EMPTY_LIST); // blacklist
+            Collections.EMPTY_LIST, // blacklist
+            1); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }
@@ -130,7 +132,8 @@ public final class RepairRunStatusTest {
             RepairParallelism.PARALLEL, // repairParellelism
             Collections.EMPTY_LIST, // nodes
             Collections.EMPTY_LIST, // datacenters
-            Collections.EMPTY_LIST); // blacklist
+            Collections.EMPTY_LIST, // blacklist
+            1); // repair thread count
 
     assertEquals("1 minute 50 seconds", repairStatus.getDuration());
   }
@@ -158,7 +161,8 @@ public final class RepairRunStatusTest {
             RepairParallelism.PARALLEL, // repairParellelism
             Collections.EMPTY_LIST, // nodes
             Collections.EMPTY_LIST, // datacenters
-            Collections.EMPTY_LIST); // blacklist
+            Collections.EMPTY_LIST, // blacklist
+            1); // repair thread count
 
     assertEquals("30 seconds", repairStatus.getDuration());
   }

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -211,7 +211,8 @@ public final class ClusterRepairSchedulerTest {
         Boolean.FALSE,
         Collections.emptySet(),
         Collections.emptySet(),
-        Collections.emptySet());
+        Collections.emptySet(),
+        1);
   }
 
   private ClusterRepairScheduleAssertion assertThatClusterRepairSchedules(Collection<RepairSchedule> repairSchedules) {

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -62,6 +62,7 @@ public final class RepairManagerTest {
     final Set<String> nodes = Sets.newHashSet("127.0.0.1");
     final Set<String> datacenters = Collections.emptySet();
     final double intensity = 0.5f;
+    final int repairThreadCount = 1;
 
     // use CassandraStorage so we get both IStorage and IDistributedStorage
     final IStorage storage = mock(CassandraStorage.class);
@@ -76,15 +77,16 @@ public final class RepairManagerTest {
     context.repairManager = repairManager;
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    final RepairUnit cf
-        = new RepairUnit.Builder(
+    final RepairUnit cf =
+        new RepairUnit.Builder(
                 clusterName,
                 ksName,
                 cfNames,
                 incrementalRepair,
                 nodes,
                 datacenters,
-                Collections.emptySet())
+                Collections.emptySet(),
+                repairThreadCount)
             .build(UUIDs.timeBased());
 
     final RepairRun run
@@ -133,6 +135,7 @@ public final class RepairManagerTest {
     final Set<String> nodes = Sets.newHashSet("127.0.0.1");
     final Set<String> datacenters = Collections.emptySet();
     final double intensity = 0.5f;
+    final int repairThreadCount = 1;
 
     // use CassandraStorage so we get both IStorage and IDistributedStorage
     final IStorage storage = mock(CassandraStorage.class);
@@ -147,15 +150,16 @@ public final class RepairManagerTest {
     context.repairManager = repairManager;
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    final RepairUnit cf
-        = new RepairUnit.Builder(
+    final RepairUnit cf =
+        new RepairUnit.Builder(
                 clusterName,
                 ksName,
                 cfNames,
                 incrementalRepair,
                 nodes,
                 datacenters,
-                Collections.emptySet())
+                Collections.emptySet(),
+                repairThreadCount)
             .build(UUIDs.timeBased());
 
     final RepairRun run
@@ -205,6 +209,7 @@ public final class RepairManagerTest {
     final Set<String> nodes = Sets.newHashSet("127.0.0.1");
     final Set<String> datacenters = Collections.emptySet();
     final double intensity = 0.5f;
+    final int repairThreadCount = 1;
 
     final IStorage storage = mock(IStorage.class);
 
@@ -218,15 +223,16 @@ public final class RepairManagerTest {
     context.repairManager = repairManager;
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    final RepairUnit cf
-        = new RepairUnit.Builder(
+    final RepairUnit cf =
+        new RepairUnit.Builder(
                 clusterName,
                 ksName,
                 cfNames,
                 incrementalRepair,
                 nodes,
                 datacenters,
-                Collections.emptySet())
+                Collections.emptySet(),
+                repairThreadCount)
             .build(UUIDs.timeBased());
 
     final RepairRun run
@@ -272,6 +278,7 @@ public final class RepairManagerTest {
     final Set<String> nodes = Sets.newHashSet("127.0.0.1");
     final Set<String> datacenters = Collections.emptySet();
     final double intensity = 0.5f;
+    final int repairThreadCount = 1;
 
     final IStorage storage = mock(IStorage.class);
 
@@ -285,15 +292,16 @@ public final class RepairManagerTest {
     context.repairManager = repairManager;
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    final RepairUnit cf
-        = new RepairUnit.Builder(
+    final RepairUnit cf =
+        new RepairUnit.Builder(
                 clusterName,
                 ksName,
                 cfNames,
                 incrementalRepair,
                 nodes,
                 datacenters,
-                Collections.emptySet())
+                Collections.emptySet(),
+                repairThreadCount)
             .build(UUIDs.timeBased());
 
     final RepairRun run
@@ -339,16 +347,18 @@ public final class RepairManagerTest {
     final boolean incrementalRepair = false;
     final Set<String> nodes = Sets.newHashSet("127.0.0.1");
     final Set<String> datacenters = Collections.emptySet();
+    final int repairThreadCount = 1;
 
-    final RepairUnit cf
-        = new RepairUnit.Builder(
+    final RepairUnit cf =
+        new RepairUnit.Builder(
                 clusterName,
                 ksName,
                 cfNames,
                 incrementalRepair,
                 nodes,
                 datacenters,
-                Collections.emptySet())
+                Collections.emptySet(),
+                repairThreadCount)
             .build(UUIDs.timeBased());
 
     double intensity = 0.5f;

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -83,14 +83,14 @@ public final class RepairRunnerTest {
     final Set<String> BLACKLISTED_TABLES = Collections.emptySet();
     final long TIME_RUN = 41L;
     final double INTENSITY = 0.5f;
+    final int REPAIR_THREAD_COUNT = 1;
 
     final IStorage storage = new MemoryStorage();
-
     storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton("127.0.0.1")));
     RepairUnit cf =
         storage.addRepairUnit(
             new RepairUnit.Builder(CLUSTER_NAME, KS_NAME, CF_NAMES, INCREMENTAL_REPAIR, NODES,
-                DATACENTERS, BLACKLISTED_TABLES));
+                DATACENTERS, BLACKLISTED_TABLES, REPAIR_THREAD_COUNT));
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
     RepairRun run =
         storage.addRepairRun(
@@ -135,7 +135,7 @@ public final class RepairRunnerTest {
 
             when(jmx.triggerRepair(any(BigInteger.class), any(BigInteger.class),
                     any(), any(RepairParallelism.class), any(),
-                    anyBoolean(), any(), any(), any()))
+                    anyBoolean(), any(), any(), any(), any(Integer.class)))
                 .then(
                     (invocation) -> {
                       assertEquals(
@@ -235,6 +235,7 @@ public final class RepairRunnerTest {
     final Set<String> BLACKLISTED_TABLES = Collections.emptySet();
     final long TIME_RUN = 41L;
     final double INTENSITY = 0.5f;
+    final int REPAIR_THREAD_COUNT = 1;
 
     final IStorage storage = new MemoryStorage();
 
@@ -248,7 +249,8 @@ public final class RepairRunnerTest {
                 INCREMENTAL_REPAIR,
                 NODES,
                 DATACENTERS,
-                BLACKLISTED_TABLES));
+                BLACKLISTED_TABLES,
+                REPAIR_THREAD_COUNT));
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
     RepairRun run =
         storage.addRepairRun(
@@ -294,7 +296,7 @@ public final class RepairRunnerTest {
 
             when(jmx.triggerRepair(
                     any(BigInteger.class), any(BigInteger.class), any(), any(RepairParallelism.class),
-                    any(), anyBoolean(), any(), any(), any()))
+                    any(), anyBoolean(), any(), any(), any(), any(Integer.class)))
                 .then(
                     (invocation) -> {
                       assertEquals(
@@ -385,6 +387,7 @@ public final class RepairRunnerTest {
     final Set<String> BLACKLISTED_TABLES = Collections.emptySet();
     final long TIME_RUN = 41L;
     final double INTENSITY = 0.5f;
+    final int REPAIR_THREAD_COUNT = 1;
 
     final IStorage storage = new MemoryStorage();
     AppContext context = new AppContext();
@@ -403,7 +406,8 @@ public final class RepairRunnerTest {
                     INCREMENTAL_REPAIR,
                     NODES,
                     DATACENTERS,
-                    BLACKLISTED_TABLES))
+                    BLACKLISTED_TABLES,
+                    REPAIR_THREAD_COUNT))
             .getId();
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
 
@@ -457,7 +461,7 @@ public final class RepairRunnerTest {
                     any(),
                     anyBoolean(),
                     any(),
-                    any(), any()))
+                    any(), any(), any(Integer.class)))
                 .then(
                     (invocation) -> {
                       assertEquals(

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -88,7 +88,8 @@ public final class SegmentRunnerTest {
                 false,
                 Sets.newHashSet("127.0.0.1"),
                 Collections.emptySet(),
-                Collections.emptySet()));
+                Collections.emptySet(),
+                1));
     RepairRun run =
         context.storage.addRepairRun(
             new RepairRun.Builder(
@@ -129,7 +130,7 @@ public final class SegmentRunnerTest {
                     any(),
                     anyBoolean(),
                     any(),
-                    any(), any()))
+                    any(), any(), any(Integer.class)))
                 .then(
                     (invocation) -> {
                       assertEquals(
@@ -200,7 +201,8 @@ public final class SegmentRunnerTest {
                 false,
                 Sets.newHashSet("127.0.0.1"),
                 Collections.emptySet(),
-                Collections.emptySet()));
+                Collections.emptySet(),
+                1));
     RepairRun run =
         storage.addRepairRun(
             new RepairRun.Builder(
@@ -246,7 +248,7 @@ public final class SegmentRunnerTest {
                     any(),
                     anyBoolean(),
                     any(),
-                    any(), any()))
+                    any(), any(), any(Integer.class)))
                 .then(
                     invocation -> {
                       assertEquals(
@@ -346,7 +348,8 @@ public final class SegmentRunnerTest {
                 false,
                 Sets.newHashSet("127.0.0.1"),
                 Collections.emptySet(),
-                Collections.emptySet()));
+                Collections.emptySet(),
+                1));
     RepairRun run =
         storage.addRepairRun(
             new RepairRun.Builder(
@@ -392,7 +395,7 @@ public final class SegmentRunnerTest {
                     any(),
                     anyBoolean(),
                     any(),
-                    any(), any()))
+                    any(), any(), any(Integer.class)))
                 .then(
                     (invocation) -> {
                       assertEquals(

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -21,7 +21,7 @@ const repairForm = React.createClass({
       parallelism: null, intensity: null, cause: null, incrementalRepair: null, formCollapsed: true, nodes: "", datacenters: "", blacklistedTables: "",
       nodeList: [], datacenterList: [], clusterStatus: {}, urlPrefix: URL_PREFIX, nodeSuggestions: [], datacenterSuggestions: [], tableSuggestions: [], 
       clusterTables: {}, blacklistSuggestions: [], tableList: [], blacklistList: [], keyspaceList: [], keyspaceSuggestions: [],
-      blacklistReadOnly: false, tablelistReadOnly: false, advancedFormCollapsed: true
+      blacklistReadOnly: false, tablelistReadOnly: false, advancedFormCollapsed: true, repairThreadCount: 1
     };
   },
 
@@ -106,6 +106,7 @@ const repairForm = React.createClass({
     if(this.state.nodes) repair.nodes = this.state.nodes;
     if(this.state.datacenters) repair.datacenters = this.state.datacenters;
     if(this.state.blacklistedTables) repair.blacklistedTables = this.state.blacklistedTables;
+    if(this.state.repairThreadCount && this.state.repairThreadCount > 0) repair.repairThreadCount = this.state.repairThreadCount;
 
     // Force incremental repair to FALSE if empty
     if(!this.state.incrementalRepair) repair.incrementalRepair = "false";
@@ -507,6 +508,14 @@ const repairForm = React.createClass({
                           <option value="false">false</option>
                           <option value="true">true</option>
                         </select>
+                      </div>
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor="in_repairThreadCount" className="col-sm-3 control-label">Repair threads</label>
+                      <div className="col-sm-14 col-md-12 col-lg-9">
+                        <input type="number" className="form-control" value={this.state.repairThreadCount}
+                          min="1" max="4"
+                          onChange={this._handleChange} id="in_repairThreadCount" placeholder="repair threads"/>
                       </div>
                     </div>
                   </div>

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -198,6 +198,10 @@ const TableRowDetails = React.createClass({
                     <td>{incremental}</td>
                 </tr>
                 <tr>
+                    <td>Repair threads</td>
+                    <td>{this.props.row.repair_thread_count}</td>
+                </tr>
+                <tr>
                     <td>Nodes</td>
                     <td><CFsListRender list={this.props.row.nodes} /></td>
                 </tr>

--- a/src/ui/app/jsx/schedule-form.jsx
+++ b/src/ui/app/jsx/schedule-form.jsx
@@ -22,7 +22,7 @@ const scheduleForm = React.createClass({
       parallelism: null, intensity: null, startTime: null, intervalDays: null, incrementalRepair: null, formCollapsed: true, nodes: null, datacenters: null,
       nodes: "", datacenters: "", blacklistedTables: "", nodeList: [], datacenterList: [], clusterStatus: {}, urlPrefix: URL_PREFIX, nodeSuggestions: [], datacenterSuggestions: [],
       clusterTables: {}, tableSuggestions: [], blacklistSuggestions: [], tableList: [], blacklistList: [], keyspaceList: [], keyspaceSuggestions: [], 
-      blacklistReadOnly: false, tablelistReadOnly: false, advancedFormCollapsed: true
+      blacklistReadOnly: false, tablelistReadOnly: false, advancedFormCollapsed: true, repairThreadCount: 1
     };
   },
 
@@ -110,6 +110,7 @@ const scheduleForm = React.createClass({
     if(this.state.nodes) schedule.nodes = this.state.nodes;
     if(this.state.datacenters) schedule.datacenters = this.state.datacenters;
     if(this.state.blacklistedTables) schedule.blacklistedTables = this.state.blacklistedTables;
+    if(this.state.repairThreadCount) schedule.repairThreadCount = this.state.repairThreadCount;
 
     this.props.addScheduleSubject.onNext(schedule);
   },
@@ -513,6 +514,14 @@ const scheduleForm = React.createClass({
                           <option value="false">false</option>
                           <option value="true">true</option>                  
                         </select>
+                      </div>
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor="in_repairThreadCount" className="col-sm-3 control-label">Repair threads</label>
+                      <div className="col-sm-14 col-md-12 col-lg-9">
+                        <input type="number" className="form-control" value={this.state.repairThreadCount}
+                          min="1" max="4"
+                          onChange={this._handleChange} id="in_repairThreadCount" placeholder="repair threads"/>
                       </div>
                     </div>
                   </div>

--- a/src/ui/app/jsx/schedule-list.jsx
+++ b/src/ui/app/jsx/schedule-list.jsx
@@ -86,6 +86,10 @@ const TableRowDetails = React.createClass({
                     <td>{this.props.row.intensity}</td>
                 </tr>
                 <tr>
+                    <td>Repair threads</td>
+                    <td>{this.props.row.repair_thread_count}</td>
+                </tr>
+                <tr>
                     <td>Repair parallelism</td>
                     <td>{this.props.row.repair_parallelism}</td>
                 </tr>


### PR DESCRIPTION
Since Cassandra 2.2, repairs are multithreaded in order to process several token ranges concurrently and speed up the process.
While it would have made no sense to support this before, token range coalescing made it necessary to maximize performance on Cassandra 2.2.
No more than four threads are authorized by Cassandra. The number of repair threads can be set differently for each repair run/schedule.
