### PR TITLE
Handle out of order repair notifications

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -149,6 +149,11 @@ final class RepairRunner implements Runnable {
       throw new ReaperException(msg);
     }
 
+    LOG.debug(
+        "Possible parallel repairs : {}",
+        Math.min(
+            ranges.size() / ranges.values().iterator().next().size(),
+            Math.max(1, hostsInRing.keySet().size() / ranges.values().iterator().next().size())));
     return Math.min(
         ranges.size() / ranges.values().iterator().next().size(),
         Math.max(1, hostsInRing.keySet().size() / ranges.values().iterator().next().size()));
@@ -176,6 +181,8 @@ final class RepairRunner implements Runnable {
         new RingRange(
             segments.get((parallelRepairs - 1) * segments.size() / parallelRepairs).getStart(),
             segments.get(0).getStart()));
+
+    LOG.debug("Parallel ranges : {}", parallelRanges);
 
     return parallelRanges;
   }

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -791,6 +791,11 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         break;
 
       case SUCCESS:
+
+        Preconditions.checkState(
+            !successOrFailedNotified.get(),
+            "illegal multiple 'SUCCESS' and 'FAILURE', %s:%s", repairRunner.getRepairRunId(), segmentId);
+
         try {
           if (segmentFailed.get()) {
             LOG.debug(
@@ -828,6 +833,11 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
 
       case ERROR:
       case ABORT:
+
+        Preconditions.checkState(
+            !successOrFailedNotified.get(),
+            "illegal multiple 'SUCCESS' and 'FAILURE', %s:%s", repairRunner.getRepairRunId(), segmentId);
+
         LOG.warn(
             "repair session failed for segment with id '{}' and repair number '{}'",
             segmentId,
@@ -847,6 +857,11 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         // regardless of succeeded or failed sessions.
         // Since we can get out of order notifications,
         // we won't exit unless we already got a SUCCESS or ERROR notification.
+
+        Preconditions.checkState(
+            !completeNotified.get(),
+            "illegal multiple 'COMPLETE', %s:%s", repairRunner.getRepairRunId(), segmentId);
+
         LOG.debug(
             "repair session finished for segment with id '{}' and repair number '{}'",
             segmentId,
@@ -896,6 +911,11 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         break;
 
       case SESSION_SUCCESS:
+
+        Preconditions.checkState(
+            !successOrFailedNotified.get(),
+            "illegal multiple 'SUCCESS' and 'FAILURE', %s:%s", repairRunner.getRepairRunId(), segmentId);
+
         try {
           if (segmentFailed.get()) {
             LOG.debug(
@@ -933,6 +953,11 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         break;
 
       case SESSION_FAILED:
+
+        Preconditions.checkState(
+            !successOrFailedNotified.get(),
+            "illegal multiple 'SUCCESS' and 'FAILURE', %s:%s", repairRunner.getRepairRunId(), segmentId);
+
         LOG.warn(
             "repair session failed for segment with id '{}' and repair number '{}'",
             segmentId,
@@ -948,6 +973,11 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         break;
 
       case FINISHED:
+
+        Preconditions.checkState(
+            !completeNotified.get(),
+            "illegal multiple 'COMPLETE', %s:%s", repairRunner.getRepairRunId(), segmentId);
+
         // This gets called through the JMX proxy at the end
         // regardless of succeeded or failed sessions.
         // Since we can get out of order notifications,

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.utils.progress.ProgressEventType;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.joda.time.DateTime;
@@ -472,6 +473,568 @@ public final class SegmentRunnerTest {
     executor.shutdown();
 
     assertEquals(RepairSegment.State.NOT_STARTED, storage.getRepairSegment(runId, segmentId).get().getState());
+    assertEquals(2, storage.getRepairSegment(runId, segmentId).get().getFailCount());
+  }
+
+  @Test
+  public void outOfOrderSuccessCass21Test()
+      throws InterruptedException, ReaperException, ExecutionException {
+    final IStorage storage = new MemoryStorage();
+    RepairUnit cf =
+        storage.addRepairUnit(
+            new RepairUnit.Builder(
+                "reaper",
+                "reaper",
+                Sets.newHashSet("reaper"),
+                false,
+                Sets.newHashSet("127.0.0.1"),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                1));
+    RepairRun run =
+        storage.addRepairRun(
+            new RepairRun.Builder(
+                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+            Collections.singleton(
+                RepairSegment.builder(
+                    Segment.builder()
+                        .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .build(),
+                    cf.getId())));
+    final UUID runId = run.getId();
+    final UUID segmentId =
+        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final MutableObject<Future<?>> future = new MutableObject<>();
+
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = Mockito.mock(ReaperApplicationConfiguration.class);
+    when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
+    when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
+
+    context.jmxConnectionFactory =
+        new JmxConnectionFactory() {
+          @Override
+          protected JmxProxy connect(
+              final Optional<RepairStatusHandler> handler, Node host, int connectionTimeout)
+              throws ReaperException {
+
+            JmxProxy jmx = mock(JmxProxy.class);
+            when(jmx.getClusterName()).thenReturn("reaper");
+            when(jmx.isConnectionAlive()).thenReturn(true);
+            when(jmx.tokenRangeToEndpoint(anyString(), any(Segment.class)))
+                .thenReturn(Lists.newArrayList(""));
+            when(jmx.getDataCenter()).thenReturn("dc1");
+            when(jmx.getDataCenter(anyString())).thenReturn("dc1");
+
+            when(jmx.triggerRepair(
+                    any(BigInteger.class),
+                    any(BigInteger.class),
+                    any(),
+                    any(RepairParallelism.class),
+                    any(),
+                    anyBoolean(),
+                    any(),
+                    any(),
+                    any(),
+                    any(Integer.class)))
+                .then(
+                    invocation -> {
+                      assertEquals(
+                          RepairSegment.State.NOT_STARTED,
+                          storage.getRepairSegment(runId, segmentId).get().getState());
+
+                      future.setValue(
+                          executor.submit(
+                              () -> {
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.STARTED),
+                                        Optional.absent(),
+                                        "Repair command 1 has started",
+                                        jmx);
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.FINISHED),
+                                        Optional.absent(),
+                                        "Repair command 1 has finished",
+                                        jmx);
+
+                                assertEquals(
+                                    RepairSegment.State.RUNNING,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                                        Optional.absent(),
+                                        "Repair session succeeded in command 1",
+                                        jmx);
+
+                                assertEquals(
+                                    RepairSegment.State.DONE,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+                              }));
+                      return 1;
+                    });
+
+            return jmx;
+          }
+        };
+
+    RepairRunner rr = mock(RepairRunner.class);
+    RepairUnit ru = mock(RepairUnit.class);
+
+    SegmentRunner sr =
+        new SegmentRunner(
+            context,
+            segmentId,
+            Collections.singleton(""),
+            5000,
+            0.5,
+            RepairParallelism.PARALLEL,
+            "reaper",
+            ru,
+            rr);
+
+    sr.run();
+
+    future.getValue().get();
+    executor.shutdown();
+
+    assertEquals(
+        RepairSegment.State.DONE, storage.getRepairSegment(runId, segmentId).get().getState());
+    assertEquals(0, storage.getRepairSegment(runId, segmentId).get().getFailCount());
+  }
+
+  @Test
+  public void outOfOrderSuccessCass22Test()
+      throws InterruptedException, ReaperException, ExecutionException {
+    final IStorage storage = new MemoryStorage();
+    RepairUnit cf =
+        storage.addRepairUnit(
+            new RepairUnit.Builder(
+                "reaper",
+                "reaper",
+                Sets.newHashSet("reaper"),
+                false,
+                Sets.newHashSet("127.0.0.1"),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                1));
+    RepairRun run =
+        storage.addRepairRun(
+            new RepairRun.Builder(
+                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+            Collections.singleton(
+                RepairSegment.builder(
+                    Segment.builder()
+                        .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .build(),
+                    cf.getId())));
+    final UUID runId = run.getId();
+    final UUID segmentId =
+        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final MutableObject<Future<?>> future = new MutableObject<>();
+
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = Mockito.mock(ReaperApplicationConfiguration.class);
+    when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
+    when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
+
+    context.jmxConnectionFactory =
+        new JmxConnectionFactory() {
+          @Override
+          protected JmxProxy connect(
+              final Optional<RepairStatusHandler> handler, Node host, int connectionTimeout)
+              throws ReaperException {
+
+            JmxProxy jmx = mock(JmxProxy.class);
+            when(jmx.getClusterName()).thenReturn("reaper");
+            when(jmx.isConnectionAlive()).thenReturn(true);
+            when(jmx.tokenRangeToEndpoint(anyString(), any(Segment.class)))
+                .thenReturn(Lists.newArrayList(""));
+            when(jmx.getDataCenter()).thenReturn("dc1");
+            when(jmx.getDataCenter(anyString())).thenReturn("dc1");
+
+            when(jmx.triggerRepair(
+                    any(BigInteger.class),
+                    any(BigInteger.class),
+                    any(),
+                    any(RepairParallelism.class),
+                    any(),
+                    anyBoolean(),
+                    any(),
+                    any(),
+                    any(),
+                    any(Integer.class)))
+                .then(
+                    invocation -> {
+                      assertEquals(
+                          RepairSegment.State.NOT_STARTED,
+                          storage.getRepairSegment(runId, segmentId).get().getState());
+
+                      future.setValue(
+                          executor.submit(
+                              () -> {
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.absent(),
+                                        Optional.of(ProgressEventType.START),
+                                        "Repair command 1 has started",
+                                        jmx);
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.absent(),
+                                        Optional.of(ProgressEventType.COMPLETE),
+                                        "Repair command 1 has finished",
+                                        jmx);
+
+                                assertEquals(
+                                    RepairSegment.State.RUNNING,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.absent(),
+                                        Optional.of(ProgressEventType.SUCCESS),
+                                        "Repair session succeeded in command 1",
+                                        jmx);
+
+                                assertEquals(
+                                    RepairSegment.State.DONE,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+                              }));
+                      return 1;
+                    });
+
+            return jmx;
+          }
+        };
+
+    RepairRunner rr = mock(RepairRunner.class);
+    RepairUnit ru = mock(RepairUnit.class);
+
+    SegmentRunner sr =
+        new SegmentRunner(
+            context,
+            segmentId,
+            Collections.singleton(""),
+            5000,
+            0.5,
+            RepairParallelism.PARALLEL,
+            "reaper",
+            ru,
+            rr);
+
+    sr.run();
+
+    future.getValue().get();
+    executor.shutdown();
+
+    assertEquals(
+        RepairSegment.State.DONE, storage.getRepairSegment(runId, segmentId).get().getState());
+    assertEquals(0, storage.getRepairSegment(runId, segmentId).get().getFailCount());
+  }
+
+  @Test
+  public void outOfOrderFailureCass21Test()
+      throws InterruptedException, ReaperException, ExecutionException {
+    final IStorage storage = new MemoryStorage();
+    RepairUnit cf =
+        storage.addRepairUnit(
+            new RepairUnit.Builder(
+                "reaper",
+                "reaper",
+                Sets.newHashSet("reaper"),
+                false,
+                Sets.newHashSet("127.0.0.1"),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                1));
+    RepairRun run =
+        storage.addRepairRun(
+            new RepairRun.Builder(
+                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+            Collections.singleton(
+                RepairSegment.builder(
+                    Segment.builder()
+                        .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .build(),
+                    cf.getId())));
+    final UUID runId = run.getId();
+    final UUID segmentId =
+        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final MutableObject<Future<?>> future = new MutableObject<>();
+
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = Mockito.mock(ReaperApplicationConfiguration.class);
+    when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
+    when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
+
+    context.jmxConnectionFactory =
+        new JmxConnectionFactory() {
+          @Override
+          protected JmxProxy connect(
+              final Optional<RepairStatusHandler> handler, Node host, int connectionTimeout)
+              throws ReaperException {
+
+            JmxProxy jmx = mock(JmxProxy.class);
+            when(jmx.getClusterName()).thenReturn("reaper");
+            when(jmx.isConnectionAlive()).thenReturn(true);
+            when(jmx.tokenRangeToEndpoint(anyString(), any(Segment.class)))
+                .thenReturn(Lists.newArrayList(""));
+            when(jmx.getDataCenter()).thenReturn("dc1");
+            when(jmx.getDataCenter(anyString())).thenReturn("dc1");
+
+            when(jmx.triggerRepair(
+                    any(BigInteger.class),
+                    any(BigInteger.class),
+                    any(),
+                    any(RepairParallelism.class),
+                    any(),
+                    anyBoolean(),
+                    any(),
+                    any(),
+                    any(),
+                    any(Integer.class)))
+                .then(
+                    invocation -> {
+                      assertEquals(
+                          RepairSegment.State.NOT_STARTED,
+                          storage.getRepairSegment(runId, segmentId).get().getState());
+
+                      future.setValue(
+                          executor.submit(
+                              () -> {
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.STARTED),
+                                        Optional.absent(),
+                                        "Repair command 1 has started",
+                                        jmx);
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.FINISHED),
+                                        Optional.absent(),
+                                        "Repair command 1 has finished",
+                                        jmx);
+
+                                assertEquals(
+                                    RepairSegment.State.RUNNING,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.of(ActiveRepairService.Status.SESSION_FAILED),
+                                        Optional.absent(),
+                                        "Repair session succeeded in command 1",
+                                        jmx);
+
+                                assertEquals(
+                                    RepairSegment.State.NOT_STARTED,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+                              }));
+                      return 1;
+                    });
+
+            return jmx;
+          }
+        };
+
+    RepairRunner rr = mock(RepairRunner.class);
+    RepairUnit ru = mock(RepairUnit.class);
+
+    SegmentRunner sr =
+        new SegmentRunner(
+            context,
+            segmentId,
+            Collections.singleton(""),
+            5000,
+            0.5,
+            RepairParallelism.PARALLEL,
+            "reaper",
+            ru,
+            rr);
+
+    sr.run();
+
+    future.getValue().get();
+    executor.shutdown();
+
+    assertEquals(
+        RepairSegment.State.NOT_STARTED,
+        storage.getRepairSegment(runId, segmentId).get().getState());
+    assertEquals(2, storage.getRepairSegment(runId, segmentId).get().getFailCount());
+  }
+
+  @Test
+  public void outOfOrderFailureTestCass22()
+      throws InterruptedException, ReaperException, ExecutionException {
+    final IStorage storage = new MemoryStorage();
+    RepairUnit cf =
+        storage.addRepairUnit(
+            new RepairUnit.Builder(
+                "reaper",
+                "reaper",
+                Sets.newHashSet("reaper"),
+                false,
+                Sets.newHashSet("127.0.0.1"),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                1));
+    RepairRun run =
+        storage.addRepairRun(
+            new RepairRun.Builder(
+                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+            Collections.singleton(
+                RepairSegment.builder(
+                    Segment.builder()
+                        .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .build(),
+                    cf.getId())));
+    final UUID runId = run.getId();
+    final UUID segmentId =
+        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final MutableObject<Future<?>> future = new MutableObject<>();
+
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = Mockito.mock(ReaperApplicationConfiguration.class);
+    when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
+    when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
+
+    context.jmxConnectionFactory =
+        new JmxConnectionFactory() {
+          @Override
+          protected JmxProxy connect(
+              final Optional<RepairStatusHandler> handler, Node host, int connectionTimeout)
+              throws ReaperException {
+
+            JmxProxy jmx = mock(JmxProxy.class);
+            when(jmx.getClusterName()).thenReturn("reaper");
+            when(jmx.isConnectionAlive()).thenReturn(true);
+            when(jmx.tokenRangeToEndpoint(anyString(), any(Segment.class)))
+                .thenReturn(Lists.newArrayList(""));
+            when(jmx.getDataCenter()).thenReturn("dc1");
+            when(jmx.getDataCenter(anyString())).thenReturn("dc1");
+
+            when(jmx.triggerRepair(
+                    any(BigInteger.class),
+                    any(BigInteger.class),
+                    any(),
+                    any(RepairParallelism.class),
+                    any(),
+                    anyBoolean(),
+                    any(),
+                    any(),
+                    any(),
+                    any(Integer.class)))
+                .then(
+                    invocation -> {
+                      assertEquals(
+                          RepairSegment.State.NOT_STARTED,
+                          storage.getRepairSegment(runId, segmentId).get().getState());
+
+                      future.setValue(
+                          executor.submit(
+                              () -> {
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.absent(),
+                                        Optional.of(ProgressEventType.START),
+                                        "Repair command 1 has started",
+                                        jmx);
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.absent(),
+                                        Optional.of(ProgressEventType.COMPLETE),
+                                        "Repair command 1 has finished",
+                                        jmx);
+
+                                assertEquals(
+                                    RepairSegment.State.RUNNING,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+
+                                handler
+                                    .get()
+                                    .handle(
+                                        1,
+                                        Optional.absent(),
+                                        Optional.of(ProgressEventType.ERROR),
+                                        "Repair session succeeded in command 1",
+                                        jmx);
+
+                                assertEquals(
+                                    RepairSegment.State.NOT_STARTED,
+                                    storage.getRepairSegment(runId, segmentId).get().getState());
+                              }));
+                      return 1;
+                    });
+
+            return jmx;
+          }
+        };
+
+    RepairRunner rr = mock(RepairRunner.class);
+    RepairUnit ru = mock(RepairUnit.class);
+
+    SegmentRunner sr =
+        new SegmentRunner(
+            context,
+            segmentId,
+            Collections.singleton(""),
+            5000,
+            0.5,
+            RepairParallelism.PARALLEL,
+            "reaper",
+            ru,
+            rr);
+
+    sr.run();
+
+    future.getValue().get();
+    executor.shutdown();
+
+    assertEquals(
+        RepairSegment.State.NOT_STARTED,
+        storage.getRepairSegment(runId, segmentId).get().getState());
     assertEquals(2, storage.getRepairSegment(runId, segmentId).get().getFailCount());
   }
 


### PR DESCRIPTION
In the case repair sessions end in a very short time (within a few 10s of milliseconds) we can get out of order notifications from Cassandra :
Instead of `START -> SUCCESS -> COMPLETE`, we get `START -> COMPLETE -> SUCCESS`
This commit handles this case by not signaling the wait condition of the segment unless we have both a `SUCCESS` or an `ERROR` notification plus a `COMPLETE` one.