### PR TITLE
Improve start time selection for schedules

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
@@ -170,7 +170,7 @@ public final class RepairSchedule {
       this.segmentCountPerNode = segmentCountPerNode;
     }
 
-    private Builder(RepairSchedule original) {
+    public Builder(RepairSchedule original) {
       repairUnitId = original.repairUnitId;
       state = original.state;
       daysBetween = original.daysBetween;

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -128,8 +128,8 @@ public final class SchedulingManager extends TimerTask {
       case ACTIVE:
         if (schdle.getNextActivation().isBeforeNow()) {
 
-          RepairSchedule schedule
-              = schdle.with().nextActivation(schdle.getFollowingActivation()).build(schdle.getId());
+          RepairSchedule schedule =
+              schdle.with().nextActivation(schdle.getFollowingActivation()).build(schdle.getId());
 
           context.storage.updateRepairSchedule(schedule);
 
@@ -146,15 +146,20 @@ public final class SchedulingManager extends TimerTask {
           try {
             RepairRun newRepairRun = createNewRunForUnit(schedule, repairUnit);
 
-            ImmutableList<UUID> newRunHistory
-                = new ImmutableList.Builder<UUID>().addAll(schedule.getRunHistory()).add(newRepairRun.getId()).build();
+            ImmutableList<UUID> newRunHistory =
+                new ImmutableList.Builder<UUID>()
+                    .addAll(schedule.getRunHistory())
+                    .add(newRepairRun.getId())
+                    .build();
 
-            RepairSchedule latestSchedule = context.storage.getRepairSchedule(schedule.getId()).get();
+            RepairSchedule latestSchedule =
+                context.storage.getRepairSchedule(schedule.getId()).get();
 
             if (equal(schedule, latestSchedule)) {
 
-              boolean result = context.storage.updateRepairSchedule(
-                  schedule.with().runHistory(newRunHistory).build(schedule.getId()));
+              boolean result =
+                  context.storage.updateRepairSchedule(
+                      schedule.with().runHistory(newRunHistory).build(schedule.getId()));
               // FIXME – concurrency is broken unless we atomically add/remove run history items
               // boolean result = context.storage
               //        .addRepairRunToRepairSchedule(schedule.getId(), newRepairRun.getId());
@@ -164,14 +169,19 @@ public final class SchedulingManager extends TimerTask {
                 return true;
               }
             } else if (schedule.getRunHistory().size() < latestSchedule.getRunHistory().size()) {
-              UUID newRepairRunId = latestSchedule.getRunHistory().get(latestSchedule.getRunHistory().size() - 1);
-              LOG.info("schedule {} has already added a new repair run {}", schedule.getId(), newRepairRunId);
+              latestSchedule.getRunHistory().get(latestSchedule.getRunHistory().size() - 1);
+              LOG.info(
+                  "schedule {} has already added a new repair run {}",
+                  schedule.getId(),
+                  newRepairRun.getId());
               // this repair_run is identified as a duplicate (for this activation):
               // so take the last repair run, and try start it. it's ok if already running.
-              newRepairRun = context.storage.getRepairRun(newRepairRunId).get();
+              newRepairRun = context.storage.getRepairRun(newRepairRun.getId()).get();
               context.repairManager.startRepairRun(newRepairRun);
             } else {
-              LOG.warn("schedule {} has been altered by someone else. not running repair", schedule.getId());
+              LOG.warn(
+                  "schedule {} has been altered by someone else. not running repair",
+                  schedule.getId());
             }
             // this duplicated repair_run needs to be removed from the schedule's history
             // FIXME – concurrency is broken unless we atomically add/remove run history items

--- a/src/ui/app/jsx/schedule-form.jsx
+++ b/src/ui/app/jsx/schedule-form.jsx
@@ -102,7 +102,7 @@ const scheduleForm = React.createClass({
   _onAdd: function(e) {
     const schedule = {
       clusterName: this.state.clusterName, keyspace: this.state.keyspace,
-      owner: this.state.owner, scheduleTriggerTime: moment(this.state.startTime).format("YYYY-MM-DDTHH:mm:ss"),
+      owner: this.state.owner, scheduleTriggerTime: moment(this.state.startTime).utc().format("YYYY-MM-DDTHH:mm"),
       scheduleDaysBetween: this.state.intervalDays
     };
     if(this.state.tables) schedule.tables = this.state.tables;


### PR DESCRIPTION
Fixes #398 
Fixes #241 

This commit eases using the UI to create repair schedules by adjusting the time from the client timezone to UTC (as the server uses UTC).
It also allows activation times in the past, which will trigger a repair immediately.
A "run now" button was added to the UI in order to start a schedule right away by updating the next activation time.