### PR TITLE
Ensure notifications for a given repairNo are processed in order

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
@@ -138,7 +138,7 @@ public interface JmxProxy extends NotificationListener {
 
   void close();
 
-  void removeRepairStatusHandler(int commandId);
+  void removeRepairStatusHandler(int repairNo);
 
   List<Snapshot> listSnapshots() throws UnsupportedOperationException;
 

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -266,14 +266,19 @@ public final class SegmentRunnerTest {
                                 assertEquals(
                                     RepairSegment.State.RUNNING,
                                     storage.getRepairSegment(runId, segmentId).get().getState());
-                                // report about an unrelated repair. Shouldn't affect anything.
-                                ((RepairStatusHandler)invocation.getArgument(7))
-                                    .handle(
-                                        2,
-                                        Optional.of(ActiveRepairService.Status.SESSION_FAILED),
-                                        Optional.absent(),
-                                        "Repair command 2 has failed",
-                                        jmx);
+
+                                // test an unrelated repair. Should throw exception
+                                try {
+                                  ((RepairStatusHandler)invocation.getArgument(7))
+                                      .handle(
+                                          2,
+                                          Optional.of(ActiveRepairService.Status.SESSION_FAILED),
+                                          Optional.absent(),
+                                          "Repair command 2 has failed",
+                                          jmx);
+
+                                  throw new AssertionError("illegal handle of wrong repairNo");
+                                } catch (IllegalArgumentException ignore) { }
 
                                 ((RepairStatusHandler)invocation.getArgument(7))
                                     .handle(


### PR DESCRIPTION
The first commit is a code cleaning commit.
It
 - refactors all parameter/variable names of `commandId` to `repairNo`, as that is the terminology used by Cassandra
 - throws an exception if a segmentRunner is asked to handle a repairNo that is incorrect.

The second commit fixes both errors below, by providing a single separate threads per SegmentRunner for notifications to be processed on.
These errors were…
 - IllegalStateException: illegal multiple 'SUCCESS' and 'FAILURE'
 - IllegalStateException: endTime can only be set if segment is DONE

ref: https://github.com/thelastpickle/cassandra-reaper/issues/457