### PR TITLE
Implement limit in `CassandraStorage.getRepairRunsForCluster(cluster, limit)`

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/ClusterResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/ClusterResource.java
@@ -312,7 +312,7 @@ public final class ClusterResource {
           .entity("cluster \"" + clusterName + "\" cannot be deleted, as it has repair schedules")
           .build();
     }
-    if (!context.storage.getRepairRunsForCluster(clusterName).isEmpty()) {
+    if (!context.storage.getRepairRunsForCluster(clusterName, Optional.absent()).isEmpty()) {
       return Response.status(Response.Status.CONFLICT)
           .entity("cluster \"" + clusterName + "\" cannot be deleted, as it has repair runs")
           .build();

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -606,7 +606,7 @@ public final class RepairRunResource {
       @PathParam("cluster_name") String clusterName) {
 
     LOG.debug("get repair run for cluster called with: cluster_name = {}", clusterName);
-    final Collection<RepairRun> repairRuns = context.storage.getRepairRunsForCluster(clusterName);
+    final Collection<RepairRun> repairRuns = context.storage.getRepairRunsForCluster(clusterName, Optional.absent());
     final Collection<RepairRunStatus> repairRunViews = new ArrayList<>();
     for (final RepairRun repairRun : repairRuns) {
       repairRunViews.add(getRepairRunStatus(repairRun));
@@ -660,7 +660,7 @@ public final class RepairRunResource {
           .or(context.storage.getClusters());
 
       for (final Cluster clstr : clusters) {
-        Collection<RepairRun> runs = context.storage.getRepairRunsForCluster(clstr.getName());
+        Collection<RepairRun> runs = context.storage.getRepairRunsForCluster(clstr.getName(), Optional.absent());
         runStatuses.addAll(
             (List<RepairRunStatus>) getRunStatuses(runs, desiredStates)
                 .stream()

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -27,6 +27,7 @@ import io.cassandrareaper.service.RepairParameters;
 import io.cassandrareaper.service.RingRange;
 
 import java.util.Collection;
+import java.util.SortedSet;
 import java.util.UUID;
 
 import com.google.common.base.Optional;
@@ -62,7 +63,8 @@ public interface IStorage {
 
   Optional<RepairRun> getRepairRun(UUID id);
 
-  Collection<RepairRun> getRepairRunsForCluster(String clusterName);
+  /** return all the repair runs in a cluster, in reverse chronological order, with default limit is 1000 */
+  Collection<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit);
 
   Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId);
 
@@ -100,7 +102,7 @@ public interface IStorage {
 
   Collection<RepairParameters> getOngoingRepairsInCluster(String clusterName);
 
-  Collection<UUID> getRepairRunIdsForCluster(String clusterName);
+  SortedSet<UUID> getRepairRunIdsForCluster(String clusterName);
 
   int getSegmentAmountForRepairRun(UUID runId);
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -39,12 +39,15 @@ import io.cassandrareaper.storage.postgresql.UuidUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.SortedSet;
 import java.util.UUID;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.exceptions.DBIException;
@@ -159,10 +162,10 @@ public final class PostgresStorage implements IStorage {
   }
 
   @Override
-  public Collection<RepairRun> getRepairRunsForCluster(String clusterName) {
+  public Collection<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit) {
     Collection<RepairRun> result;
     try (Handle h = jdbi.open()) {
-      result = getPostgresStorage(h).getRepairRunsForCluster(clusterName);
+      result = getPostgresStorage(h).getRepairRunsForCluster(clusterName, limit.or(1000));
     }
     return result == null ? Lists.<RepairRun>newArrayList() : result;
   }
@@ -384,8 +387,8 @@ public final class PostgresStorage implements IStorage {
   }
 
   @Override
-  public Collection<UUID> getRepairRunIdsForCluster(String clusterName) {
-    Collection<UUID> result = Lists.newArrayList();
+  public SortedSet<UUID> getRepairRunIdsForCluster(String clusterName) {
+    SortedSet<UUID> result = Sets.newTreeSet(Collections.reverseOrder());
     try (Handle h = jdbi.open()) {
       for (Long l : getPostgresStorage(h).getRepairRunIdsForCluster(clusterName)) {
         result.add(UuidUtil.fromSequenceId(l));

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -75,7 +75,7 @@ public interface IStoragePostgreSql {
       + "repair_parallelism = :repairParallelism WHERE id = :id";
   String SQL_GET_REPAIR_RUN = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS + " FROM repair_run WHERE id = :id";
   String SQL_GET_REPAIR_RUNS_FOR_CLUSTER = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS
-      + " FROM repair_run WHERE cluster_name = :clusterName";
+      + " FROM repair_run WHERE cluster_name = :clusterName ORDER BY id desc LIMIT :limit";
   String SQL_GET_REPAIR_RUNS_WITH_STATE = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS
       + " FROM repair_run WHERE state = :state";
   String SQL_GET_REPAIR_RUNS_FOR_UNIT = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS
@@ -272,7 +272,8 @@ public interface IStoragePostgreSql {
   @SqlQuery(SQL_GET_REPAIR_RUNS_FOR_CLUSTER)
   @Mapper(RepairRunMapper.class)
   Collection<RepairRun> getRepairRunsForCluster(
-      @Bind("clusterName") String clusterName);
+      @Bind("clusterName") String clusterName,
+      @Bind("limit") int limit);
 
   @SqlQuery(SQL_GET_REPAIR_RUNS_WITH_STATE)
   @Mapper(RepairRunMapper.class)

--- a/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
@@ -72,7 +72,7 @@ public final class ClusterResourceTest {
 
     Cluster cluster = mocks.context.storage.getCluster(CLUSTER_NAME).get();
     assertNotNull("Did not find expected cluster", cluster);
-    assertEquals(0, mocks.context.storage.getRepairRunsForCluster(cluster.getName()).size());
+    assertEquals(0, mocks.context.storage.getRepairRunsForCluster(cluster.getName(), Optional.of(1)).size());
     assertEquals(CLUSTER_NAME, cluster.getName());
     assertEquals(1, cluster.getSeedHosts().size());
     assertEquals(SEED_HOST, cluster.getSeedHosts().iterator().next());
@@ -95,7 +95,7 @@ public final class ClusterResourceTest {
 
     cluster = mocks.context.storage.getCluster(CLUSTER_NAME).get();
     assertNotNull("Did not find expected cluster", cluster);
-    assertEquals(0, mocks.context.storage.getRepairRunsForCluster(cluster.getName()).size());
+    assertEquals(0, mocks.context.storage.getRepairRunsForCluster(cluster.getName(), Optional.of(1)).size());
     assertEquals(CLUSTER_NAME, cluster.getName());
     assertEquals(1, cluster.getSeedHosts().size());
     assertEquals(SEED_HOST, cluster.getSeedHosts().iterator().next());
@@ -118,7 +118,7 @@ public final class ClusterResourceTest {
 
     cluster = mocks.context.storage.getCluster(CLUSTER_NAME).get();
     assertNotNull("Did not find expected cluster", cluster);
-    assertEquals(0, mocks.context.storage.getRepairRunsForCluster(cluster.getName()).size());
+    assertEquals(0, mocks.context.storage.getRepairRunsForCluster(cluster.getName(), Optional.of(1)).size());
     assertEquals(CLUSTER_NAME, cluster.getName());
     assertEquals(1, cluster.getSeedHosts().size());
     assertEquals(SEED_HOST, cluster.getSeedHosts().iterator().next());

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -218,7 +218,7 @@ public final class RepairRunResourceTest {
     assertTrue(response.getEntity() instanceof RepairRunStatus);
 
     assertEquals(1, context.storage.getClusters().size());
-    assertEquals(1, context.storage.getRepairRunsForCluster(CLUSTER_NAME).size());
+    assertEquals(1, context.storage.getRepairRunsForCluster(CLUSTER_NAME, Optional.of(2)).size());
     assertEquals(1, context.storage.getRepairRunIdsForCluster(CLUSTER_NAME).size());
     UUID runId = context.storage.getRepairRunIdsForCluster(CLUSTER_NAME).iterator().next();
     RepairRun run = context.storage.getRepairRun(runId).get();
@@ -243,7 +243,18 @@ public final class RepairRunResourceTest {
     assertTrue(response.getEntity() instanceof RepairRunStatus);
 
     assertEquals(1, context.storage.getClusters().size());
-    assertEquals(2, context.storage.getRepairRunsForCluster(CLUSTER_NAME).size());
+    assertEquals(1, context.storage.getRepairRunsForCluster(CLUSTER_NAME, Optional.of(1)).size());
+    assertEquals(2, context.storage.getRepairRunsForCluster(CLUSTER_NAME, Optional.of(2)).size());
+    assertEquals(2, context.storage.getRepairRunsForCluster(CLUSTER_NAME, Optional.of(3)).size());
+
+    assertEquals(
+        context.storage.getRepairRunsForCluster(CLUSTER_NAME, Optional.of(3)).iterator().next().getId(),
+        context.storage.getRepairRunsForCluster(CLUSTER_NAME, Optional.of(1)).iterator().next().getId());
+
+    assertEquals(
+        context.storage.getRepairRunsForCluster(CLUSTER_NAME, Optional.of(2)).iterator().next().getId(),
+        context.storage.getRepairRunsForCluster(CLUSTER_NAME, Optional.of(1)).iterator().next().getId());
+
   }
 
   @Test


### PR DESCRIPTION
As this was previously unimplemented it lead to large scans that performed poorly, and impacted the ability of a Cassandra backend to store repair run history.
This came up in PR#427 where a purge feature that deleted repair run history was deemed to be necessary, and again in issue #435 which presumed the fix would have to be schema changes.
Further investigation reveal it was simply the matter that the IStorage contract was not being fully implemented.

The implementation takes a small step further by also adding a limit to `IStorage.getRepairRunsForCluster(cluster)`
 and narrowing the return type of `IStorage.getRepairRunIdsForCluster(cluster)` from Collection to SortedSet, as this collection now contains time-based UUIDs which can (and should) be returned sorted in reverse chronological order.

References:
 - Optimize repair runs scans with the Cassandra backend :: https://github.com/thelastpickle/cassandra-reaper/issues/435
 - Add automated purge functions :: https://github.com/thelastpickle/cassandra-reaper/pull/427

