### PR TITLE
Fix incremental repair segments from being identified as stuck

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -146,14 +146,20 @@ public final class RepairManager implements AutoCloseable {
           "No leader on the following segments : {}",
           runningSegments
               .stream()
-              .filter(segment -> !activeLeaders.contains(segment.getId()))
+              .filter(
+                  segment ->
+                      !activeLeaders.contains(segment.getId())
+                          && !activeLeaders.contains(segment.getRunId()))
               .map(seg -> seg.getId())
               .collect(Collectors.toSet()));
 
       abortSegments(
           runningSegments
               .stream()
-              .filter(segment -> !activeLeaders.contains(segment.getId()))
+              .filter(
+                  segment ->
+                      !activeLeaders.contains(segment.getId())
+                          && !activeLeaders.contains(segment.getRunId()))
               .collect(Collectors.toSet()),
           repairRun,
           false,


### PR DESCRIPTION
Fixes #439 and #285 

We implemented a cleanup process to unblock stuck segments in the database when using Cassandra as backend.
To do this, we check if segments at RUNNING have a leader and if not we cancel their leadership and abort the repair on the coordinator node.

Incremental repairs use the repair run id instead of the segment id to take leadership so that only one segment can be processed at once on the cluster (otherwise incremental repair fails), but the cleanup process only checks the segment ids, thus leading to Reaper aborting running incremental repairs.
The fix checks both segment ids and repair run ids when looking for leaders.