### PR TITLE
Clean code: Replace RepairRun, RepairUnit and RepairSchedule's inner Builder classes

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
@@ -17,6 +17,7 @@ package io.cassandrareaper.core;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.google.common.base.Preconditions;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeComparator;
@@ -57,6 +58,10 @@ public final class RepairRun implements Comparable<RepairRun> {
     this.lastEvent = builder.lastEvent;
     this.segmentCount = builder.segmentCount;
     this.repairParallelism = builder.repairParallelism;
+  }
+
+  public static Builder builder(String clusterName, UUID repairUnitId) {
+    return new Builder(clusterName, repairUnitId);
   }
 
   public UUID getId() {
@@ -175,33 +180,21 @@ public final class RepairRun implements Comparable<RepairRun> {
 
     public final String clusterName;
     public final UUID repairUnitId;
-    private RunState runState;
-    private DateTime creationTime;
-    private double intensity;
-    private String cause;
-    private String owner;
+    private RunState runState = RunState.NOT_STARTED;
+    private DateTime creationTime = DateTime.now();
+    private Double intensity;
+    private String cause = "";
+    private String owner = "";
     private DateTime startTime;
     private DateTime endTime;
     private DateTime pauseTime;
     private String lastEvent = "no events";
-    private int segmentCount;
+    private Integer segmentCount;
     private RepairParallelism repairParallelism;
 
-    public Builder(
-        String clusterName,
-        UUID repairUnitId,
-        DateTime creationTime,
-        double intensity,
-        int segmentCount,
-        RepairParallelism repairParallelism) {
-
+    private Builder(String clusterName, UUID repairUnitId) {
       this.clusterName = clusterName;
       this.repairUnitId = repairUnitId;
-      this.runState = RunState.NOT_STARTED;
-      this.creationTime = creationTime;
-      this.intensity = intensity;
-      this.segmentCount = segmentCount;
-      this.repairParallelism = repairParallelism;
     }
 
     private Builder(RepairRun original) {
@@ -276,6 +269,9 @@ public final class RepairRun implements Comparable<RepairRun> {
     }
 
     public RepairRun build(UUID id) {
+      Preconditions.checkState(null != repairParallelism, "repairParallelism(..) must be called before build(..)");
+      Preconditions.checkState(null != intensity, "intensity(..) must be called before build(..)");
+      Preconditions.checkState(null != segmentCount, "segmentCount(..) must be called before build(..)");
       return new RepairRun(this, id);
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.cassandra.repair.RepairParallelism;
@@ -55,6 +56,10 @@ public final class RepairSchedule {
     this.owner = builder.owner;
     this.pauseTime = builder.pauseTime;
     this.segmentCountPerNode = builder.segmentCountPerNode;
+  }
+
+  public static Builder builder(UUID repairUnitId) {
+    return new Builder(repairUnitId);
   }
 
   public UUID getId() {
@@ -131,46 +136,27 @@ public final class RepairSchedule {
     DELETED
   }
 
-  public static class Builder {
+  public static final class Builder {
 
     public final UUID repairUnitId;
-    private State state;
-    private int daysBetween;
+    private State state = RepairSchedule.State.ACTIVE;
+    private Integer daysBetween;
     private DateTime nextActivation;
-    private ImmutableList<UUID> runHistory;
-    @Deprecated private int segmentCount;
+    private ImmutableList<UUID> runHistory = ImmutableList.<UUID>of();
+    @Deprecated private int segmentCount = 0;
     private RepairParallelism repairParallelism;
-    private double intensity;
-    private DateTime creationTime;
-    private String owner;
+    private Double intensity;
+    private DateTime creationTime = DateTime.now();
+    private String owner = "";
     private DateTime pauseTime;
-    private int segmentCountPerNode;
+    private Integer segmentCountPerNode;
+    private boolean majorCompaction = false;
 
-
-    public Builder(
-        UUID repairUnitId,
-        State state,
-        int daysBetween,
-        DateTime nextActivation,
-        ImmutableList<UUID> runHistory,
-        int segmentCount,
-        RepairParallelism repairParallelism,
-        double intensity,
-        DateTime creationTime,
-        int segmentCountPerNode) {
+    private Builder(UUID repairUnitId) {
       this.repairUnitId = repairUnitId;
-      this.state = state;
-      this.daysBetween = daysBetween;
-      this.nextActivation = nextActivation;
-      this.runHistory = runHistory;
-      this.segmentCount = segmentCount;
-      this.repairParallelism = repairParallelism;
-      this.intensity = intensity;
-      this.creationTime = creationTime;
-      this.segmentCountPerNode = segmentCountPerNode;
     }
 
-    public Builder(RepairSchedule original) {
+    private Builder(RepairSchedule original) {
       repairUnitId = original.repairUnitId;
       state = original.state;
       daysBetween = original.daysBetween;
@@ -242,6 +228,11 @@ public final class RepairSchedule {
     }
 
     public RepairSchedule build(UUID id) {
+      Preconditions.checkState(null != daysBetween, "daysBetween(..) must be called before build(..)");
+      Preconditions.checkState(null != nextActivation, "nextActivation(..) must be called before build(..)");
+      Preconditions.checkState(null != repairParallelism, "repairParallelism(..) must be called before build(..)");
+      Preconditions.checkState(null != intensity, "intensity(..) must be called before build(..)");
+      Preconditions.checkState(null != segmentCountPerNode, "segmentCountPerNode(..) must be called before build(..)");
       return new RepairSchedule(this, id);
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairUnit.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairUnit.java
@@ -14,9 +14,12 @@
 
 package io.cassandrareaper.core;
 
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+
+import com.google.common.base.Preconditions;
 
 public final class RepairUnit {
 
@@ -40,6 +43,10 @@ public final class RepairUnit {
     this.datacenters = builder.datacenters;
     this.blacklistedTables = builder.blacklistedTables;
     this.repairThreadCount = builder.repairThreadCount;
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 
   public UUID getId() {
@@ -82,35 +89,18 @@ public final class RepairUnit {
     return new Builder(this);
   }
 
-  public static class Builder {
+  public static final class Builder {
 
-    public final String clusterName;
-    public final String keyspaceName;
-    public final Set<String> columnFamilies;
-    public final boolean incrementalRepair;
-    public final Set<String> nodes;
-    public final Set<String> datacenters;
-    public final Set<String> blacklistedTables;
-    public final int repairThreadCount;
+    public String clusterName;
+    public String keyspaceName;
+    public Set<String> columnFamilies = Collections.emptySet();
+    public Boolean incrementalRepair;
+    public Set<String> nodes = Collections.emptySet();
+    public Set<String> datacenters = Collections.emptySet();
+    public Set<String> blacklistedTables = Collections.emptySet();
+    public Integer repairThreadCount;
 
-    public Builder(
-        String clusterName,
-        String keyspaceName,
-        Set<String> columnFamilies,
-        boolean incrementalRepair,
-        Set<String> nodes,
-        Set<String> datacenters,
-        Set<String> blacklistedTables,
-        int repairThreadCount) {
-      this.clusterName = clusterName;
-      this.keyspaceName = keyspaceName;
-      this.columnFamilies = columnFamilies;
-      this.incrementalRepair = incrementalRepair;
-      this.nodes = nodes;
-      this.datacenters = datacenters;
-      this.blacklistedTables = blacklistedTables;
-      this.repairThreadCount = repairThreadCount;
-    }
+    private Builder() {}
 
     private Builder(RepairUnit original) {
       clusterName = original.clusterName;
@@ -123,7 +113,51 @@ public final class RepairUnit {
       repairThreadCount = original.repairThreadCount;
     }
 
+    public Builder clusterName(String clusterName) {
+      this.clusterName = clusterName;
+      return this;
+    }
+
+    public Builder keyspaceName(String keyspaceName) {
+      this.keyspaceName = keyspaceName;
+      return this;
+    }
+
+    public Builder columnFamilies(Set<String> columnFamilies) {
+      this.columnFamilies = Collections.unmodifiableSet(columnFamilies);
+      return this;
+    }
+
+    public Builder incrementalRepair(boolean incrementalRepair) {
+      this.incrementalRepair = incrementalRepair;
+      return this;
+    }
+
+    public Builder nodes(Set<String> nodes) {
+      this.nodes = Collections.unmodifiableSet(nodes);
+      return this;
+    }
+
+    public Builder datacenters(Set<String> datacenters) {
+      this.datacenters = Collections.unmodifiableSet(datacenters);
+      return this;
+    }
+
+    public Builder blacklistedTables(Set<String> blacklistedTables) {
+      this.blacklistedTables = Collections.unmodifiableSet(blacklistedTables);
+      return this;
+    }
+
+    public Builder repairThreadCount(int repairThreadCount) {
+      this.repairThreadCount = repairThreadCount;
+      return this;
+    }
+
     public RepairUnit build(UUID id) {
+      Preconditions.checkState(null != clusterName, "clusterName(..) must be called before build(..)");
+      Preconditions.checkState(null != keyspaceName, "keyspaceName(..) must be called before build(..)");
+      Preconditions.checkState(null != incrementalRepair, "incrementalRepair(..) must be called before build(..)");
+      Preconditions.checkState(null != repairThreadCount, "repairThreadCount(..) must be called before build(..)");
       return new RepairUnit(this, id);
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -191,16 +191,15 @@ public final class RepairRunResource {
       }
 
 
-      RepairUnit.Builder builder =
-          new RepairUnit.Builder(
-              cluster.getName(),
-              keyspace.get(),
-              tableNames,
-              incrementalRepair,
-              nodesToRepair,
-              datacentersToRepair,
-              blacklistedTableNames,
-              repairThreadCountParam.or(context.config.getRepairThreadCount()));
+      RepairUnit.Builder builder = RepairUnit.builder()
+              .clusterName(cluster.getName())
+              .keyspaceName(keyspace.get())
+              .columnFamilies(tableNames)
+              .incrementalRepair(incrementalRepair)
+              .nodes(nodesToRepair)
+              .datacenters(datacentersToRepair)
+              .blacklistedTables(blacklistedTableNames)
+              .repairThreadCount(repairThreadCountParam.or(context.config.getRepairThreadCount()));
 
       RepairUnit theRepairUnit = repairUnitService.getNewOrExistingRepairUnit(cluster, builder);
 
@@ -229,8 +228,7 @@ public final class RepairRunResource {
         parallelism = RepairParallelism.PARALLEL;
       }
 
-      final RepairRun newRepairRun =
-          repairRunService.registerRepairRun(
+      final RepairRun newRepairRun = repairRunService.registerRepairRun(
               cluster,
               theRepairUnit,
               cause,

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -22,7 +22,6 @@ import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.jmx.JmxProxy;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -107,19 +106,13 @@ public final class ClusterRepairScheduler {
   private void createRepairSchedule(Cluster cluster, String keyspace, DateTime nextActivationTime) {
     boolean incrementalRepair = context.config.getIncrementalRepair();
 
-    RepairUnit.Builder builder =
-        new RepairUnit.Builder(
-            cluster.getName(),
-            keyspace,
-            Collections.emptySet(),
-            incrementalRepair,
-            Collections.emptySet(),
-            Collections.emptySet(),
-            Collections.emptySet(),
-            context.config.getRepairThreadCount());
+    RepairUnit.Builder builder = RepairUnit.builder()
+        .clusterName(cluster.getName())
+        .keyspaceName(keyspace)
+        .incrementalRepair(incrementalRepair)
+        .repairThreadCount(context.config.getRepairThreadCount());
 
-    RepairSchedule repairSchedule =
-        repairScheduleService.storeNewRepairSchedule(
+    RepairSchedule repairSchedule = repairScheduleService.storeNewRepairSchedule(
             cluster,
             repairUnitService.getNewOrExistingRepairUnit(cluster, builder),
             context.config.getScheduleDaysBetween(),

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -24,11 +24,9 @@ import io.cassandrareaper.jmx.JmxProxy;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-import java.util.UUID;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
@@ -92,20 +90,14 @@ public final class RepairScheduleService {
         repairUnit.getKeyspaceName(),
         repairUnit.getColumnFamilies());
 
-    RepairSchedule.Builder scheduleBuilder =
-        new RepairSchedule.Builder(
-            repairUnit.getId(),
-            RepairSchedule.State.ACTIVE,
-            daysBetween,
-            nextActivation,
-            ImmutableList.<UUID>of(),
-            0,
-            repairParallelism,
-            intensity,
-            DateTime.now(),
-            segmentCountPerNode);
+    RepairSchedule.Builder scheduleBuilder = RepairSchedule.builder(repairUnit.getId())
+        .daysBetween(daysBetween)
+        .nextActivation(nextActivation)
+        .repairParallelism(repairParallelism)
+        .intensity(intensity)
+        .segmentCountPerNode(segmentCountPerNode)
+        .owner(owner);
 
-    scheduleBuilder.owner(owner);
     return context.storage.addRepairSchedule(scheduleBuilder);
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -653,15 +653,15 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   private RepairUnit getRepairUnitImpl(UUID id) {
     Row repairUnitRow = session.execute(getRepairUnitPrepStmt.bind(id)).one();
     if (repairUnitRow != null) {
-      return new RepairUnit.Builder(
-                  repairUnitRow.getString("cluster_name"),
-                  repairUnitRow.getString("keyspace_name"),
-                  repairUnitRow.getSet("column_families", String.class),
-                  repairUnitRow.getBool("incremental_repair"),
-                  repairUnitRow.getSet("nodes", String.class),
-                  repairUnitRow.getSet("datacenters", String.class),
-                  repairUnitRow.getSet("blacklisted_tables", String.class),
-                  repairUnitRow.getInt("repair_thread_count"))
+      return RepairUnit.builder()
+              .clusterName(repairUnitRow.getString("cluster_name"))
+              .keyspaceName(repairUnitRow.getString("keyspace_name"))
+              .columnFamilies(repairUnitRow.getSet("column_families", String.class))
+              .incrementalRepair(repairUnitRow.getBool("incremental_repair"))
+              .nodes(repairUnitRow.getSet("nodes", String.class))
+              .datacenters(repairUnitRow.getSet("datacenters", String.class))
+              .blacklistedTables(repairUnitRow.getSet("blacklisted_tables", String.class))
+              .repairThreadCount(repairUnitRow.getInt("repair_thread_count"))
               .build(id);
     }
     throw new IllegalArgumentException("No repair unit exists for " + id);
@@ -691,17 +691,16 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
               .equals(params.blacklistedTables)
           && repairUnitRow.getInt("repair_thread_count") == params.repairThreadCount) {
 
-        repairUnit =
-            new RepairUnit.Builder(
-                    repairUnitRow.getString("cluster_name"),
-                    repairUnitRow.getString("keyspace_name"),
-                    repairUnitRow.getSet("column_families", String.class),
-                    repairUnitRow.getBool("incremental_repair"),
-                    repairUnitRow.getSet("nodes", String.class),
-                    repairUnitRow.getSet("datacenters", String.class),
-                    repairUnitRow.getSet("blacklisted_tables", String.class),
-                    repairUnitRow.getInt("repair_thread_count"))
-                .build(repairUnitRow.getUUID("id"));
+        repairUnit = RepairUnit.builder()
+            .clusterName(repairUnitRow.getString("cluster_name"))
+            .keyspaceName(repairUnitRow.getString("keyspace_name"))
+            .columnFamilies(repairUnitRow.getSet("column_families", String.class))
+            .incrementalRepair(repairUnitRow.getBool("incremental_repair"))
+            .nodes(repairUnitRow.getSet("nodes", String.class))
+            .datacenters(repairUnitRow.getSet("datacenters", String.class))
+            .blacklistedTables(repairUnitRow.getSet("blacklisted_tables", String.class))
+            .repairThreadCount(repairUnitRow.getInt("repair_thread_count"))
+            .build(repairUnitRow.getUUID("id"));
         // exit the loop once we find a match
         break;
       }
@@ -918,17 +917,16 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   }
 
   private RepairSchedule createRepairScheduleFromRow(Row repairScheduleRow) {
-    return new RepairSchedule.Builder(
-            repairScheduleRow.getUUID("repair_unit_id"),
-            RepairSchedule.State.valueOf(repairScheduleRow.getString("state")),
-            repairScheduleRow.getInt("days_between"),
-            new DateTime(repairScheduleRow.getTimestamp("next_activation")),
-            ImmutableList.copyOf(repairScheduleRow.getSet("run_history", UUID.class)),
-            repairScheduleRow.getInt("segment_count"),
-            RepairParallelism.fromName(repairScheduleRow.getString("repair_parallelism")),
-            repairScheduleRow.getDouble("intensity"),
-            new DateTime(repairScheduleRow.getTimestamp("creation_time")),
-            repairScheduleRow.getInt("segment_count_per_node"))
+    return RepairSchedule.builder(repairScheduleRow.getUUID("repair_unit_id"))
+        .state(RepairSchedule.State.valueOf(repairScheduleRow.getString("state")))
+        .daysBetween(repairScheduleRow.getInt("days_between"))
+        .nextActivation(new DateTime(repairScheduleRow.getTimestamp("next_activation")))
+        .runHistory(ImmutableList.copyOf(repairScheduleRow.getSet("run_history", UUID.class)))
+        .segmentCount(repairScheduleRow.getInt("segment_count"))
+        .repairParallelism(RepairParallelism.fromName(repairScheduleRow.getString("repair_parallelism")))
+        .intensity(repairScheduleRow.getDouble("intensity"))
+        .creationTime(new DateTime(repairScheduleRow.getTimestamp("creation_time")))
+        .segmentCountPerNode(repairScheduleRow.getInt("segment_count_per_node"))
         .owner(repairScheduleRow.getString("owner"))
         .pauseTime(new DateTime(repairScheduleRow.getTimestamp("pause_time")))
         .build(repairScheduleRow.getUUID("id"));
@@ -1092,13 +1090,11 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   private RepairRun buildRepairRunFromRow(Row repairRunResult, UUID id) {
     LOG.trace("buildRepairRunFromRow {} / {}", id, repairRunResult);
-    return new RepairRun.Builder(
-        repairRunResult.getString("cluster_name"),
-        repairRunResult.getUUID("repair_unit_id"),
-        new DateTime(repairRunResult.getTimestamp("creation_time")),
-        repairRunResult.getDouble("intensity"),
-        repairRunResult.getInt("segment_count"),
-        RepairParallelism.fromName(repairRunResult.getString("repair_parallelism")))
+    return RepairRun.builder(repairRunResult.getString("cluster_name"), repairRunResult.getUUID("repair_unit_id"))
+        .creationTime(new DateTime(repairRunResult.getTimestamp("creation_time")))
+        .intensity(repairRunResult.getDouble("intensity"))
+        .segmentCount(repairRunResult.getInt("segment_count"))
+        .repairParallelism(RepairParallelism.fromName(repairRunResult.getString("repair_parallelism")))
         .cause(repairRunResult.getString("cause"))
         .owner(repairRunResult.getString("owner"))
         .endTime(new DateTime(repairRunResult.getTimestamp("end_time")))

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunMapper.java
@@ -42,15 +42,11 @@ public final class RepairRunMapper implements ResultSetMapper<RepairRun> {
     RepairParallelism repairParallelism = RepairParallelism.fromName(
         rs.getString("repair_parallelism").toLowerCase().replace("datacenter_aware", "dc_parallel"));
 
-    RepairRun.Builder repairRunBuilder = new RepairRun.Builder(
-        rs.getString("cluster_name"),
-        UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")),
-        getDateTimeOrNull(rs, "creation_time"),
-        rs.getFloat("intensity"),
-        rs.getInt("segment_count"),
-        repairParallelism);
-
-    return repairRunBuilder
+    return RepairRun.builder(rs.getString("cluster_name"), UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")))
+        .creationTime(getDateTimeOrNull(rs, "creation_time"))
+        .intensity(rs.getDouble("intensity"))
+        .segmentCount(rs.getInt("segment_count"))
+        .repairParallelism(repairParallelism)
         .runState(runState)
         .owner(rs.getString("owner"))
         .cause(rs.getString("cause"))

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleMapper.java
@@ -60,21 +60,18 @@ public final class RepairScheduleMapper implements ResultSetMapper<RepairSchedul
     }
 
     RepairSchedule.State scheduleState = RepairSchedule.State.valueOf(stateStr);
+    String parallelism = rs.getString("repair_parallelism").toLowerCase().replace("datacenter_aware", "dc_parallel");
 
-    return new RepairSchedule.Builder(
-            UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")),
-            scheduleState,
-            rs.getInt("days_between"),
-            RepairRunMapper.getDateTimeOrNull(rs, "next_activation"),
-            ImmutableList.copyOf(runHistoryUuids),
-            rs.getInt("segment_count"),
-            RepairParallelism.fromName(
-                rs.getString("repair_parallelism")
-                    .toLowerCase()
-                    .replace("datacenter_aware", "dc_parallel")),
-            rs.getDouble("intensity"),
-            RepairRunMapper.getDateTimeOrNull(rs, "creation_time"),
-            rs.getInt("segment_count_per_node"))
+    return RepairSchedule.builder(UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")))
+        .state(scheduleState)
+        .daysBetween(rs.getInt("days_between"))
+        .nextActivation(RepairRunMapper.getDateTimeOrNull(rs, "next_activation"))
+        .runHistory(ImmutableList.copyOf(runHistoryUuids))
+        .segmentCount(rs.getInt("segment_count"))
+        .repairParallelism(RepairParallelism.fromName(parallelism))
+        .intensity(rs.getDouble("intensity"))
+        .creationTime(RepairRunMapper.getDateTimeOrNull(rs, "creation_time"))
+        .segmentCountPerNode(rs.getInt("segment_count_per_node"))
         .owner(rs.getString("owner"))
         .pauseTime(RepairRunMapper.getDateTimeOrNull(rs, "pause_time"))
         .build(UuidUtil.fromSequenceId(rs.getLong("id")));

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
@@ -43,16 +43,15 @@ public final class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
             ? new String[] {}
             : parseStringArray(rs.getArray("blacklisted_tables").getArray());
 
-    RepairUnit.Builder builder =
-        new RepairUnit.Builder(
-            rs.getString("cluster_name"),
-            rs.getString("keyspace_name"),
-            Sets.newHashSet(columnFamilies),
-            rs.getBoolean("incremental_repair"),
-            Sets.newHashSet(nodes),
-            Sets.newHashSet(datacenters),
-            Sets.newHashSet(blacklistedTables),
-            rs.getInt("repair_thread_count"));
+    RepairUnit.Builder builder = RepairUnit.builder()
+            .clusterName(rs.getString("cluster_name"))
+            .keyspaceName(rs.getString("keyspace_name"))
+            .columnFamilies(Sets.newHashSet(columnFamilies))
+            .incrementalRepair(rs.getBoolean("incremental_repair"))
+            .nodes(Sets.newHashSet(nodes))
+            .datacenters(Sets.newHashSet(datacenters))
+            .blacklistedTables(Sets.newHashSet(blacklistedTables))
+            .repairThreadCount(rs.getInt("repair_thread_count"));
 
     return builder.build(UuidUtil.fromSequenceId(rs.getLong("id")));
   }

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -145,16 +145,15 @@ public final class RepairRunResourceTest {
     when(context.jmxConnectionFactory.connectAny(Mockito.anyCollection(), Mockito.anyInt()))
         .thenReturn(proxy);
 
-    RepairUnit.Builder repairUnitBuilder =
-        new RepairUnit.Builder(
-            CLUSTER_NAME,
-            KEYSPACE,
-            TABLES,
-            INCREMENTAL,
-            NODES,
-            DATACENTERS,
-            BLACKLISTED_TABLES,
-            REPAIR_THREAD_COUNT);
+    RepairUnit.Builder repairUnitBuilder = RepairUnit.builder()
+            .clusterName(CLUSTER_NAME)
+            .keyspaceName(KEYSPACE)
+            .columnFamilies(TABLES)
+            .incrementalRepair(INCREMENTAL)
+            .nodes(NODES)
+            .datacenters(DATACENTERS)
+            .blacklistedTables(BLACKLISTED_TABLES)
+            .repairThreadCount(REPAIR_THREAD_COUNT);
 
     context.storage.addRepairUnit(repairUnitBuilder);
   }

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -28,7 +28,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
@@ -188,29 +187,24 @@ public final class ClusterRepairSchedulerTest {
 
   private RepairSchedule.Builder aRepairSchedule(Cluster cluster, String keyspace, DateTime creationTime) {
     RepairUnit repairUnit = context.storage.addRepairUnit(aRepair(cluster, keyspace));
-    return new RepairSchedule.Builder(
-        repairUnit.getId(),
-        RepairSchedule.State.ACTIVE,
-        1,
-        DateTime.now(),
-        ImmutableList.of(),
-        10,
-        RepairParallelism.DATACENTER_AWARE,
-        0.9,
-        creationTime,
-        0);
+
+    return RepairSchedule.builder(repairUnit.getId())
+        .creationTime(creationTime)
+        .daysBetween(1)
+        .nextActivation(DateTime.now())
+        .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+        .intensity(0.9)
+        .segmentCount(10)
+        .segmentCountPerNode(0);
+
   }
 
   private RepairUnit.Builder aRepair(Cluster cluster, String keyspace) {
-    return new RepairUnit.Builder(
-        cluster.getName(),
-        keyspace,
-        Collections.emptySet(),
-        Boolean.FALSE,
-        Collections.emptySet(),
-        Collections.emptySet(),
-        Collections.emptySet(),
-        1);
+    return RepairUnit.builder()
+        .clusterName(cluster.getName())
+        .keyspaceName(keyspace)
+        .incrementalRepair(Boolean.FALSE)
+        .repairThreadCount(1);
   }
 
   private ClusterRepairScheduleAssertion assertThatClusterRepairSchedules(Collection<RepairSchedule> repairSchedules) {

--- a/src/server/src/test/java/io/cassandrareaper/service/PurgeManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/PurgeManagerTest.java
@@ -65,14 +65,13 @@ public final class PurgeManagerTest {
     for (int i = 0; i < 10; i++) {
       UUID repairUnitId = UUIDs.timeBased();
       DateTime startTime = currentDate.minusDays(i).minusHours(1);
+
       repairRuns.add(
-          new RepairRun.Builder(
-                  CLUSTER_NAME,
-                  repairUnitId,
-                  startTime,
-                  0.9,
-                  10,
-                  RepairParallelism.DATACENTER_AWARE)
+          RepairRun.builder(CLUSTER_NAME, repairUnitId)
+              .startTime(startTime)
+              .intensity(0.9)
+              .segmentCount(10)
+              .repairParallelism(RepairParallelism.DATACENTER_AWARE)
               .endTime(startTime.plusSeconds(1))
               .runState(RunState.DONE)
               .build(UUIDs.timeBased()));
@@ -106,14 +105,13 @@ public final class PurgeManagerTest {
     UUID repairUnitId = UUIDs.timeBased();
     for (int i = 0; i < 20; i++) {
       DateTime startTime = currentDate.minusDays(i).minusHours(1);
+
       repairRuns.add(
-          new RepairRun.Builder(
-                  CLUSTER_NAME,
-                  repairUnitId,
-                  startTime,
-                  0.9,
-                  10,
-                  RepairParallelism.DATACENTER_AWARE)
+          RepairRun.builder(CLUSTER_NAME, repairUnitId)
+              .startTime(startTime)
+              .intensity(0.9)
+              .segmentCount(10)
+              .repairParallelism(RepairParallelism.DATACENTER_AWARE)
               .endTime(startTime.plusSeconds(1))
               .runState(RunState.DONE)
               .build(UUIDs.timeBased()));
@@ -147,14 +145,13 @@ public final class PurgeManagerTest {
     for (int i = 0; i < 10; i++) {
       UUID repairUnitId = UUIDs.timeBased();
       DateTime startTime = currentDate.minusDays(i).minusHours(1);
+
       repairRuns.add(
-          new RepairRun.Builder(
-                  CLUSTER_NAME,
-                  repairUnitId,
-                  startTime,
-                  0.9,
-                  10,
-                  RepairParallelism.DATACENTER_AWARE)
+          RepairRun.builder(CLUSTER_NAME, repairUnitId)
+              .startTime(startTime)
+              .intensity(0.9)
+              .segmentCount(10)
+              .repairParallelism(RepairParallelism.DATACENTER_AWARE)
               .endTime(startTime.plusSeconds(1))
               .runState(RunState.PAUSED)
               .build(UUIDs.timeBased()));

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -36,7 +36,6 @@ import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.fest.assertions.api.Assertions;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -77,21 +76,20 @@ public final class RepairManagerTest {
     context.repairManager = repairManager;
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    final RepairUnit cf =
-        new RepairUnit.Builder(
-                clusterName,
-                ksName,
-                cfNames,
-                incrementalRepair,
-                nodes,
-                datacenters,
-                Collections.emptySet(),
-                repairThreadCount)
-            .build(UUIDs.timeBased());
+    final RepairUnit cf = RepairUnit.builder()
+        .clusterName(clusterName)
+        .keyspaceName(ksName)
+        .columnFamilies(cfNames)
+        .incrementalRepair(incrementalRepair)
+        .nodes(nodes)
+        .datacenters(datacenters)
+        .repairThreadCount(repairThreadCount)
+        .build(UUIDs.timeBased());
 
-    final RepairRun run
-        = new RepairRun.Builder(
-                clusterName, cf.getId(), DateTime.now(), intensity, 1, RepairParallelism.PARALLEL)
+    final RepairRun run = RepairRun.builder(clusterName, cf.getId())
+            .intensity(intensity)
+            .segmentCount(1)
+            .repairParallelism(RepairParallelism.PARALLEL)
             .build(UUIDs.timeBased());
 
     final RepairSegment segment =
@@ -150,21 +148,20 @@ public final class RepairManagerTest {
     context.repairManager = repairManager;
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    final RepairUnit cf =
-        new RepairUnit.Builder(
-                clusterName,
-                ksName,
-                cfNames,
-                incrementalRepair,
-                nodes,
-                datacenters,
-                Collections.emptySet(),
-                repairThreadCount)
-            .build(UUIDs.timeBased());
+    final RepairUnit cf = RepairUnit.builder()
+        .clusterName(clusterName)
+        .keyspaceName(ksName)
+        .columnFamilies(cfNames)
+        .incrementalRepair(incrementalRepair)
+        .nodes(nodes)
+        .datacenters(datacenters)
+        .repairThreadCount(repairThreadCount)
+        .build(UUIDs.timeBased());
 
-    final RepairRun run
-        = new RepairRun.Builder(
-                clusterName, cf.getId(), DateTime.now(), intensity, 1, RepairParallelism.PARALLEL)
+    final RepairRun run = RepairRun.builder(clusterName, cf.getId())
+            .intensity(intensity)
+            .segmentCount(1)
+            .repairParallelism(RepairParallelism.PARALLEL)
             .build(UUIDs.timeBased());
 
     final RepairSegment segment =
@@ -223,20 +220,20 @@ public final class RepairManagerTest {
     context.repairManager = repairManager;
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    final RepairUnit cf =
-        new RepairUnit.Builder(
-                clusterName,
-                ksName,
-                cfNames,
-                incrementalRepair,
-                nodes,
-                datacenters,
-                Collections.emptySet(),
-                repairThreadCount)
-            .build(UUIDs.timeBased());
+    final RepairUnit cf = RepairUnit.builder()
+        .clusterName(clusterName)
+        .keyspaceName(ksName)
+        .columnFamilies(cfNames)
+        .incrementalRepair(incrementalRepair)
+        .nodes(nodes)
+        .datacenters(datacenters)
+        .repairThreadCount(repairThreadCount)
+        .build(UUIDs.timeBased());
 
-    final RepairRun run
-        = new RepairRun.Builder(clusterName, cf.getId(), DateTime.now(), intensity, 1, RepairParallelism.PARALLEL)
+    final RepairRun run = RepairRun.builder(clusterName, cf.getId())
+            .intensity(intensity)
+            .segmentCount(1)
+            .repairParallelism(RepairParallelism.PARALLEL)
             .build(UUIDs.timeBased());
 
     final RepairSegment segment =
@@ -292,20 +289,20 @@ public final class RepairManagerTest {
     context.repairManager = repairManager;
     context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
-    final RepairUnit cf =
-        new RepairUnit.Builder(
-                clusterName,
-                ksName,
-                cfNames,
-                incrementalRepair,
-                nodes,
-                datacenters,
-                Collections.emptySet(),
-                repairThreadCount)
-            .build(UUIDs.timeBased());
+    final RepairUnit cf = RepairUnit.builder()
+        .clusterName(clusterName)
+        .keyspaceName(ksName)
+        .columnFamilies(cfNames)
+        .incrementalRepair(incrementalRepair)
+        .nodes(nodes)
+        .datacenters(datacenters)
+        .repairThreadCount(repairThreadCount)
+        .build(UUIDs.timeBased());
 
-    final RepairRun run
-        = new RepairRun.Builder(clusterName, cf.getId(), DateTime.now(), intensity, 1, RepairParallelism.PARALLEL)
+    final RepairRun run = RepairRun.builder(clusterName, cf.getId())
+            .intensity(intensity)
+            .segmentCount(1)
+            .repairParallelism(RepairParallelism.PARALLEL)
             .build(UUIDs.timeBased());
 
     final RepairSegment segment =
@@ -349,22 +346,22 @@ public final class RepairManagerTest {
     final Set<String> datacenters = Collections.emptySet();
     final int repairThreadCount = 1;
 
-    final RepairUnit cf =
-        new RepairUnit.Builder(
-                clusterName,
-                ksName,
-                cfNames,
-                incrementalRepair,
-                nodes,
-                datacenters,
-                Collections.emptySet(),
-                repairThreadCount)
-            .build(UUIDs.timeBased());
+    final RepairUnit cf = RepairUnit.builder()
+        .clusterName(clusterName)
+        .keyspaceName(ksName)
+        .columnFamilies(cfNames)
+        .incrementalRepair(incrementalRepair)
+        .nodes(nodes)
+        .datacenters(datacenters)
+        .repairThreadCount(repairThreadCount)
+        .build(UUIDs.timeBased());
 
     double intensity = 0.5f;
 
-    final RepairRun run
-        = new RepairRun.Builder(clusterName, cf.getId(), DateTime.now(), intensity, 1, RepairParallelism.PARALLEL)
+    final RepairRun run = RepairRun.builder(clusterName, cf.getId())
+            .intensity(intensity)
+            .segmentCount(1)
+            .repairParallelism(RepairParallelism.PARALLEL)
             .build(UUIDs.timeBased());
 
     when(context.storage.updateRepairRun(any())).thenReturn(true);

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -87,21 +87,30 @@ public final class RepairRunnerTest {
 
     final IStorage storage = new MemoryStorage();
     storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton("127.0.0.1")));
-    RepairUnit cf =
-        storage.addRepairUnit(
-            new RepairUnit.Builder(CLUSTER_NAME, KS_NAME, CF_NAMES, INCREMENTAL_REPAIR, NODES,
-                DATACENTERS, BLACKLISTED_TABLES, REPAIR_THREAD_COUNT));
+
+    RepairUnit cf = storage.addRepairUnit(
+            RepairUnit.builder()
+            .clusterName(CLUSTER_NAME)
+            .keyspaceName(KS_NAME)
+            .columnFamilies(CF_NAMES)
+            .incrementalRepair(INCREMENTAL_REPAIR)
+            .nodes(NODES)
+            .datacenters(DATACENTERS)
+            .blacklistedTables(BLACKLISTED_TABLES)
+            .repairThreadCount(REPAIR_THREAD_COUNT));
+
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                CLUSTER_NAME, cf.getId(), DateTime.now(), INTENSITY, 1, RepairParallelism.PARALLEL),
+
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder(CLUSTER_NAME, cf.getId())
+                .intensity(INTENSITY)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
-                    Segment.builder()
-                        .withTokenRange(new RingRange(BigInteger.ZERO, BigInteger.ONE))
-                        .build(),
+                    Segment.builder().withTokenRange(new RingRange(BigInteger.ZERO, BigInteger.ONE)).build(),
                     cf.getId())));
+
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
@@ -205,8 +214,7 @@ public final class RepairRunnerTest {
       try {
         mutex.acquire();
         LOG.info("MUTEX ACQUIRED");
-        // TODO: refactor so that we can properly wait for the repair runner to finish rather than
-        // TODO: using this sleep().
+        // TODO: refactor so that we can properly wait for the repair runner to finish rather than using this sleep()
         Thread.sleep(1000);
         return true;
       } catch (InterruptedException ex) {
@@ -232,28 +240,32 @@ public final class RepairRunnerTest {
     final IStorage storage = new MemoryStorage();
 
     storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton("127.0.0.1")));
-    RepairUnit cf =
-        storage.addRepairUnit(
-            new RepairUnit.Builder(
-                CLUSTER_NAME,
-                KS_NAME,
-                CF_NAMES,
-                INCREMENTAL_REPAIR,
-                NODES,
-                DATACENTERS,
-                BLACKLISTED_TABLES,
-                REPAIR_THREAD_COUNT));
+
+    RepairUnit cf = storage.addRepairUnit(
+            RepairUnit.builder()
+            .clusterName(CLUSTER_NAME)
+            .keyspaceName(KS_NAME)
+            .columnFamilies(CF_NAMES)
+            .incrementalRepair(INCREMENTAL_REPAIR)
+            .nodes(NODES)
+            .datacenters(DATACENTERS)
+            .blacklistedTables(BLACKLISTED_TABLES)
+            .repairThreadCount(REPAIR_THREAD_COUNT));
+
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                CLUSTER_NAME, cf.getId(), DateTime.now(), INTENSITY, 1, RepairParallelism.PARALLEL),
+
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder(CLUSTER_NAME, cf.getId())
+                .intensity(INTENSITY)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ZERO, BigInteger.ONE))
                         .build(),
                     cf.getId())));
+
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
@@ -383,25 +395,26 @@ public final class RepairRunnerTest {
     context.repairManager = RepairManager.create(context);
 
     storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton("127.0.0.1")));
-    UUID cf =
-        storage
-            .addRepairUnit(
-                new RepairUnit.Builder(
-                    CLUSTER_NAME,
-                    KS_NAME,
-                    CF_NAMES,
-                    INCREMENTAL_REPAIR,
-                    NODES,
-                    DATACENTERS,
-                    BLACKLISTED_TABLES,
-                    REPAIR_THREAD_COUNT))
-            .getId();
+
+    UUID cf = storage.addRepairUnit(
+        RepairUnit.builder()
+            .clusterName(CLUSTER_NAME)
+            .keyspaceName(KS_NAME)
+            .columnFamilies(CF_NAMES)
+            .incrementalRepair(INCREMENTAL_REPAIR)
+            .nodes(NODES)
+            .datacenters(DATACENTERS)
+            .blacklistedTables(BLACKLISTED_TABLES)
+            .repairThreadCount(REPAIR_THREAD_COUNT))
+        .getId();
+
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
 
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                CLUSTER_NAME, cf, DateTime.now(), INTENSITY, 1, RepairParallelism.PARALLEL),
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder(CLUSTER_NAME, cf)
+                .intensity(INTENSITY)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Lists.newArrayList(
                 RepairSegment.builder(
                         Segment.builder()

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -48,7 +48,6 @@ import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.progress.ProgressEventType;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.commons.lang3.tuple.Pair;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -80,21 +79,21 @@ public final class SegmentRunnerTest {
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
     context.storage = new MemoryStorage();
-    RepairUnit cf =
-        context.storage.addRepairUnit(
-            new RepairUnit.Builder(
-                "reaper",
-                "reaper",
-                Sets.newHashSet("reaper"),
-                false,
-                Sets.newHashSet("127.0.0.1"),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                1));
-    RepairRun run =
-        context.storage.addRepairRun(
-            new RepairRun.Builder(
-                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+
+    RepairUnit cf = context.storage.addRepairUnit(
+            RepairUnit.builder()
+                .clusterName("reaper")
+                .keyspaceName("reaper")
+                .columnFamilies(Sets.newHashSet("reaper"))
+                .incrementalRepair(false)
+                .nodes(Sets.newHashSet("127.0.0.1"))
+                .repairThreadCount(1));
+
+    RepairRun run = context.storage.addRepairRun(
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
@@ -191,27 +190,28 @@ public final class SegmentRunnerTest {
   @Test
   public void successTest() throws InterruptedException, ReaperException, ExecutionException {
     final IStorage storage = new MemoryStorage();
-    RepairUnit cf =
-        storage.addRepairUnit(
-            new RepairUnit.Builder(
-                "reaper",
-                "reaper",
-                Sets.newHashSet("reaper"),
-                false,
-                Sets.newHashSet("127.0.0.1"),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                1));
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+
+    RepairUnit cf = storage.addRepairUnit(
+            RepairUnit.builder()
+                .clusterName("reaper")
+                .keyspaceName("reaper")
+                .columnFamilies(Sets.newHashSet("reaper"))
+                .incrementalRepair(false)
+                .nodes(Sets.newHashSet("127.0.0.1"))
+                .repairThreadCount(1));
+
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
                         .build(),
                     cf.getId())));
+
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
@@ -337,27 +337,27 @@ public final class SegmentRunnerTest {
   @Test
   public void failureTest() throws InterruptedException, ReaperException, ExecutionException {
     final IStorage storage = new MemoryStorage();
-    RepairUnit cf =
-        storage.addRepairUnit(
-            new RepairUnit.Builder(
-                "reaper",
-                "reaper",
-                Sets.newHashSet("reaper"),
-                false,
-                Sets.newHashSet("127.0.0.1"),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                1));
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+    RepairUnit cf = storage.addRepairUnit(
+            RepairUnit.builder()
+                .clusterName("reaper")
+                .keyspaceName("reaper")
+                .columnFamilies(Sets.newHashSet("reaper"))
+                .incrementalRepair(false)
+                .nodes(Sets.newHashSet("127.0.0.1"))
+                .repairThreadCount(1));
+
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
                         .build(),
                     cf.getId())));
+
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
@@ -472,30 +472,30 @@ public final class SegmentRunnerTest {
   public void outOfOrderSuccessCass21Test()
       throws InterruptedException, ReaperException, ExecutionException {
     final IStorage storage = new MemoryStorage();
-    RepairUnit cf =
-        storage.addRepairUnit(
-            new RepairUnit.Builder(
-                "reaper",
-                "reaper",
-                Sets.newHashSet("reaper"),
-                false,
-                Sets.newHashSet("127.0.0.1"),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                1));
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+
+    RepairUnit cf = storage.addRepairUnit(
+            RepairUnit.builder()
+                .clusterName("reaper")
+                .keyspaceName("reaper")
+                .columnFamilies(Sets.newHashSet("reaper"))
+                .incrementalRepair(false)
+                .nodes(Sets.newHashSet("127.0.0.1"))
+                .repairThreadCount(1));
+
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
                         .build(),
                     cf.getId())));
+
     final UUID runId = run.getId();
-    final UUID segmentId =
-        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+    final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final MutableObject<Future<?>> future = new MutableObject<>();
@@ -607,30 +607,30 @@ public final class SegmentRunnerTest {
   public void outOfOrderSuccessCass22Test()
       throws InterruptedException, ReaperException, ExecutionException {
     final IStorage storage = new MemoryStorage();
-    RepairUnit cf =
-        storage.addRepairUnit(
-            new RepairUnit.Builder(
-                "reaper",
-                "reaper",
-                Sets.newHashSet("reaper"),
-                false,
-                Sets.newHashSet("127.0.0.1"),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                1));
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+
+    RepairUnit cf = storage.addRepairUnit(
+            RepairUnit.builder()
+                .clusterName("reaper")
+                .keyspaceName("reaper")
+                .columnFamilies(Sets.newHashSet("reaper"))
+                .incrementalRepair(false)
+                .nodes(Sets.newHashSet("127.0.0.1"))
+                .repairThreadCount(1));
+
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
                         .build(),
                     cf.getId())));
+
     final UUID runId = run.getId();
-    final UUID segmentId =
-        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+    final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final MutableObject<Future<?>> future = new MutableObject<>();
@@ -742,30 +742,30 @@ public final class SegmentRunnerTest {
   public void outOfOrderFailureCass21Test()
       throws InterruptedException, ReaperException, ExecutionException {
     final IStorage storage = new MemoryStorage();
-    RepairUnit cf =
-        storage.addRepairUnit(
-            new RepairUnit.Builder(
-                "reaper",
-                "reaper",
-                Sets.newHashSet("reaper"),
-                false,
-                Sets.newHashSet("127.0.0.1"),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                1));
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+
+    RepairUnit cf = storage.addRepairUnit(
+            RepairUnit.builder()
+                .clusterName("reaper")
+                .keyspaceName("reaper")
+                .columnFamilies(Sets.newHashSet("reaper"))
+                .incrementalRepair(false)
+                .nodes(Sets.newHashSet("127.0.0.1"))
+                .repairThreadCount(1));
+
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
                         .build(),
                     cf.getId())));
+
     final UUID runId = run.getId();
-    final UUID segmentId =
-        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+    final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final MutableObject<Future<?>> future = new MutableObject<>();
@@ -878,30 +878,30 @@ public final class SegmentRunnerTest {
   public void outOfOrderFailureTestCass22()
       throws InterruptedException, ReaperException, ExecutionException {
     final IStorage storage = new MemoryStorage();
-    RepairUnit cf =
-        storage.addRepairUnit(
-            new RepairUnit.Builder(
-                "reaper",
-                "reaper",
-                Sets.newHashSet("reaper"),
-                false,
-                Sets.newHashSet("127.0.0.1"),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                1));
-    RepairRun run =
-        storage.addRepairRun(
-            new RepairRun.Builder(
-                "reaper", cf.getId(), DateTime.now(), 0.5, 1, RepairParallelism.PARALLEL),
+
+    RepairUnit cf = storage.addRepairUnit(
+            RepairUnit.builder()
+                .clusterName("reaper")
+                .keyspaceName("reaper")
+                .columnFamilies(Sets.newHashSet("reaper"))
+                .incrementalRepair(false)
+                .nodes(Sets.newHashSet("127.0.0.1"))
+                .repairThreadCount(1));
+
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
                         .build(),
                     cf.getId())));
+
     final UUID runId = run.getId();
-    final UUID segmentId =
-        storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
+    final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.absent()).get().getId();
 
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final MutableObject<Future<?>> future = new MutableObject<>();


### PR DESCRIPTION
Clean code: replace RepairRun, RepairUnit and RepairSchedule's inner Builder classes' verbose public constructor with a static `builder()` methods and builder methods.