### PR TITLE
display node metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,24 +222,6 @@
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <configuration>
-                            <passphraseServerId>ossrh</passphraseServerId>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <phase>verify</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
                           <skip>false</skip>

--- a/src/server/src/main/java/io/cassandrareaper/AppContext.java
+++ b/src/server/src/main/java/io/cassandrareaper/AppContext.java
@@ -15,6 +15,7 @@
 package io.cassandrareaper;
 
 import io.cassandrareaper.jmx.JmxConnectionFactory;
+import io.cassandrareaper.service.MetricsGrabber;
 import io.cassandrareaper.service.PurgeManager;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.SnapshotManager;
@@ -48,6 +49,7 @@ public final class AppContext {
   public MetricRegistry metricRegistry = new MetricRegistry();
   public SnapshotManager snapshotManager;
   public PurgeManager purgeManager;
+  public MetricsGrabber metricsGrabber;
 
   private static String initialiseInstanceAddress() {
     String reaperInstanceAddress;

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -160,7 +160,6 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
         context,
         environment.lifecycle().executorService("SnapshotManager").minThreads(5).maxThreads(5).build());
 
-    context.snapshotManager = SnapshotManager.create(context);
     context.metricsGrabber = MetricsGrabber.create(context);
 
     int repairThreads = config.getRepairRunThreadCount();

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -19,6 +19,7 @@ import io.cassandrareaper.ReaperApplicationConfiguration.JmxCredentials;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxConnectionsInitializer;
 import io.cassandrareaper.resources.ClusterResource;
+import io.cassandrareaper.resources.NodeStatsResource;
 import io.cassandrareaper.resources.PingResource;
 import io.cassandrareaper.resources.ReaperHealthCheck;
 import io.cassandrareaper.resources.RepairRunResource;
@@ -27,6 +28,7 @@ import io.cassandrareaper.resources.SnapshotResource;
 import io.cassandrareaper.resources.auth.LoginResource;
 import io.cassandrareaper.resources.auth.ShiroExceptionMapper;
 import io.cassandrareaper.service.AutoSchedulingManager;
+import io.cassandrareaper.service.MetricsGrabber;
 import io.cassandrareaper.service.PurgeManager;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.SchedulingManager;
@@ -158,6 +160,9 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
         context,
         environment.lifecycle().executorService("SnapshotManager").minThreads(5).maxThreads(5).build());
 
+    context.snapshotManager = SnapshotManager.create(context);
+    context.metricsGrabber = MetricsGrabber.create(context);
+
     int repairThreads = config.getRepairRunThreadCount();
     LOG.info("initializing runner thread pool with {} threads", repairThreads);
 
@@ -234,6 +239,9 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     environment.jersey().register(addRepairScheduleResource);
     final SnapshotResource snapshotResource = new SnapshotResource(context);
     environment.jersey().register(snapshotResource);
+
+    final NodeStatsResource nodeStatsResource = new NodeStatsResource(context);
+    environment.jersey().register(nodeStatsResource);
 
     if (config.isAccessControlEnabled()) {
       SessionHandler sessionHandler = new SessionHandler();

--- a/src/server/src/main/java/io/cassandrareaper/core/DroppedMessages.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/DroppedMessages.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = DroppedMessages.Builder.class)
+public final class DroppedMessages {
+  private final String name;
+  private final Integer count;
+  private final Double oneMinuteRate;
+  private final Double fiveMinuteRate;
+  private final Double fifteenMinuteRate;
+  private final Double meanRate;
+
+  private DroppedMessages(Builder builder) {
+    this.name = builder.name;
+    this.count = builder.count;
+    this.oneMinuteRate = builder.oneMinuteRate;
+    this.fiveMinuteRate = builder.fiveMinuteRate;
+    this.fifteenMinuteRate = builder.fifteenMinuteRate;
+    this.meanRate = builder.meanRate;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Integer getCount() {
+    return count;
+  }
+
+  public Double getOneMinuteRate() {
+    return oneMinuteRate;
+  }
+
+  public Double getFiveMinuteRate() {
+    return fiveMinuteRate;
+  }
+
+  public Double getFifteenMinuteRate() {
+    return fifteenMinuteRate;
+  }
+
+  public Double getMeanRate() {
+    return meanRate;
+  }
+
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+  public static final class Builder {
+    private String name;
+    private Integer count;
+    private Double oneMinuteRate;
+    private Double fiveMinuteRate;
+    private Double fifteenMinuteRate;
+    private Double meanRate;
+
+    private Builder() {}
+
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder withCount(Integer count) {
+      this.count = count;
+      return this;
+    }
+
+    public Builder withOneMinuteRate(Double oneMinuteRate) {
+      this.oneMinuteRate = oneMinuteRate;
+      return this;
+    }
+
+    public Builder withFiveMinuteRate(Double fiveMinuteRate) {
+      this.fiveMinuteRate = fiveMinuteRate;
+      return this;
+    }
+
+    public Builder withFifteenMinuteRate(Double fifteenMinuteRate) {
+      this.fifteenMinuteRate = fifteenMinuteRate;
+      return this;
+    }
+
+    public Builder withMeanRate(Double meanRate) {
+      this.meanRate = meanRate;
+      return this;
+    }
+
+    public DroppedMessages build() {
+      return new DroppedMessages(this);
+    }
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/core/JmxStat.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/JmxStat.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = JmxStat.Builder.class)
+public final class JmxStat {
+  private final String scope;
+  private final String name;
+  private final String attribute;
+  private final Double value;
+
+  private JmxStat(Builder builder) {
+    this.scope = builder.scope;
+    this.name = builder.name;
+    this.attribute = builder.attribute;
+    this.value = builder.value;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getAttribute() {
+    return attribute;
+  }
+
+  public Double getValue() {
+    return value;
+  }
+
+
+  @Override
+  public String toString() {
+    return scope + "/" + name + "/" + attribute + " = " + value;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+  public static final class Builder {
+    private String scope;
+    private String name;
+    private String attribute;
+    private Double value;
+
+    private Builder() {}
+
+    public Builder withScope(String scope) {
+      this.scope = scope;
+      return this;
+    }
+
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder withAttribute(String attribute) {
+      this.attribute = attribute;
+      return this;
+    }
+
+    public Builder withValue(Double value) {
+      this.value = value;
+      return this;
+    }
+
+    public JmxStat build() {
+      return new JmxStat(this);
+    }
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/core/MetricsHistogram.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/MetricsHistogram.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = MetricsHistogram.Builder.class)
+public final class MetricsHistogram {
+  private final String name;
+  private final String type;
+  private final Double p50;
+  private final Double p75;
+  private final Double p95;
+  private final Double p98;
+  private final Double p99;
+  private final Double p999;
+  private final Double min;
+  private final Double mean;
+  private final Double max;
+  private final Integer count;
+  private final Double oneMinuteRate;
+  private final Double fiveMinuteRate;
+  private final Double fifteenMinuteRate;
+  private final Double meanRate;
+  private final Double stdDev;
+
+  private MetricsHistogram(Builder builder) {
+    this.name = builder.name;
+    this.type = builder.type;
+    this.p50 = builder.p50;
+    this.p75 = builder.p75;
+    this.p95 = builder.p95;
+    this.p98 = builder.p98;
+    this.p99 = builder.p99;
+    this.p999 = builder.p999;
+    this.min = builder.min;
+    this.mean = builder.mean;
+    this.max = builder.max;
+    this.count = builder.count;
+    this.oneMinuteRate = builder.oneMinuteRate;
+    this.fiveMinuteRate = builder.fiveMinuteRate;
+    this.fifteenMinuteRate = builder.fifteenMinuteRate;
+    this.meanRate = builder.meanRate;
+    this.stdDev = builder.stdDev;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public Double getP50() {
+    return p50;
+  }
+
+  public Double getP75() {
+    return p75;
+  }
+
+  public Double getP95() {
+    return p95;
+  }
+
+  public Double getP98() {
+    return p98;
+  }
+
+  public Double getP99() {
+    return p99;
+  }
+
+  public Double getP999() {
+    return p999;
+  }
+
+  public Double getMin() {
+    return min;
+  }
+
+  public Double getMean() {
+    return mean;
+  }
+
+  public Double getMax() {
+    return max;
+  }
+
+  public Integer getCount() {
+    return count;
+  }
+
+  public Double getOneMinuteRate() {
+    return oneMinuteRate;
+  }
+
+  public Double getFiveMinuteRate() {
+    return fiveMinuteRate;
+  }
+
+  public Double getFifteenMinuteRate() {
+    return fifteenMinuteRate;
+  }
+
+  public Double getMeanRate() {
+    return meanRate;
+  }
+
+  public Double getStdDev() {
+    return stdDev;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+  public static final class Builder {
+    private String name;
+    private String type;
+    private Double p50;
+    private Double p75;
+    private Double p95;
+    private Double p98;
+    private Double p99;
+    private Double p999;
+    private Double min;
+    private Double mean;
+    private Double max;
+    private Integer count;
+    private Double oneMinuteRate;
+    private Double fiveMinuteRate;
+    private Double fifteenMinuteRate;
+    private Double meanRate;
+    private Double stdDev;
+
+    private Builder() {}
+
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder withType(String type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder withP50(Double p50) {
+      this.p50 = p50;
+      return this;
+    }
+
+    public Builder withP75(Double p75) {
+      this.p75 = p75;
+      return this;
+    }
+
+    public Builder withP95(Double p95) {
+      this.p95 = p95;
+      return this;
+    }
+
+    public Builder withP98(Double p98) {
+      this.p98 = p98;
+      return this;
+    }
+
+    public Builder withP99(Double p99) {
+      this.p99 = p99;
+      return this;
+    }
+
+    public Builder withP999(Double p999) {
+      this.p999 = p999;
+      return this;
+    }
+
+    public Builder withMin(Double min) {
+      this.min = min;
+      return this;
+    }
+
+    public Builder withMean(Double mean) {
+      this.mean = mean;
+      return this;
+    }
+
+    public Builder withMax(Double max) {
+      this.max = max;
+      return this;
+    }
+
+    public Builder withCount(Integer count) {
+      this.count = count;
+      return this;
+    }
+
+    public Builder withOneMinuteRate(Double oneMinuteRate) {
+      this.oneMinuteRate = oneMinuteRate;
+      return this;
+    }
+
+    public Builder withFiveMinuteRate(Double fiveMinuteRate) {
+      this.fiveMinuteRate = fiveMinuteRate;
+      return this;
+    }
+
+    public Builder withFifteenMinuteRate(Double fifteenMinuteRate) {
+      this.fifteenMinuteRate = fifteenMinuteRate;
+      return this;
+    }
+
+    public Builder withMeanRate(Double meanRate) {
+      this.meanRate = meanRate;
+      return this;
+    }
+
+    public Builder withStdDev(Double stdDev) {
+      this.stdDev = stdDev;
+      return this;
+    }
+
+    public MetricsHistogram build() {
+      return new MetricsHistogram(this);
+    }
+  }
+
+}

--- a/src/server/src/main/java/io/cassandrareaper/core/ThreadPoolStat.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/ThreadPoolStat.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = ThreadPoolStat.Builder.class)
+public final class ThreadPoolStat {
+  private final String name;
+  private final Integer activeTasks;
+  private final Integer pendingTasks;
+  private final Integer completedTasks;
+  private final Integer currentlyBlockedTasks;
+  private final Integer totalBlockedTasks;
+  private final Integer maxPoolSize;
+
+  private ThreadPoolStat(Builder builder) {
+    this.name = builder.name;
+    this.activeTasks = builder.activeTasks;
+    this.pendingTasks = builder.pendingTasks;
+    this.currentlyBlockedTasks = builder.currentlyBlockedTasks;
+    this.completedTasks = builder.completedTasks;
+    this.totalBlockedTasks = builder.totalBlockedTasks;
+    this.maxPoolSize = builder.maxPoolSize;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Integer getActiveTasks() {
+    return activeTasks;
+  }
+
+  public Integer getPendingTasks() {
+    return pendingTasks;
+  }
+
+  public Integer getCurrentlyBlockedTasks() {
+    return currentlyBlockedTasks;
+  }
+
+  public Integer getCompletedTasks() {
+    return completedTasks;
+  }
+
+  public Integer getTotalBlockedTasks() {
+    return totalBlockedTasks;
+  }
+
+  public Integer getMaxPoolSize() {
+    return maxPoolSize;
+  }
+
+
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+  public static final class Builder {
+    private String name;
+    private Integer activeTasks;
+    private Integer pendingTasks;
+    private Integer currentlyBlockedTasks;
+    private Integer completedTasks;
+    private Integer totalBlockedTasks;
+    private Integer maxPoolSize;
+
+    private Builder() {}
+
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder withActiveTasks(Integer activeTasks) {
+      this.activeTasks = activeTasks;
+      return this;
+    }
+
+    public Builder withPendingTasks(Integer pendingTasks) {
+      this.pendingTasks = pendingTasks;
+      return this;
+    }
+
+    public Builder withCurrentlyBlockedTasks(Integer currentlyBlockedTasks) {
+      this.currentlyBlockedTasks = currentlyBlockedTasks;
+      return this;
+    }
+
+    public Builder withCompletedTasks(Integer completedTasks) {
+      this.completedTasks = completedTasks;
+      return this;
+    }
+
+    public Builder withTotalBlockedTasks(Integer totalBlockedTasks) {
+      this.totalBlockedTasks = totalBlockedTasks;
+      return this;
+    }
+
+    public Builder withMaxPoolSize(Integer maxPoolSize) {
+      this.maxPoolSize = maxPoolSize;
+      return this;
+    }
+
+    public ThreadPoolStat build() {
+      return new ThreadPoolStat(this);
+    }
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
@@ -15,10 +15,12 @@
 package io.cassandrareaper.jmx;
 
 import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.JmxStat;
 import io.cassandrareaper.core.Segment;
 import io.cassandrareaper.core.Snapshot;
 import io.cassandrareaper.service.RingRange;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.util.Collection;
@@ -27,7 +29,9 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
 import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
 import javax.management.NotificationListener;
 import javax.management.ReflectionException;
 import javax.validation.constraints.NotNull;
@@ -146,4 +150,16 @@ public interface JmxProxy extends NotificationListener {
 
   void takeColumnFamilySnapshot(String keyspaceName, String columnFamilyName, String snapshotName)
       throws ReaperException;
+
+  Map<String, List<JmxStat>> collectTpStats()
+      throws MalformedObjectNameException, IOException, AttributeNotFoundException,
+          InstanceNotFoundException, MBeanException, ReflectionException;
+
+  Map<String, List<JmxStat>> collectDroppedMessages()
+      throws MalformedObjectNameException, IOException, AttributeNotFoundException,
+          InstanceNotFoundException, MBeanException, ReflectionException;
+
+  Map<String, List<JmxStat>> collectLatencyMetrics()
+      throws MalformedObjectNameException, IOException, AttributeNotFoundException,
+          InstanceNotFoundException, MBeanException, ReflectionException;
 }

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
@@ -16,6 +16,7 @@ package io.cassandrareaper.jmx;
 
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
+import io.cassandrareaper.core.JmxStat;
 import io.cassandrareaper.core.Segment;
 import io.cassandrareaper.core.Snapshot;
 import io.cassandrareaper.core.Snapshot.Builder;
@@ -29,11 +30,13 @@ import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import java.rmi.server.RMIClientSocketFactory;
 import java.rmi.server.RMISocketFactory;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,11 +49,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import javax.management.Attribute;
+import javax.management.AttributeList;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
+import javax.management.JMException;
 import javax.management.JMX;
 import javax.management.ListenerNotFoundException;
+import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanException;
+import javax.management.MBeanInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
 import javax.management.Notification;
@@ -72,6 +80,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 import org.apache.cassandra.db.ColumnFamilyStoreMBean;
 import org.apache.cassandra.gms.FailureDetector;
@@ -1134,5 +1143,114 @@ final class JmxProxyImpl implements JmxProxy {
     } catch (IOException e) {
       throw new ReaperException(e);
     }
+  }
+
+  /**
+   * Collects all attributes for a given set of JMX beans.
+   *
+   * @param beans the list of beans to collect through JMX
+   * @return a map with a key for each bean and a list of jmx stat in generic format.
+   */
+  private Map<String, List<JmxStat>> collectMetrics(List<String> beans)
+      throws MalformedObjectNameException, IOException, AttributeNotFoundException,
+          InstanceNotFoundException, MBeanException, ReflectionException {
+    List<List<JmxStat>> allStats = Lists.newArrayList();
+    Set beanSet = Sets.newLinkedHashSet();
+    for (String bean : beans) {
+      beanSet.addAll(mbeanServer.queryNames(new ObjectName(bean), null));
+    }
+
+    for (Object bean : beanSet) {
+      ObjectName objName = (ObjectName) bean;
+      List<JmxStat> attributes = scrapeBean(objName);
+      allStats.add(attributes);
+    }
+
+    List<JmxStat> flatStatList =
+        allStats.stream().flatMap(attr -> attr.stream()).collect(Collectors.toList());
+
+    // Group the stats by scope to ease displaying/manipulating the data
+    Map<String, List<JmxStat>> groupedStatList =
+        flatStatList.stream().collect(Collectors.groupingBy(JmxStat::getScope));
+
+    return groupedStatList;
+  }
+
+  @Override
+  public Map<String, List<JmxStat>> collectTpStats()
+      throws MalformedObjectNameException, IOException, AttributeNotFoundException,
+          InstanceNotFoundException, MBeanException, ReflectionException {
+
+    return collectMetrics(
+        Arrays.asList(
+            "org.apache.cassandra.metrics:type=ThreadPools,path=request,*",
+            "org.apache.cassandra.metrics:type=ThreadPools,path=internal,*"));
+  }
+
+  @Override
+  public Map<String, List<JmxStat>> collectDroppedMessages()
+      throws MalformedObjectNameException, IOException, AttributeNotFoundException,
+          InstanceNotFoundException, MBeanException, ReflectionException {
+
+    return collectMetrics(Arrays.asList("org.apache.cassandra.metrics:type=DroppedMessage,*"));
+  }
+
+  @Override
+  public Map<String, List<JmxStat>> collectLatencyMetrics()
+      throws MalformedObjectNameException, IOException, AttributeNotFoundException,
+          InstanceNotFoundException, MBeanException, ReflectionException {
+
+    Map<String, List<JmxStat>> metrics =
+        collectMetrics(Arrays.asList("org.apache.cassandra.metrics:type=ClientRequest,*"));
+    LOG.info("latencies : {}", metrics);
+
+    return metrics;
+  }
+
+  private List<JmxStat> scrapeBean(ObjectName mbeanName) {
+    MBeanInfo info;
+    List<JmxStat> attributeList = Lists.newArrayList();
+    try {
+      info = mbeanServer.getMBeanInfo(mbeanName);
+    } catch (IOException e) {
+      return attributeList;
+    } catch (JMException e) {
+      LOG.error(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+      return attributeList;
+    }
+    MBeanAttributeInfo[] attrInfos = info.getAttributes();
+
+    Map<String, MBeanAttributeInfo> name2AttrInfo = new LinkedHashMap<String, MBeanAttributeInfo>();
+    for (MBeanAttributeInfo attrInfo : attrInfos) {
+      MBeanAttributeInfo attr = attrInfo;
+      if (!attr.isReadable()) {
+        LOG.warn("{}.{} not readable", mbeanName, attr);
+        continue;
+      }
+      name2AttrInfo.put(attr.getName(), attr);
+    }
+    final AttributeList attributes;
+    try {
+      attributes =
+          mbeanServer.getAttributes(mbeanName, name2AttrInfo.keySet().toArray(new String[0]));
+    } catch (RuntimeException | InstanceNotFoundException | ReflectionException | IOException e) {
+      LOG.error("Fail grabbing attributes for mbean {} ", mbeanName, e);
+      return attributeList;
+    }
+    for (Attribute attribute : attributes.asList()) {
+      Object value = attribute.getValue();
+      JmxStat.Builder jmxStatBuilder =
+          JmxStat.builder()
+              .withAttribute(attribute.getName())
+              .withName(mbeanName.getKeyProperty("name"))
+              .withScope(mbeanName.getKeyProperty("scope"));
+      if (value == null) {
+        attributeList.add(jmxStatBuilder.withValue(0.0).build());
+      } else if (value instanceof Number) {
+        attributeList.add(jmxStatBuilder.withValue(((Number) value).doubleValue()).build());
+      }
+    }
+
+    return attributeList;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/NodeStatsResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/NodeStatsResource.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.resources;
+
+import io.cassandrareaper.AppContext;
+import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.Node;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("/node")
+@Produces(MediaType.APPLICATION_JSON)
+public final class NodeStatsResource {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NodeStatsResource.class);
+
+  private final AppContext context;
+
+  public NodeStatsResource(AppContext context) {
+    this.context = context;
+  }
+
+  /**
+   * Endpoint used to collect thread pool stats for a node.
+   *
+   * @return a list of thread pools if ok, and a status code 500 in case of errors.
+   */
+  @GET
+  @Path("/tpstats/{clusterName}/{host}")
+  public Response getTpStats(
+      @Context UriInfo uriInfo,
+      @PathParam("clusterName") String clusterName,
+      @PathParam("host") String host) {
+
+    try {
+      Node node = Node.builder().withClusterName(clusterName).withHostname(host).build();
+      return Response.ok().entity(context.metricsGrabber.getTpStats(node)).build();
+    } catch (RuntimeException | ReaperException e) {
+      LOG.error(e.getMessage(), e);
+      return Response.serverError().entity(e.getMessage()).build();
+    }
+  }
+
+  /**
+   * Endpoint used to collect dropped messages stats for a node.
+   *
+   * @return a list of dropped messages metrics if ok, and a status code 500 in case of errors.
+   */
+  @GET
+  @Path("/dropped/{clusterName}/{host}")
+  public Response getDroppedMessages(
+      @Context UriInfo uriInfo,
+      @PathParam("clusterName") String clusterName,
+      @PathParam("host") String host) {
+
+    try {
+      Node node = Node.builder().withClusterName(clusterName).withHostname(host).build();
+      return Response.ok().entity(context.metricsGrabber.getDroppedMessages(node)).build();
+    } catch (RuntimeException | ReaperException e) {
+      LOG.error(e.getMessage(), e);
+      return Response.serverError().entity(e.getMessage()).build();
+    }
+  }
+
+  /**
+   * Endpoint used to collect client request latencies for a node.
+   *
+   * @return a list of latency histograms if ok, and a status code 500 in case of errors.
+   */
+  @GET
+  @Path("/clientRequestLatencies/{clusterName}/{host}")
+  public Response getClientRequestLatencies(
+      @Context UriInfo uriInfo,
+      @PathParam("clusterName") String clusterName,
+      @PathParam("host") String host) {
+
+    try {
+      Node node = Node.builder().withClusterName(clusterName).withHostname(host).build();
+      return Response.ok().entity(context.metricsGrabber.getClientRequestLatencies(node)).build();
+    } catch (RuntimeException | ReaperException e) {
+      LOG.error(e.getMessage(), e);
+      return Response.serverError().entity(e.getMessage()).build();
+    }
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/service/MetricsGrabber.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/MetricsGrabber.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.service;
+
+import io.cassandrareaper.AppContext;
+import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.DroppedMessages;
+import io.cassandrareaper.core.JmxStat;
+import io.cassandrareaper.core.MetricsHistogram;
+import io.cassandrareaper.core.Node;
+import io.cassandrareaper.core.ThreadPoolStat;
+import io.cassandrareaper.core.ThreadPoolStat.Builder;
+import io.cassandrareaper.jmx.JmxProxy;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ReflectionException;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class MetricsGrabber {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetricsGrabber.class);
+
+  private final AppContext context;
+  private final ExecutorService executor = Executors.newFixedThreadPool(5);
+
+  private MetricsGrabber(AppContext context) {
+    this.context = context;
+  }
+
+  public static MetricsGrabber create(AppContext context) {
+    return new MetricsGrabber(context);
+  }
+
+  public List<ThreadPoolStat> getTpStats(Node host) throws ReaperException {
+    try {
+      JmxProxy jmxProxy
+          = context.jmxConnectionFactory.connect(host, context.config.getJmxConnectionTimeoutInSeconds());
+
+      return convertToThreadPoolStats(jmxProxy.collectTpStats());
+    } catch (RuntimeException
+        | InterruptedException
+        | MalformedObjectNameException
+        | AttributeNotFoundException
+        | InstanceNotFoundException
+        | MBeanException
+        | ReflectionException
+        | IOException e) {
+      LOG.error("Failed collecting tpstats for host {}", host, e);
+      throw new ReaperException(e);
+    }
+  }
+
+  @VisibleForTesting
+  public List<ThreadPoolStat> convertToThreadPoolStats(Map<String, List<JmxStat>> jmxStats) {
+    List<ThreadPoolStat> tpstats = Lists.newArrayList();
+    for (Entry<String, List<JmxStat>> pool : jmxStats.entrySet()) {
+      Builder builder = ThreadPoolStat.builder().withName(pool.getKey());
+      for (JmxStat stat : pool.getValue()) {
+        if (stat.getName().equals("MaxPoolSize")) {
+          builder.withMaxPoolSize(stat.getValue().intValue());
+        } else if (stat.getName().equals("TotalBlockedTasks")) {
+          builder.withTotalBlockedTasks(stat.getValue().intValue());
+        } else if (stat.getName().equals("PendingTasks")) {
+          builder.withPendingTasks(stat.getValue().intValue());
+        } else if (stat.getName().equals("CurrentlyBlockedTasks")) {
+          builder.withCurrentlyBlockedTasks(stat.getValue().intValue());
+        } else if (stat.getName().equals("CompletedTasks")) {
+          builder.withCompletedTasks(stat.getValue().intValue());
+        } else if (stat.getName().equals("ActiveTasks")) {
+          builder.withActiveTasks(stat.getValue().intValue());
+        }
+      }
+      tpstats.add(builder.build());
+    }
+
+    return tpstats;
+  }
+
+  public List<DroppedMessages> getDroppedMessages(Node host) throws ReaperException {
+    try {
+      JmxProxy jmxProxy =
+          context.jmxConnectionFactory.connect(
+              host, context.config.getJmxConnectionTimeoutInSeconds());
+
+      return convertToDroppedMessages(jmxProxy.collectDroppedMessages());
+    } catch (RuntimeException
+        | InterruptedException
+        | MalformedObjectNameException
+        | AttributeNotFoundException
+        | InstanceNotFoundException
+        | MBeanException
+        | ReflectionException
+        | IOException e) {
+      LOG.error("Failed collecting tpstats for host {}", host, e);
+      throw new ReaperException(e);
+    }
+  }
+
+  @VisibleForTesting
+  public List<DroppedMessages> convertToDroppedMessages(Map<String, List<JmxStat>> jmxStats) {
+    List<DroppedMessages> droppedMessages = Lists.newArrayList();
+    for (Entry<String, List<JmxStat>> pool : jmxStats.entrySet()) {
+      DroppedMessages.Builder builder = DroppedMessages.builder().withName(pool.getKey());
+      for (JmxStat stat : pool.getValue()) {
+        if (stat.getAttribute().equals("Count")) {
+          builder.withCount(stat.getValue().intValue());
+        } else if (stat.getAttribute().equals("OneMinuteRate")) {
+          builder.withOneMinuteRate(stat.getValue());
+        } else if (stat.getAttribute().equals("FiveMinuteRate")) {
+          builder.withFiveMinuteRate(stat.getValue());
+        } else if (stat.getAttribute().equals("FifteenMinuteRate")) {
+          builder.withFifteenMinuteRate(stat.getValue());
+        } else if (stat.getAttribute().equals("MeanRate")) {
+          builder.withMeanRate(stat.getValue());
+        }
+      }
+      droppedMessages.add(builder.build());
+    }
+
+    return droppedMessages;
+  }
+
+  public List<MetricsHistogram> getClientRequestLatencies(Node host) throws ReaperException {
+    try {
+      JmxProxy jmxProxy =
+          context.jmxConnectionFactory.connect(
+              host, context.config.getJmxConnectionTimeoutInSeconds());
+
+      return convertToMetricsHistogram(jmxProxy.collectLatencyMetrics());
+    } catch (RuntimeException
+        | InterruptedException
+        | MalformedObjectNameException
+        | AttributeNotFoundException
+        | InstanceNotFoundException
+        | MBeanException
+        | ReflectionException
+        | IOException e) {
+      LOG.error("Failed collecting tpstats for host {}", host, e);
+      throw new ReaperException(e);
+    }
+  }
+
+  @VisibleForTesting
+  public List<MetricsHistogram> convertToMetricsHistogram(Map<String, List<JmxStat>> jmxStats) {
+    List<MetricsHistogram> droppedMessages = Lists.newArrayList();
+    for (Entry<String, List<JmxStat>> pool : jmxStats.entrySet()) {
+      // We have several metric types that we need to process separately
+      // We'll group on MetricsHistogram::getType in order to generate one histogram per type
+      Map<String, List<JmxStat>> metrics =
+          pool.getValue().stream().collect(Collectors.groupingBy(JmxStat::getName));
+
+      for (Entry<String, List<JmxStat>> metric : metrics.entrySet()) {
+        MetricsHistogram.Builder builder =
+            MetricsHistogram.builder().withName(pool.getKey()).withType(metric.getKey());
+        for (JmxStat stat : metric.getValue()) {
+          if (stat.getAttribute().equals("Count")) {
+            builder.withCount(stat.getValue().intValue());
+          } else if (stat.getAttribute().equals("OneMinuteRate")) {
+            builder.withOneMinuteRate(stat.getValue());
+          } else if (stat.getAttribute().equals("FiveMinuteRate")) {
+            builder.withFiveMinuteRate(stat.getValue());
+          } else if (stat.getAttribute().equals("FifteenMinuteRate")) {
+            builder.withFifteenMinuteRate(stat.getValue());
+          } else if (stat.getAttribute().equals("MeanRate")) {
+            builder.withMeanRate(stat.getValue());
+          } else if (stat.getAttribute().equals("StdDev")) {
+            builder.withStdDev(stat.getValue());
+          } else if (stat.getAttribute().equals("Min")) {
+            builder.withMin(stat.getValue());
+          } else if (stat.getAttribute().equals("Max")) {
+            builder.withMax(stat.getValue());
+          } else if (stat.getAttribute().equals("Mean")) {
+            builder.withMean(stat.getValue());
+          } else if (stat.getAttribute().equals("50thPercentile")) {
+            builder.withP50(stat.getValue());
+          } else if (stat.getAttribute().equals("75thPercentile")) {
+            builder.withP75(stat.getValue());
+          } else if (stat.getAttribute().equals("95thPercentile")) {
+            builder.withP95(stat.getValue());
+          } else if (stat.getAttribute().equals("98thPercentile")) {
+            builder.withP98(stat.getValue());
+          } else if (stat.getAttribute().equals("99thPercentile")) {
+            builder.withP99(stat.getValue());
+          } else if (stat.getAttribute().equals("999thPercentile")) {
+            builder.withP999(stat.getValue());
+          }
+        }
+        droppedMessages.add(builder.build());
+      }
+    }
+
+    return droppedMessages;
+  }
+
+}

--- a/src/server/src/main/java/io/cassandrareaper/service/MetricsGrabber.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/MetricsGrabber.java
@@ -32,11 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanException;
-import javax.management.MalformedObjectNameException;
-import javax.management.ReflectionException;
+import javax.management.JMException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -64,14 +60,7 @@ public final class MetricsGrabber {
           = context.jmxConnectionFactory.connect(host, context.config.getJmxConnectionTimeoutInSeconds());
 
       return convertToThreadPoolStats(jmxProxy.collectTpStats());
-    } catch (RuntimeException
-        | InterruptedException
-        | MalformedObjectNameException
-        | AttributeNotFoundException
-        | InstanceNotFoundException
-        | MBeanException
-        | ReflectionException
-        | IOException e) {
+    } catch (JMException | RuntimeException | InterruptedException | IOException e) {
       LOG.error("Failed collecting tpstats for host {}", host, e);
       throw new ReaperException(e);
     }
@@ -110,14 +99,7 @@ public final class MetricsGrabber {
               host, context.config.getJmxConnectionTimeoutInSeconds());
 
       return convertToDroppedMessages(jmxProxy.collectDroppedMessages());
-    } catch (RuntimeException
-        | InterruptedException
-        | MalformedObjectNameException
-        | AttributeNotFoundException
-        | InstanceNotFoundException
-        | MBeanException
-        | ReflectionException
-        | IOException e) {
+    } catch (JMException | RuntimeException | InterruptedException | IOException e) {
       LOG.error("Failed collecting tpstats for host {}", host, e);
       throw new ReaperException(e);
     }
@@ -154,14 +136,7 @@ public final class MetricsGrabber {
               host, context.config.getJmxConnectionTimeoutInSeconds());
 
       return convertToMetricsHistogram(jmxProxy.collectLatencyMetrics());
-    } catch (RuntimeException
-        | InterruptedException
-        | MalformedObjectNameException
-        | AttributeNotFoundException
-        | InstanceNotFoundException
-        | MBeanException
-        | ReflectionException
-        | IOException e) {
+    } catch (JMException | RuntimeException | InterruptedException | IOException e) {
       LOG.error("Failed collecting tpstats for host {}", host, e);
       throw new ReaperException(e);
     }

--- a/src/server/src/test/java/io/cassandrareaper/SimpleReaperClient.java
+++ b/src/server/src/test/java/io/cassandrareaper/SimpleReaperClient.java
@@ -14,8 +14,11 @@
 
 package io.cassandrareaper;
 
+import io.cassandrareaper.core.DroppedMessages;
+import io.cassandrareaper.core.MetricsHistogram;
 import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.core.Snapshot;
+import io.cassandrareaper.core.ThreadPoolStat;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
 
@@ -164,6 +167,18 @@ public final class SimpleReaperClient {
 
   public static Map<String, List<Snapshot>> parseSnapshotMapJSON(String json) {
     return parseJSON(json, new TypeReference<Map<String, List<Snapshot>>>() {});
+  }
+
+  public static List<ThreadPoolStat> parseTpStatJSON(String json) {
+    return parseJSON(json, new TypeReference<List<ThreadPoolStat>>() {});
+  }
+
+  public static List<DroppedMessages> parseDroppedMessagesJSON(String json) {
+    return parseJSON(json, new TypeReference<List<DroppedMessages>>() {});
+  }
+
+  public static List<MetricsHistogram> parseClientRequestMetricsJSON(String json) {
+    return parseJSON(json, new TypeReference<List<MetricsHistogram>>() {});
   }
 
 }

--- a/src/server/src/test/java/io/cassandrareaper/service/MetricsGrabberTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/MetricsGrabberTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.service;
+
+import io.cassandrareaper.AppContext;
+import io.cassandrareaper.ReaperApplicationConfiguration;
+import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.Cluster;
+import io.cassandrareaper.core.DroppedMessages;
+import io.cassandrareaper.core.JmxStat;
+import io.cassandrareaper.core.Node;
+import io.cassandrareaper.core.ThreadPoolStat;
+import io.cassandrareaper.jmx.JmxConnectionFactory;
+import io.cassandrareaper.jmx.JmxProxy;
+import io.cassandrareaper.storage.IStorage;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ReflectionException;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+import jersey.repackaged.com.google.common.collect.Lists;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MetricsGrabberTest {
+
+  @Test
+  public void testGetTpstats()
+      throws InterruptedException, ReaperException, MalformedObjectNameException,
+          AttributeNotFoundException, InstanceNotFoundException, MBeanException,
+          ReflectionException, IOException {
+    AppContext context = new AppContext();
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setJmxConnectionTimeoutInSeconds(10);
+
+    context.storage = mock(IStorage.class);
+    Cluster cluster =
+        new Cluster("testCluster", "murmur3", new TreeSet<String>(Arrays.asList("127.0.0.1")));
+    when(context.storage.getCluster(anyString())).thenReturn(Optional.of(cluster));
+
+    final JmxProxy jmx = mock(JmxProxy.class);
+    when(jmx.getLiveNodes()).thenReturn(Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
+
+    final MetricsGrabber metricsGrabber = MetricsGrabber.create(context);
+    context.jmxConnectionFactory =
+        new JmxConnectionFactory() {
+          @Override
+          public JmxProxy connect(Node host, int connectionTimeout)
+              throws ReaperException, InterruptedException {
+            return jmx;
+          }
+
+          @Override
+          public JmxProxy connectAny(Cluster cluster, int connectionTimeout)
+              throws ReaperException {
+            return jmx;
+          }
+        };
+    Node node = Node.builder().withClusterName("test").withHostname("127.0.0.1").build();
+    metricsGrabber.getTpStats(node);
+    verify(jmx, times(1)).collectTpStats();
+  }
+
+  @Test
+  public void testConvertToThreadPoolStats() {
+    AppContext context = new AppContext();
+    final MetricsGrabber metricsGrabber = MetricsGrabber.create(context);
+
+    List<JmxStat> statList = Lists.newArrayList();
+    statList.add(
+        JmxStat.builder()
+            .withScope("ReadStage")
+            .withName("PendingTasks")
+            .withAttribute("Value")
+            .withValue(1.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("ReadStage")
+            .withName("ActiveTasks")
+            .withAttribute("Value")
+            .withValue(2.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("ReadStage")
+            .withName("CurrentlyBlockedTasks")
+            .withAttribute("Value")
+            .withValue(3.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("ReadStage")
+            .withName("CompletedTasks")
+            .withAttribute("Value")
+            .withValue(4.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("ReadStage")
+            .withName("MaxPoolSize")
+            .withAttribute("Value")
+            .withValue(5.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("ReadStage")
+            .withName("TotalBlockedTasks")
+            .withAttribute("Value")
+            .withValue(6.0)
+            .build());
+
+    Map<String, List<JmxStat>> jmxStats = Maps.newHashMap();
+    jmxStats.put("ReadStage", statList);
+
+    List<ThreadPoolStat> threadPoolStats = metricsGrabber.convertToThreadPoolStats(jmxStats);
+    ThreadPoolStat tpstat = threadPoolStats.get(0);
+
+    assertEquals(1, tpstat.getPendingTasks().intValue());
+    assertEquals(2, tpstat.getActiveTasks().intValue());
+    assertEquals(3, tpstat.getCurrentlyBlockedTasks().intValue());
+    assertEquals(4, tpstat.getCompletedTasks().intValue());
+    assertEquals(5, tpstat.getMaxPoolSize().intValue());
+    assertEquals(6, tpstat.getTotalBlockedTasks().intValue());
+  }
+
+  @Test
+  public void testGetDroppedMessages()
+      throws InterruptedException, ReaperException, MalformedObjectNameException,
+          AttributeNotFoundException, InstanceNotFoundException, MBeanException,
+          ReflectionException, IOException {
+    AppContext context = new AppContext();
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setJmxConnectionTimeoutInSeconds(10);
+
+    context.storage = mock(IStorage.class);
+    Cluster cluster =
+        new Cluster("testCluster", "murmur3", new TreeSet<String>(Arrays.asList("127.0.0.1")));
+    when(context.storage.getCluster(anyString())).thenReturn(Optional.of(cluster));
+
+    final JmxProxy jmx = mock(JmxProxy.class);
+    when(jmx.getLiveNodes()).thenReturn(Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
+
+    final MetricsGrabber metricsGrabber = MetricsGrabber.create(context);
+    context.jmxConnectionFactory =
+        new JmxConnectionFactory() {
+          @Override
+          public JmxProxy connect(Node host, int connectionTimeout)
+              throws ReaperException, InterruptedException {
+            return jmx;
+          }
+
+          @Override
+          public JmxProxy connectAny(Cluster cluster, int connectionTimeout)
+              throws ReaperException {
+            return jmx;
+          }
+        };
+    Node node = Node.builder().withClusterName("test").withHostname("127.0.0.1").build();
+    metricsGrabber.getDroppedMessages(node);
+    verify(jmx, times(1)).collectDroppedMessages();
+  }
+
+  @Test
+  public void testConvertToDroppedMessages() {
+    AppContext context = new AppContext();
+    final MetricsGrabber metricsGrabber = MetricsGrabber.create(context);
+
+    List<JmxStat> statList = Lists.newArrayList();
+    statList.add(
+        JmxStat.builder()
+            .withScope("READ")
+            .withName("Dropped")
+            .withAttribute("MeanRate")
+            .withValue(1.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("READ")
+            .withName("Dropped")
+            .withAttribute("OneMinuteRate")
+            .withValue(2.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("READ")
+            .withName("Dropped")
+            .withAttribute("FiveMinuteRate")
+            .withValue(3.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("READ")
+            .withName("Dropped")
+            .withAttribute("FifteenMinuteRate")
+            .withValue(4.0)
+            .build());
+    statList.add(
+        JmxStat.builder()
+            .withScope("READ")
+            .withName("Dropped")
+            .withAttribute("Count")
+            .withValue(5.0)
+            .build());
+
+    Map<String, List<JmxStat>> jmxStats = Maps.newHashMap();
+    jmxStats.put("READ", statList);
+
+    List<DroppedMessages> droppedMessages = metricsGrabber.convertToDroppedMessages(jmxStats);
+    DroppedMessages dropped = droppedMessages.get(0);
+
+    assertEquals(1, dropped.getMeanRate().intValue());
+    assertEquals(2, dropped.getOneMinuteRate().intValue());
+    assertEquals(3, dropped.getFiveMinuteRate().intValue());
+    assertEquals(4, dropped.getFifteenMinuteRate().intValue());
+    assertEquals(5, dropped.getCount().intValue());
+  }
+
+}

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -19,6 +19,9 @@ Feature: Using Reaper to launch repairs and schedule them
     Given that we are going to use "127.0.0.1@test" as cluster seed host
     And reaper has no cluster in storage
     When an add-cluster request is made to reaper
+    And we can collect the tpstats from the seed node
+    And we can collect the dropped messages stats from the seed node
+    And we can collect the client request metrics from the seed node
     Then reaper has the last added cluster in storage
     And reaper has 0 scheduled repairs for the last added cluster
     When a new daily "full" repair schedule is added for the last added cluster and keyspace "booya"

--- a/src/ui/app/jsx/client-request-latency.jsx
+++ b/src/ui/app/jsx/client-request-latency.jsx
@@ -1,0 +1,181 @@
+import React from "react";
+import Table from 'react-bootstrap/lib/Table';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import {DeleteStatusMessageMixin, humanFileSize, getUrlPrefix, toast} from "jsx/mixin";
+import $ from "jquery";
+
+const ClientRequestLatency = React.createClass({
+    propTypes: {
+      endpoint: React.PropTypes.string.isRequired,
+      clusterName: React.PropTypes.string.isRequired
+    },
+
+    getInitialState() {
+      return {clientRequestLatencies: [], scheduler: {}};
+    },
+
+    componentWillMount: function() {
+      this._collectClientRequestLatencies();
+      this.setState({scheduler : setInterval(this._collectclientRequestLatencies, 10000)});
+    },
+
+    componentWillUnmount: function() {
+      clearInterval(this.state.scheduler);
+    },
+
+    _collectClientRequestLatencies: function() {    
+      $.ajax({
+        url: getUrlPrefix(window.top.location.pathname) + '/node/clientRequestLatencies/' +  encodeURIComponent(this.props.clusterName) + '/' + encodeURIComponent(this.props.endpoint),
+        method: 'GET',
+        component: this,
+        dataType: 'json',
+        complete: function(data) {
+            this.component.setState({clientRequestLatencies: data.responseJSON});
+        },
+        error: function(data) {
+            console.log("Failed getting client request latencies : " + data.responseText);
+        }
+    })
+    },
+  
+    render: function() {
+      function roundLatency(number, roundTo) {
+        return number==null?"":number.toFixed(roundTo);
+      }
+
+      const alignRightStyle = {
+        textAlign: "right" 
+      }
+
+      const headerStyle = {
+        fontWeight: "bold" 
+      }
+
+      const tooltipP50 = (
+        <Tooltip id="tooltip">
+          50th Percentile
+        </Tooltip>
+      );
+
+      const tooltipP75 = (
+        <Tooltip id="tooltip">
+          75th Percentile
+        </Tooltip>
+      );
+
+      const tooltipP95 = (
+        <Tooltip id="tooltip">
+          95th Percentile
+        </Tooltip>
+      );
+
+      const tooltipP99 = (
+        <Tooltip id="tooltip">
+          99th Percentile
+        </Tooltip>
+      );
+
+      const tooltipP999 = (
+        <Tooltip id="tooltip">
+          99.9th Percentile
+        </Tooltip>
+      );
+
+      const tooltipMax = (
+        <Tooltip id="tooltip">
+          Max
+        </Tooltip>
+      );
+
+      const tooltip1min = (
+        <Tooltip id="tooltip">
+          1 minute rate
+        </Tooltip>
+      );
+
+      const tooltip5min = (
+        <Tooltip id="tooltip">
+          5 minutes rate
+        </Tooltip>
+      );
+
+      const tooltip15min = (
+        <Tooltip id="tooltip">
+          15 minutes rate
+        </Tooltip>
+      );
+
+      const clientRequestLatenciesHeader = 
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th style={alignRightStyle}>p50</th>
+            <th style={alignRightStyle}>p75</th>
+            <th style={alignRightStyle}>p95</th>
+            <th style={alignRightStyle}>p99</th>
+            <th style={alignRightStyle}>p999</th>
+            <th style={alignRightStyle}>Max</th>
+            <th style={alignRightStyle}>1min</th>
+            <th style={alignRightStyle}>5min</th>
+            <th style={alignRightStyle}>15min</th>
+          </tr>
+        </thead>
+        ;
+
+      const clientRequestLatenciesBodyFirstPart = this.state.clientRequestLatencies.sort(
+        (a, b) => {if(a.name + a.type < b.name + b.type) return -1;
+        if(a.name + a.type > b.name + b.type) return 1;
+        return 0;})
+        .filter(metric => metric.type == "Latency")
+        .map(clientRequest => 
+          <tr>
+            <td>{clientRequest.name}</td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP50}><span>{roundLatency(clientRequest.p50, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP75}><span>{roundLatency(clientRequest.p75, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP95}><span>{roundLatency(clientRequest.p95, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP99}><span>{roundLatency(clientRequest.p99, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP999}><span>{roundLatency(clientRequest.p999, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipMax}><span>{roundLatency(clientRequest.max, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltip1min}><span>{roundLatency(clientRequest.oneMinuteRate, 2)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltip5min}><span>{roundLatency(clientRequest.fiveMinuteRate, 2)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltip15min}><span>{roundLatency(clientRequest.fifteenMinuteRate, 2)}</span></OverlayTrigger></td>
+          </tr>
+      )
+      ;
+
+      const clientRequestLatenciesBodySecondPart = this.state.clientRequestLatencies.sort(
+        (a, b) => {if(a.name + a.type < b.name + b.type) return -1;
+        if(a.name + a.type > b.name + b.type) return 1;
+        return 0;})
+        .filter(metric => metric.type != "Latency")
+        .map(clientRequest => 
+          <tr>
+            <td >{clientRequest.name} {clientRequest.type}</td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP50}><span>{roundLatency(clientRequest.p50, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP75}><span>{roundLatency(clientRequest.p75, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP95}><span>{roundLatency(clientRequest.p95, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP99}><span>{roundLatency(clientRequest.p99, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP999}><span>{roundLatency(clientRequest.p999, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipMax}><span>{roundLatency(clientRequest.max, 3)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltip1min}><span>{roundLatency(clientRequest.oneMinuteRate, 2)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltip5min}><span>{roundLatency(clientRequest.fiveMinuteRate, 2)}</span></OverlayTrigger></td>
+            <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltip15min}><span>{roundLatency(clientRequest.fifteenMinuteRate, 2)}</span></OverlayTrigger></td>
+          </tr>
+      )
+      ;
+  
+      return (<div className="col-lg-12"> 
+              <Table striped bordered condensed hover>
+                {clientRequestLatenciesHeader}
+                <tbody>
+                  {clientRequestLatenciesBodyFirstPart}
+                  {clientRequestLatenciesBodySecondPart}
+                </tbody>
+              </Table>
+              </div>
+      );
+    }
+  })
+
+  export default ClientRequestLatency;

--- a/src/ui/app/jsx/dropped-messages.jsx
+++ b/src/ui/app/jsx/dropped-messages.jsx
@@ -1,0 +1,86 @@
+import React from "react";
+import Table from 'react-bootstrap/lib/Table';
+import {DeleteStatusMessageMixin, humanFileSize, getUrlPrefix, toast} from "jsx/mixin";
+import $ from "jquery";
+
+const DroppedMessages = React.createClass({
+    propTypes: {
+      endpoint: React.PropTypes.string.isRequired,
+      clusterName: React.PropTypes.string.isRequired
+    },
+
+    getInitialState() {
+      return {droppedMessages: [], scheduler: {}};
+    },
+
+    componentWillMount: function() {
+      this._collectDroppedMessages();
+      this.setState({scheduler : setInterval(this._collectDroppedMessages, 10000)});
+    },
+
+    componentWillUnmount: function() {
+      clearInterval(this.state.scheduler);
+    },
+
+    _collectDroppedMessages: function() {    
+      $.ajax({
+        url: getUrlPrefix(window.top.location.pathname) + '/node/dropped/' +  encodeURIComponent(this.props.clusterName) + '/' + encodeURIComponent(this.props.endpoint),
+        method: 'GET',
+        component: this,
+        dataType: 'json',
+        complete: function(data) {
+            this.component.setState({droppedMessages: data.responseJSON});
+        },
+        error: function(data) {
+            console.log("Failed getting dropped messages : " + data.responseText);
+        }
+    })
+    },
+  
+    render: function() {
+      const alignRightStyle = {
+        textAlign: "right" 
+      }
+
+      const headerStyle = {
+        fontWeight: "bold" 
+      }
+
+      const droppedMessagesHeader = 
+      <thead>
+        <tr>
+          <th>Type</th>
+          <th style={alignRightStyle}>Count</th>
+          <th style={alignRightStyle}>1 minute</th>
+          <th style={alignRightStyle}>5 minutes</th>
+          <th style={alignRightStyle}>15 minutes</th>
+          <th style={alignRightStyle}>Mean rate</th>
+        </tr>
+      </thead>
+      ;
+
+      const droppedMessagesBody = this.state.droppedMessages.sort((a, b) => {if(a.name < b.name) return -1;
+      if(a.name > b.name) return 1;
+      return 0;}).map(pool => 
+        <tr>
+          <td>{pool.name}</td>
+          <td style={alignRightStyle}>{pool.count}</td>
+          <td style={alignRightStyle}>{pool.oneMinuteRate}</td>
+          <td style={alignRightStyle}>{pool.fiveMinuteRate}</td>
+          <td style={alignRightStyle}>{pool.fifteenMinuteRate}</td>
+          <td style={alignRightStyle}>{pool.meanRate}</td>
+        </tr>
+      )
+      ;
+  
+      return (<Table striped bordered condensed hover>
+                {droppedMessagesHeader}
+                <tbody>
+                  {droppedMessagesBody}
+                </tbody>
+              </Table>
+      );
+    }
+  })
+
+  export default DroppedMessages;

--- a/src/ui/app/jsx/node-status.jsx
+++ b/src/ui/app/jsx/node-status.jsx
@@ -1,5 +1,8 @@
 import React from "react";
 import Snapshot from "jsx/snapshot";
+import TpStats from "jsx/tpstats";
+import DroppedMessages from "jsx/dropped-messages";
+import ClientRequestLatency from "jsx/client-request-latency";
 import {DeleteStatusMessageMixin, humanFileSize, getUrlPrefix, toast} from "jsx/mixin";
 import Modal from 'react-bootstrap/lib/Modal';
 import Button from 'react-bootstrap/lib/Button';
@@ -7,6 +10,8 @@ import Tooltip from 'react-bootstrap/lib/Tooltip';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import ProgressBar from 'react-bootstrap/lib/ProgressBar';
 import Popover from 'react-bootstrap/lib/Popover';
+import Tabs from 'react-bootstrap/lib/Tabs';
+import Tab from 'react-bootstrap/lib/Tab';
 import $ from "jquery";
 var NotificationSystem = require('react-notification-system');
 
@@ -170,7 +175,8 @@ const NodeStatus = React.createClass({
         </Popover>
       );
   
-      return (<span>
+      return (
+            <span>
               <OverlayTrigger placement="top" overlay={tooltip}><button type="button" style={btStyle} className={buttonStyle} onClick={this.open}>{this.props.endpointStatus.endpoint} ({humanFileSize(this.props.endpointStatus.load, 1024)})</button></OverlayTrigger>
               <Modal show={this.state.showModal} onHide={this.close} bsSize="large" aria-labelledby="contained-modal-title-lg" dialogClassName="large-modal">
                 <Modal.Header closeButton>
@@ -209,28 +215,43 @@ const NodeStatus = React.createClass({
                   </div>
                   <div className="row">
                   <div className="col-lg-12">
-                  <div className="panel panel-success">
-                    <div className="panel-heading">
-                      <div className="panel-title">
+                  <Tabs defaultActiveKey={1} id="node-tab">
+                    <Tab eventKey={1} title="Thread pool stats">
+                      <TpStats endpoint={this.props.endpointStatus.endpoint}
+                        clusterName={this.props.clusterName}/>
+                    </Tab>
+                    <Tab eventKey={2} title="Dropped messages">
+                      <DroppedMessages endpoint={this.props.endpointStatus.endpoint}
+                        clusterName={this.props.clusterName}/>
+                    </Tab>
+                    <Tab eventKey={3} title="Client Latency">
+                      <ClientRequestLatency endpoint={this.props.endpointStatus.endpoint}
+                        clusterName={this.props.clusterName}/>
+                    </Tab>
+                    <Tab eventKey={4} title="Snapshots">
+                      <div className="panel panel-success">
+                        <div className="panel-heading">
+                          <div className="panel-title">
+                            <div className="row">
+                              <div className="col-lg-8"><h4>Snapshots </h4></div><div className="col-lg-4"><h4><span className="label label-primary">Size on disk: {humanFileSize(this.state.totalSnapshotSizeOnDisk, 1024)}</span> <span className="label label-warning">True size: {humanFileSize(this.state.totalSnapshotTrueSize, 1024)}</span></h4></div>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="panel-body" id="snapshots">
                         <div className="row">
-                          <div className="col-lg-8"><h4>Snapshots </h4></div><div className="col-lg-4"><h4><span className="label label-primary">Size on disk: {humanFileSize(this.state.totalSnapshotSizeOnDisk, 1024)}</span> <span className="label label-warning">True size: {humanFileSize(this.state.totalSnapshotTrueSize, 1024)}</span></h4></div>
+                          <div className="col-lg-12">
+                            <OverlayTrigger trigger="focus" placement="bottom" overlay={takeSnapshotClick}><button type="button" className="btn btn-md btn-success" style={takeSnapshotStyle}>Take a snapshot</button></OverlayTrigger>                  
+                            <button type="button" className="btn btn-md btn-success" style={progressStyle} disabled>Taking a snapshot...</button>
+                          </div>
+                          <div className="col-lg-12">&nbsp;</div> 
+                            {snapshots}
+                          </div>
                         </div>
                       </div>
+                      </Tab>
+                    </Tabs>               
                     </div>
-                    <div className="panel-body" id="snapshots">
-                    <div className="row">
-                    <div className="col-lg-12">
-                    <OverlayTrigger trigger="focus" placement="bottom" overlay={takeSnapshotClick}><button type="button" className="btn btn-md btn-success" style={takeSnapshotStyle}>Take a snapshot</button></OverlayTrigger>                  
-                    <button type="button" className="btn btn-md btn-success" style={progressStyle} disabled>Taking a snapshot...</button>
-                  </div>
-                  <div className="col-lg-12">&nbsp;</div>                
-                    {snapshots}
-                  </div>
-                  </div>
                     </div>
-                  </div>
-                    
-                  </div>
                   
                 </Modal.Body>
                 <Modal.Footer>

--- a/src/ui/app/jsx/tpstats.jsx
+++ b/src/ui/app/jsx/tpstats.jsx
@@ -1,0 +1,86 @@
+import React from "react";
+import Table from 'react-bootstrap/lib/Table';
+import {DeleteStatusMessageMixin, humanFileSize, getUrlPrefix, toast} from "jsx/mixin";
+import $ from "jquery";
+
+const TpStats = React.createClass({
+    propTypes: {
+      endpoint: React.PropTypes.string.isRequired,
+      clusterName: React.PropTypes.string.isRequired
+    },
+
+    getInitialState() {
+      return {tpstats: [], scheduler: {}};
+    },
+
+    componentWillMount: function() {
+      this._collectTpstats();
+      this.setState({scheduler : setInterval(this._collectTpstats, 10000)});
+    },
+
+    componentWillUnmount: function() {
+      clearInterval(this.state.scheduler);
+    },
+
+    _collectTpstats: function() {    
+      $.ajax({
+        url: getUrlPrefix(window.top.location.pathname) + '/node/tpstats/' +  encodeURIComponent(this.props.clusterName) + '/' + encodeURIComponent(this.props.endpoint),
+        method: 'GET',
+        component: this,
+        dataType: 'json',
+        complete: function(data) {
+            this.component.setState({tpstats: data.responseJSON});
+        },
+        error: function(data) {
+            console.log("Failed getting tpstats : " + data.responseText);
+        }
+    })
+    },
+  
+    render: function() {
+      const alignRightStyle = {
+        textAlign: "right" 
+      }
+
+      const headerStyle = {
+        fontWeight: "bold" 
+      }
+
+      const tpstatsHeader = 
+      <thead>
+        <tr>
+          <th >Pool name</th>
+          <th style={alignRightStyle}>Active</th>
+          <th style={alignRightStyle}>Pending</th>
+          <th style={alignRightStyle}>Completed</th>
+          <th style={alignRightStyle}>Blocked</th>
+          <th style={alignRightStyle}>All time blocked</th>
+        </tr>
+      </thead>
+      ;
+
+      const tpstatsBody = this.state.tpstats.sort((a, b) => {if(a.name < b.name) return -1;
+      if(a.name > b.name) return 1;
+      return 0;}).map(pool => 
+        <tr>
+          <td >{pool.name}</td>
+          <td style={alignRightStyle}>{pool.activeTasks}</td>
+          <td style={alignRightStyle}>{pool.pendingTasks}</td>
+          <td style={alignRightStyle}>{pool.completedTasks}</td>
+          <td style={alignRightStyle}>{pool.currentlyBlockedTasks}</td>
+          <td style={alignRightStyle}>{pool.totalBlockedTasks}</td>
+        </tr>
+      )
+      ;
+  
+      return (<Table striped bordered condensed hover>
+                {tpstatsHeader}
+                <tbody>
+                  {tpstatsBody}
+                </tbody>
+              </Table>
+      );
+    }
+  })
+
+  export default TpStats;


### PR DESCRIPTION
Adds all the necessary bits to expose REST endpoints to retrieve tpstats, dropped messages and client requests metrics for a specific node and display them in the UI.

![reaper-metrics1](https://user-images.githubusercontent.com/5096002/41657605-3c432518-7494-11e8-90bd-359a93e77ffa.png)
![reaper-metrics2](https://user-images.githubusercontent.com/5096002/41657622-46d63f42-7494-11e8-987c-0fc442d0f694.png)
![reaper-metrics3](https://user-images.githubusercontent.com/5096002/41657628-4ad64bd2-7494-11e8-93f0-9041b38fc6c8.png)
