### PR TITLE
Upgrade dependencies (Upgrade to DropWizard 1.1.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 language: java
+addons:
+  postgresql: "9.4"
 jdk:
 - oraclejdk8
 branches:

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
           <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19</version>
+                <version>2.21.0</version>
                 <inherited>true</inherited>
                 <configuration>
                   <argLine>${surefireArgLine}</argLine>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -15,11 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.0.8</dropwizard.version>
-        <dropwizard.cassandra.version>4.1.0</dropwizard.cassandra.version>
-        <dropwizard.metrics.datadog.version>1.0.6</dropwizard.metrics.datadog.version>
-        <cassandra.version>2.2.7</cassandra.version>
-        <cucumber.version>1.2.5</cucumber.version>
+        <dropwizard.version>1.1.7</dropwizard.version>
         <docker.directory>src/main/docker</docker.directory>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
@@ -30,27 +26,27 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-access</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>javax.mail-api</artifactId>
-            <version>1.5.6</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -68,19 +64,19 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.coursera</groupId>
-            <artifactId>dropwizard-metrics-datadog</artifactId>
-            <version>${dropwizard.metrics.datadog.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.coursera</groupId>
+            <artifactId>dropwizard-metrics-datadog</artifactId>
+            <version>1.1.13</version>
+        </dependency>
+        <dependency>
             <groupId>systems.composable</groupId>
             <artifactId>dropwizard-cassandra</artifactId>
-            <version>${dropwizard.cassandra.version}</version>
+            <version>4.1.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -91,7 +87,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>${cassandra.version}</version>
+            <version>2.2.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -110,47 +106,73 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>3.1.4</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.3-1100-jdbc41</version>
+            <version>42.2.2.jre7</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.186</version>
+            <version>1.4.197</version>
         </dependency>
         <dependency>
             <groupId>org.cognitor.cassandra</groupId>
             <artifactId>cassandra-migration</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>4.0.3</version>
+            <version>5.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>0.0.25</version>
+            <version>0.4.0</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_servlet</artifactId>
-            <version>0.0.25</version>
+            <version>0.4.0</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_dropwizard</artifactId>
-            <version>0.0.25</version>
+            <version>0.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.secnod.dropwizard</groupId>
             <artifactId>dropwizard-shiro</artifactId>
             <version>0.2.0</version>
+        </dependency>
+        <dependency>
+            <!-- fixes bug around duplicate requests
+              - https://stackoverflow.com/questions/37956741/jersey-resource-receiving-duplicate-requests-from-jersey-client#39377403
+             -->
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.25.1</version>
+        </dependency>
+        <dependency>
+            <!-- required to solve dropwizard 1.1.7 & jersery-client 2.25.1 dependency issues -->
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>2.25.1</version>
+        </dependency>
+        <dependency>
+            <!-- required to solve dropwizard 1.1.7 & jersery-client 2.25.1 dependency issues -->
+          <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
+          <artifactId>jersey-guava</artifactId>
+          <version>2.25.1</version>
+        </dependency>
+        <dependency>
+            <!-- required to solve dropwizard 1.1.7 & jersery-client 2.25.1 dependency issues -->
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-api</artifactId>
+            <version>2.5.0-b61</version>
         </dependency>
         
         <!--test scope -->
@@ -158,7 +180,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -180,25 +202,25 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.10.0</version>
+            <version>2.18.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>${cucumber.version}</version>
+            <version>1.2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>${cucumber.version}</version>
+            <version>1.2.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>2.0.0</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -206,14 +228,6 @@
             <artifactId>fest-assert-core</artifactId>
             <version>2.0M10</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!-- fixes bug around duplicate requests
-              - https://stackoverflow.com/questions/37956741/jersey-resource-receiving-duplicate-requests-from-jersey-client#39377403
-             -->
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>2.25.1</version>
         </dependency>
     </dependencies>
 
@@ -268,12 +282,12 @@
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8.2</version>
+                        <version>2.8.4</version>
                     </dependency>
                     <dependency>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_core</artifactId>
-                        <version>2.1.1</version>
+                        <version>2.3.1</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -300,7 +314,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.21.0</version>
                 <executions>
                   <execution>
                     <id>integration-tests</id>
@@ -323,7 +337,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.1.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -349,7 +363,7 @@
                 <!-- Creating a fat jar by including all classes required for running the app -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <filters>
@@ -385,7 +399,7 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.0</version>
                 <configuration>
                     <imageName>cassandra-reaper</imageName>
                     <dockerDirectory>${docker.directory}</dockerDirectory>
@@ -404,7 +418,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>validate</id>
@@ -516,7 +530,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.1.0</version>
                 <executions>
                   <execution>
                     <id>copy-ui-resources</id>

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -233,9 +233,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
 
     if (config.isAccessControlEnabled()) {
       SessionHandler sessionHandler = new SessionHandler();
-      sessionHandler
-          .getSessionManager()
-          .setMaxInactiveInterval((int) config.getAccessControl().getSessionTimeout().getSeconds());
+      sessionHandler.setMaxInactiveInterval((int) config.getAccessControl().getSessionTimeout().getSeconds());
       environment.getApplicationContext().setSessionHandler(sessionHandler);
       environment.servlets().setSessionHandler(sessionHandler);
       environment.jersey().register(new ShiroExceptionMapper());

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -203,13 +203,43 @@ public final class SchedulingManager extends TimerTask {
   }
 
   private static boolean equal(RepairSchedule s1, RepairSchedule s2) {
-    Preconditions.checkArgument(s1.getId().equals(s2.getId()));
-    Preconditions.checkArgument(s1.getOwner().equals(s2.getOwner()));
-    Preconditions.checkArgument(s1.getDaysBetween() == s2.getDaysBetween());
-    Preconditions.checkArgument(s1.getIntensity() == s2.getIntensity());
-    Preconditions.checkArgument(s1.getCreationTime().equals(s2.getCreationTime()));
-    Preconditions.checkArgument(s1.getNextActivation().equals(s2.getNextActivation()));
-    Preconditions.checkArgument(s1.getFollowingActivation().equals(s2.getFollowingActivation()));
+    Preconditions.checkArgument(s1.getId().equals(s2.getId()), "%s does not equal %s", s1.getId(), s2.getId());
+
+    Preconditions.checkArgument(
+        s1.getOwner().equals(s2.getOwner()),
+        "%s does not equal %s",
+        s1.getOwner(),
+        s2.getOwner());
+
+    Preconditions.checkArgument(
+        s1.getDaysBetween() == s2.getDaysBetween(),
+        "%s does not equal %s",
+        s1.getDaysBetween(),
+        s2.getDaysBetween());
+
+    Preconditions.checkArgument(
+        0.01d > Math.abs(s1.getIntensity() - s2.getIntensity()),
+        "%s does not equal %s",
+        s1.getIntensity(),
+        s2.getIntensity());
+
+    Preconditions.checkArgument(
+        s1.getCreationTime().equals(s2.getCreationTime()),
+        "%s does not equal %s",
+        s1.getCreationTime(),
+        s2.getCreationTime());
+
+    Preconditions.checkArgument(
+        s1.getNextActivation().equals(s2.getNextActivation()),
+        "%s does not equal %s",
+        s1.getNextActivation(),
+        s2.getNextActivation());
+
+    Preconditions.checkArgument(
+        s1.getFollowingActivation().equals(s2.getFollowingActivation()),
+        "%s does not equal %s",
+        s1.getFollowingActivation(),
+        s2.getFollowingActivation());
 
     boolean result = s1.getState().equals(s2.getState());
     result &= s1.getRunHistory().size() == s2.getRunHistory().size();

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -178,7 +178,8 @@ public final class BasicSteps {
       Assertions
           .assertThat(Arrays.asList(expectedStatuses).stream().map(Response.Status::getStatusCode))
           .contains(response.getStatus())
-          .withFailMessage(responseEntity);
+          .withFailMessage(responseEntity)
+          .isNotEmpty();
 
       if (1 == RUNNERS.size() && expectedStatuses[0].getStatusCode() != response.getStatus()) {
         // we can't fail on this because the jersey client sometimes sends
@@ -214,12 +215,12 @@ public final class BasicSteps {
     synchronized (BasicSteps.class) {
       setupReaperTestRunner();
 
-//      callAndExpect(
-//          "HEAD",
-//          "/ping",
-//          Optional.<Map<String, String>>absent(),
-//          Optional.<String>absent(),
-//          Response.Status.NO_CONTENT);
+      //      callAndExpect(
+      //          "HEAD",
+      //          "/ping",
+      //          Optional.<Map<String, String>>absent(),
+      //          Optional.<String>absent(),
+      //          Response.Status.NO_CONTENT);
     }
   }
 
@@ -1128,7 +1129,7 @@ public final class BasicSteps {
           set.compareAndSet(false, true);
         }
       });
-      Assertions.assertThat(set.get());
+      Assertions.assertThat(set.get()).isTrue();
 
       callAndExpect(
           "PUT",
@@ -1171,7 +1172,7 @@ public final class BasicSteps {
           set.compareAndSet(false, true);
         }
       });
-      Assertions.assertThat(set.get());
+      Assertions.assertThat(set.get()).isTrue();
 
       callAndExpect(
           "PUT",


### PR DESCRIPTION
Reason for this PR
 - https://github.com/thelastpickle/cassandra-reaper/issues/224
 - security and bugfixes.


Upgrade dependencies.
 - dropwizard 1.0.8 -> 1.1.7
 - guava 19 -> 20
 - logback 1.2.2 -> 1.2.3
 - javax.mail-api 1.5.6 -> 1.6.6
 - dropwizard-metrics-datadog 1.0.6 -> 1.1.13
 - postgresql 9.3-1104-jdbc41 -> 9.4.1212.jre7
 - cassandra-driver-core 3.1.4 -> 3.5.0
 - cassandra 2.2.7 -> 2.2.12
 - postgresql 9.3-1100-jdbc41 -> 42.2.2.jre7
 - h2 1.4.186 -> 1.4.197
 - cassandra-migration 2.0.0 -> 2.1.2
 - flyway-core 4.0.3 -> 5.1.0
 - prometheus 0.0.25 -> 0.4.0
 - junit 4.11 -> 4.12
 - mockito-core 2.10.0 -> 2.18.3
 - awaitility 2.0.0 -> 3.1.0

Upgrade plugins.
 - maven-surefire-plugin 2.19 -> 2.21.0
 - maven-failsafe-plugin 2.20 -> 2.21.0
 - maven-resources-plugin 3.0.2 -> 3.1.0
 - maven-checkstyle-plugin 2.17 -> 3.0.0
 - docker-maven-plugin 1.0.0 -> 1.1.0
 - maven-shade-plugin 3.0.0 -> 3.1.1
 - maven-jar-plugin 3.0.2 -> 3.1.0
 - error_prone_core 2.1.1 -> 2.3.1
 - plexus-compiler-javac-errorprone 2.8.2 -> 2.8.4

Updated integration tests:
 - tests against postgresql 9.2 -> 9.4