### PR TITLE
Fix base url issues with the UI

### DIFF
--- a/src/ui/app/html_template.ejs
+++ b/src/ui/app/html_template.ejs
@@ -12,6 +12,7 @@
     <title>Cassandra Reaper<%= htmlWebpackPlugin.options.title %></title>
 
     <!-- <base href="/webui/"> -->
+    <base href="<%= htmlWebpackPlugin.options.baseUrl %>" />
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/src/ui/start-webpack.sh
+++ b/src/ui/start-webpack.sh
@@ -1,1 +1,1 @@
-webpack-dev-server --host 0.0.0.0 --port 8000 --content-base build/
+webpack-dev-server --host 0.0.0.0 --port 8000 --content-base build/ -d

--- a/src/ui/webpack.config.js
+++ b/src/ui/webpack.config.js
@@ -8,7 +8,7 @@ var _commonDeps = [
 ];
 
 // include hot reload deps in dev mode
-var isDev = process.env.BUILD_DEV == '1'; // set by server.js
+const isDev = process.argv.indexOf('-d') !== -1;
 if(isDev) {
   _commonDeps.push("webpack-dev-server/client?http://0.0.0.0:8000"); // WebpackDevServer host and port
   _commonDeps.push("webpack/hot/only-dev-server");
@@ -66,7 +66,8 @@ module.exports = {
       hash: true,
       title: ' - Clusters',
       template: path.join(__dirname, 'app', 'html_template.ejs'),
-      inject: 'head'
+      inject: 'head',
+      baseUrl: isDev ? '/' : '/webui/'
     }),
     new HtmlWebpackPlugin({ 
       filename: 'repair.html',
@@ -74,7 +75,8 @@ module.exports = {
       hash: true,
       title: ' - Repair',
       template: path.join(__dirname, 'app', 'html_template.ejs'),
-      inject: 'head'
+      inject: 'head',
+      baseUrl: isDev ? '/' : '/webui/'
     }),
     new HtmlWebpackPlugin({  
       filename: 'schedules.html',
@@ -82,7 +84,8 @@ module.exports = {
       hash: true,
       title: ' - Schedules',
       template: path.join(__dirname, 'app', 'html_template.ejs'),
-      inject: 'head'
+      inject: 'head',
+      baseUrl: isDev ? '/' : '/webui/'
     }),
     new HtmlWebpackPlugin({
       filename: 'segments.html',
@@ -90,7 +93,8 @@ module.exports = {
       hash: true,
       title: ' - Segments',
       template: path.join(__dirname, 'app', 'html_template.ejs'),
-      inject: 'head'
+      inject: 'head',
+      baseUrl: isDev ? '/' : '/webui/'
     }),
     new HtmlWebpackPlugin({
       filename: 'snapshot.html',
@@ -98,7 +102,8 @@ module.exports = {
       hash: true,
       title: ' - Snapshots',
       template: path.join(__dirname, 'app', 'html_template.ejs'),
-      inject: 'head'
+      inject: 'head',
+      baseUrl: isDev ? '/' : '/webui/'
     }),
     new HtmlWebpackPlugin({ 
       filename: 'login.html',
@@ -106,7 +111,8 @@ module.exports = {
       hash: true,
       title: ' - Login',
       template: path.join(__dirname, 'app', 'html_template.ejs'),
-      inject: 'head'
+      inject: 'head',
+      bbaseUrl: isDev ? '/' : '/webui/'
     }),
     new webpack.ProvidePlugin({
       $: "jquery",


### PR DESCRIPTION
The UI showed a blank page until now if you didn't put a slash at the end of the URL, which is very confusing and gives the impression that it's broken.
This is due to the <base .../> tag not being properly set in the html files generated by webpack.
For development the base tag needs to use a different href value though, which required to handle a dev mode. This was done by adding a -d flag when starting the webpack dev server and generate the base tag accordingly.