### PR TITLE
Refactor the `IStorage.getRepairUnit(UUID)` method to return the RepairUnit instead of an Optional

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -179,11 +178,7 @@ public final class ClusterRepairScheduler {
       Collection<RepairSchedule> currentSchedules = context.storage.getRepairSchedulesForCluster(cluster.getName());
       return currentSchedules
           .stream()
-          .map(
-              repairSchedule -> {
-                Optional<RepairUnit> repairUnit = context.storage.getRepairUnit(repairSchedule.getRepairUnitId());
-                return repairUnit.get().getKeyspaceName();
-              })
+          .map(repairSchedule -> context.storage.getRepairUnit(repairSchedule.getRepairUnitId()).getKeyspaceName())
           .collect(Collectors.toSet());
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -72,20 +72,17 @@ final class RepairRunner implements Runnable {
     assert repairRun.isPresent() : "No RepairRun with ID " + repairRunId + " found from storage";
     Optional<Cluster> cluster = context.storage.getCluster(repairRun.get().getClusterName());
     assert cluster.isPresent() : "No Cluster with name " + repairRun.get().getClusterName() + " found from storage";
-    Optional<RepairUnit> repairUnitOpt = context.storage.getRepairUnit(repairRun.get().getRepairUnitId());
-    assert repairUnitOpt.isPresent() : "No RepairUnit with id " + repairRun.get().getRepairUnitId()
-        + " found in storage";
+    RepairUnit repairUnitOpt = context.storage.getRepairUnit(repairRun.get().getRepairUnitId());
     this.clusterName = cluster.get().getName();
 
-    JmxProxy jmx =
-        this.context.jmxConnectionFactory.connectAny(
-            cluster.get(), context.config.getJmxConnectionTimeoutInSeconds());
+    JmxProxy jmx = this.context.jmxConnectionFactory
+        .connectAny(cluster.get(), context.config.getJmxConnectionTimeoutInSeconds());
 
-    String keyspace = repairUnitOpt.get().getKeyspaceName();
+    String keyspace = repairUnitOpt.getKeyspaceName();
     int parallelRepairs
         = getPossibleParallelRepairsCount(jmx.getRangeToEndpointMap(keyspace), jmx.getEndpointToHostId());
 
-    if ((repairUnitOpt.isPresent() && repairUnitOpt.get().getIncrementalRepair())) {
+    if (repairUnitOpt.getIncrementalRepair()) {
       // with incremental repair, can't have more parallel repairs than nodes
       // Same goes for local mode
       parallelRepairs = 1;
@@ -104,8 +101,8 @@ final class RepairRunner implements Runnable {
                 Collections2.transform(
                     repairSegments, segment -> segment.getTokenRange().getBaseRange())));
 
-    String repairUnitClusterName = repairUnitOpt.get().getClusterName();
-    String repairUnitKeyspaceName = repairUnitOpt.get().getKeyspaceName();
+    String repairUnitClusterName = repairUnitOpt.getClusterName();
+    String repairUnitKeyspaceName = repairUnitOpt.getKeyspaceName();
 
     // below four metric names are duplicated, so monitoring systems can follow per cluster or per cluster and keyspace
     String metricNameForRepairProgressPerKeyspace
@@ -417,7 +414,7 @@ final class RepairRunner implements Runnable {
       repairProgress = (float) amountDone / repairRun.getSegmentCount();
     }
 
-    RepairUnit repairUnit = context.storage.getRepairUnit(unitId).get();
+    RepairUnit repairUnit = context.storage.getRepairUnit(unitId);
     String keyspace = repairUnit.getKeyspaceName();
     LOG.debug("preparing to repair segment {} on run with id {}", segmentId, repairRunId);
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -56,12 +56,11 @@ public final class RepairScheduleService {
         .getRepairSchedulesForClusterAndKeyspace(repairUnit.getClusterName(), repairUnit.getKeyspaceName());
 
     for (RepairSchedule sched : repairSchedules) {
-      Optional<RepairUnit> repairUnitForSched = context.storage.getRepairUnit(sched.getRepairUnitId());
-      Preconditions.checkState(repairUnitForSched.isPresent());
-      Preconditions.checkState(repairUnitForSched.get().getClusterName().equals(repairUnit.getClusterName()));
-      Preconditions.checkState(repairUnitForSched.get().getKeyspaceName().equals(repairUnit.getKeyspaceName()));
+      RepairUnit repairUnitForSched = context.storage.getRepairUnit(sched.getRepairUnitId());
+      Preconditions.checkState(repairUnitForSched.getClusterName().equals(repairUnit.getClusterName()));
+      Preconditions.checkState(repairUnitForSched.getKeyspaceName().equals(repairUnit.getKeyspaceName()));
 
-      if (isConflictingSchedules(cluster, repairUnitForSched.get(), repairUnit)) {
+      if (isConflictingSchedules(cluster, repairUnitForSched, repairUnit)) {
         return Optional.of(sched);
       }
     }

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -138,12 +138,7 @@ public final class SchedulingManager extends TimerTask {
               schedule.getRepairUnitId(),
               schedule.getId());
 
-          Optional<RepairUnit> fetchedUnit = context.storage.getRepairUnit(schedule.getRepairUnitId());
-          if (!fetchedUnit.isPresent()) {
-            LOG.warn("RepairUnit with id {} not found", schedule.getRepairUnitId());
-            return false;
-          }
-          RepairUnit repairUnit = fetchedUnit.get();
+          RepairUnit repairUnit = context.storage.getRepairUnit(schedule.getRepairUnitId());
           if (repairRunAlreadyScheduled(schedule, repairUnit)) {
             return false;
           }

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -78,7 +78,7 @@ public interface IStorage {
 
   RepairUnit addRepairUnit(RepairUnit.Builder newRepairUnit);
 
-  Optional<RepairUnit> getRepairUnit(UUID id);
+  RepairUnit getRepairUnit(UUID id);
 
   Optional<RepairUnit> getRepairUnit(RepairUnit.Builder repairUnit);
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -218,8 +219,10 @@ public final class MemoryStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairUnit> getRepairUnit(UUID id) {
-    return Optional.fromNullable(repairUnits.get(id));
+  public RepairUnit getRepairUnit(UUID id) {
+    RepairUnit unit = repairUnits.get(id);
+    Preconditions.checkArgument(null != unit);
+    return unit;
   }
 
   @Override
@@ -299,7 +302,7 @@ public final class MemoryStorage implements IStorage {
     List<RepairParameters> ongoingRepairs = Lists.newArrayList();
     for (RepairRun run : getRepairRunsWithState(RepairRun.RunState.RUNNING)) {
       for (RepairSegment segment : getSegmentsWithState(run.getId(), RepairSegment.State.RUNNING)) {
-        RepairUnit unit = getRepairUnit(segment.getRepairUnitId()).get();
+        RepairUnit unit = getRepairUnit(segment.getRepairUnitId());
         ongoingRepairs.add(
             new RepairParameters(
                 segment.getTokenRange(), unit.getKeyspaceName(), unit.getColumnFamilies(), run.getRepairParallelism()));
@@ -355,7 +358,7 @@ public final class MemoryStorage implements IStorage {
   public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName) {
     Collection<RepairSchedule> foundRepairSchedules = new ArrayList<>();
     for (RepairSchedule repairSchedule : repairSchedules.values()) {
-      RepairUnit repairUnit = getRepairUnit(repairSchedule.getRepairUnitId()).get();
+      RepairUnit repairUnit = getRepairUnit(repairSchedule.getRepairUnitId());
       if (repairUnit.getClusterName().equals(clusterName)) {
         foundRepairSchedules.add(repairSchedule);
       }
@@ -367,7 +370,7 @@ public final class MemoryStorage implements IStorage {
   public Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName) {
     Collection<RepairSchedule> foundRepairSchedules = new ArrayList<>();
     for (RepairSchedule repairSchedule : repairSchedules.values()) {
-      RepairUnit repairUnit = getRepairUnit(repairSchedule.getRepairUnitId()).get();
+      RepairUnit repairUnit = getRepairUnit(repairSchedule.getRepairUnitId());
       if (repairUnit.getKeyspaceName().equals(keyspaceName)) {
         foundRepairSchedules.add(repairSchedule);
       }
@@ -379,7 +382,7 @@ public final class MemoryStorage implements IStorage {
   public Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName) {
     Collection<RepairSchedule> foundRepairSchedules = new ArrayList<>();
     for (RepairSchedule repairSchedule : repairSchedules.values()) {
-      RepairUnit repairUnit = getRepairUnit(repairSchedule.getRepairUnitId()).get();
+      RepairUnit repairUnit = getRepairUnit(repairSchedule.getRepairUnitId());
       if (repairUnit.getClusterName().equals(clusterName) && repairUnit.getKeyspaceName().equals(keyspaceName)) {
         foundRepairSchedules.add(repairSchedule);
       }
@@ -421,7 +424,7 @@ public final class MemoryStorage implements IStorage {
       List<RepairRun> runs = getRepairRunsForCluster(clusterName);
       Collections.sort(runs);
       for (RepairRun run : Iterables.limit(runs, limit)) {
-        RepairUnit unit = getRepairUnit(run.getRepairUnitId()).get();
+        RepairUnit unit = getRepairUnit(run.getRepairUnitId());
         int segmentsRepaired = getSegmentAmountForRepairRunWithState(run.getId(), RepairSegment.State.DONE);
         int totalSegments = getSegmentAmountForRepairRun(run.getId());
         runStatuses.add(
@@ -461,7 +464,7 @@ public final class MemoryStorage implements IStorage {
       List<RepairScheduleStatus> scheduleStatuses = Lists.newArrayList();
       Collection<RepairSchedule> schedules = getRepairSchedulesForCluster(clusterName);
       for (RepairSchedule schedule : schedules) {
-        RepairUnit unit = getRepairUnit(schedule.getRepairUnitId()).get();
+        RepairUnit unit = getRepairUnit(schedule.getRepairUnitId());
         scheduleStatuses.add(new RepairScheduleStatus(schedule, unit));
       }
       return scheduleStatuses;

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.UUID;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
@@ -268,12 +269,13 @@ public final class PostgresStorage implements IStorage {
   }
 
   @Override
-  public Optional<RepairUnit> getRepairUnit(UUID id) {
+  public RepairUnit getRepairUnit(UUID id) {
     RepairUnit result;
     try (Handle h = jdbi.open()) {
       result = getPostgresStorage(h).getRepairUnit(UuidUtil.toSequenceId(id));
     }
-    return Optional.fromNullable(result);
+    Preconditions.checkArgument(null != result);
+    return result;
   }
 
   @Override

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -222,13 +222,13 @@ public final class RepairRunResourceTest {
     assertEquals(1, context.storage.getRepairRunIdsForCluster(CLUSTER_NAME).size());
     UUID runId = context.storage.getRepairRunIdsForCluster(CLUSTER_NAME).iterator().next();
     RepairRun run = context.storage.getRepairRun(runId).get();
-    final Optional<RepairUnit> unit = context.storage.getRepairUnit(run.getRepairUnitId());
+    final RepairUnit unit = context.storage.getRepairUnit(run.getRepairUnitId());
     assertEquals(RepairRun.RunState.NOT_STARTED, run.getRunState());
     assertEquals(TIME_CREATE, run.getCreationTime().getMillis());
     assertEquals(REPAIR_INTENSITY, run.getIntensity(), 0.0f);
     assertNull(run.getStartTime());
     assertNull(run.getEndTime());
-    assertEquals(2, unit.get().getRepairThreadCount());
+    assertEquals(2, unit.getRepairThreadCount());
 
     // tokens [0, 100, 200], 6 requested segments per node and 6 nodes causes generating 38 RepairSegments
     assertEquals(

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -235,8 +235,7 @@ public final class ClusterRepairSchedulerTest {
     ClusterRepairScheduleAssertion.RepairScheduleAssertion repairScheduleForKeyspace(String keyspace) {
       RepairSchedule keyspaceRepairSchedule = repairSchedules.stream()
           .filter(repairSchedule
-              -> context.storage
-                  .getRepairUnit(repairSchedule.getRepairUnitId()).get().getKeyspaceName().equals(keyspace))
+              -> context.storage.getRepairUnit(repairSchedule.getRepairUnitId()).getKeyspaceName().equals(keyspace))
           .findFirst()
           .orElseThrow(() -> new AssertionError(format("No repair schedule found for keyspace %s", keyspace)));
       return new ClusterRepairScheduleAssertion.RepairScheduleAssertion(keyspaceRepairSchedule);


### PR DESCRIPTION
The RepairUnit is entirely an internal construct, a relationship and constraint against the RepairRun and Schedule tables. The RepairUnit UUID is only used as a reference from either of these other tables, so it makes little sense to wrap the value in an Optional. Furthermore the majority of the calling code did not deal with (or appropriately handle) an absent value.

In the Cassandra storage backend the read and write statements have been degraded from CL.ONE to CL.QUORUM accordingly. This table is small and already has row cache enabled, so this should be of small consequence.