### PR TITLE
Fix checkstyle error maxLineLength from LeftCurlyCheck

### DIFF
--- a/src/server/checkstyle.xml
+++ b/src/server/checkstyle.xml
@@ -61,9 +61,7 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="120"/>
-        </module>
+        <module name="LeftCurly"/>
         <module name="RightCurly"/>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>


### PR DESCRIPTION
Attribute has been removed and will cause an error with recent
checkstyle releases, see https://github.com/checkstyle/checkstyle/issues/3671