### PR TITLE
Fix for the schema disagreement issue created by Migration014

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration014.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration014.java
@@ -41,9 +41,11 @@ public final class Migration014 {
 
     if (0 < VersionNumber.parse("4.0").compareTo(highestNodeVersion)) {
       LOG.warn("altering every table to set `dclocal_read_repair_chance` to zero…");
-
       session.getCluster().getMetadata().getKeyspace(keyspace).getTables()
-        .forEach(tbl -> session.executeAsync("ALTER TABLE " + tbl.getName() + " WITH dclocal_read_repair_chance = 0"));
+          .stream()
+          .filter(table -> !table.getName().equals("repair_schedule") && !table.getName().equals("repair_unit"))
+          .forEach(tbl -> session.executeAsync(
+              "ALTER TABLE " + tbl.getName() + " WITH dclocal_read_repair_chance = 0"));
 
       LOG.warn("alter every table to set `dclocal_read_repair_chance` to zero completed.");
     }


### PR DESCRIPTION
Fixes #470

When creating the database from scratch, we first create the repair_unit and repair_schedule tables, then we drop them during Migration003. When Migration014 kicks in it still tries to alter both those tables (because they can linger in the session object metadata) and that messes up Cassandra which then goes into a schema disagreement (which can break Cassandra that won't start again due to inconsistencies in the system schema tables)