### PR TITLE
Set isDev flag correctly for server.js

### DIFF
--- a/src/ui/webpack.config.js
+++ b/src/ui/webpack.config.js
@@ -8,7 +8,7 @@ var _commonDeps = [
 ];
 
 // include hot reload deps in dev mode
-const isDev = process.argv.indexOf('-d') !== -1;
+const isDev = process.argv.indexOf('-d') !== -1 || process.env.BUILD_DEV;
 if(isDev) {
   _commonDeps.push("webpack-dev-server/client?http://0.0.0.0:8000"); // WebpackDevServer host and port
   _commonDeps.push("webpack/hot/only-dev-server");


### PR DESCRIPTION
After #459 running `npm run start` would not have the isDev flag correctly for webpack-dev-server.