### PR TITLE
Use executorServices from DropWizard's lifecycle, in top-level singleton Managers and Resources

### DIFF
--- a/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Set;
+import java.util.concurrent.Executors;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -63,7 +64,7 @@ public final class ClusterResourceTest {
   public void testAddCluster() throws Exception {
     final MockObjects mocks = initMocks();
 
-    ClusterResource clusterResource = new ClusterResource(mocks.context);
+    ClusterResource clusterResource = new ClusterResource(mocks.context, Executors.newFixedThreadPool(2));
     Response response = clusterResource.addOrUpdateCluster(mocks.uriInfo, Optional.of(SEED_HOST));
 
     assertEquals(HttpStatus.CREATED_201, response.getStatus());
@@ -85,7 +86,7 @@ public final class ClusterResourceTest {
     Cluster cluster = new Cluster(CLUSTER_NAME, PARTITIONER, Sets.newHashSet(SEED_HOST));
     mocks.context.storage.addCluster(cluster);
 
-    ClusterResource clusterResource = new ClusterResource(mocks.context);
+    ClusterResource clusterResource = new ClusterResource(mocks.context, Executors.newFixedThreadPool(2));
     Response response = clusterResource.addOrUpdateCluster(mocks.uriInfo, Optional.of(SEED_HOST));
 
     assertEquals(HttpStatus.NO_CONTENT_204, response.getStatus());
@@ -108,7 +109,7 @@ public final class ClusterResourceTest {
     Cluster cluster = new Cluster(CLUSTER_NAME, PARTITIONER, Sets.newHashSet(SEED_HOST));
     mocks.context.storage.addCluster(cluster);
 
-    ClusterResource clusterResource = new ClusterResource(mocks.context);
+    ClusterResource clusterResource = new ClusterResource(mocks.context, Executors.newFixedThreadPool(2));
     Response response = clusterResource.addOrUpdateCluster(mocks.uriInfo, CLUSTER_NAME, Optional.of(SEED_HOST));
 
     assertEquals(HttpStatus.NO_CONTENT_204, response.getStatus());
@@ -128,7 +129,7 @@ public final class ClusterResourceTest {
     final MockObjects mocks = initMocks();
     when(mocks.jmxProxy.getLiveNodes()).thenReturn(Arrays.asList(SEED_HOST));
 
-    ClusterResource clusterResource = new ClusterResource(mocks.context);
+    ClusterResource clusterResource = new ClusterResource(mocks.context, Executors.newFixedThreadPool(2));
     Response response = clusterResource.getCluster(I_DONT_EXIST, Optional.<Integer>absent());
     assertEquals(HttpStatus.NOT_FOUND_404, response.getStatus());
   }
@@ -141,7 +142,7 @@ public final class ClusterResourceTest {
     Cluster cluster = new Cluster(I_DO_EXIST, PARTITIONER, Sets.newHashSet(SEED_HOST));
     mocks.context.storage.addCluster(cluster);
 
-    ClusterResource clusterResource = new ClusterResource(mocks.context);
+    ClusterResource clusterResource = new ClusterResource(mocks.context, Executors.newFixedThreadPool(2));
     Response response = clusterResource.getCluster(I_DO_EXIST, Optional.<Integer>absent());
     assertEquals(HttpStatus.OK_200, response.getStatus());
   }
@@ -150,7 +151,7 @@ public final class ClusterResourceTest {
   public void testModifyClusterSeeds() throws ReaperException {
     final MockObjects mocks = initMocks();
 
-    ClusterResource clusterResource = new ClusterResource(mocks.context);
+    ClusterResource clusterResource = new ClusterResource(mocks.context, Executors.newFixedThreadPool(2));
     clusterResource.addOrUpdateCluster(mocks.uriInfo, Optional.of(SEED_HOST));
     doReturn(Arrays.asList(SEED_HOST + 1)).when(mocks.jmxProxy).getLiveNodes();
 
@@ -173,7 +174,7 @@ public final class ClusterResourceTest {
   public void testModifyClusterSeedsWithClusterName() throws ReaperException {
     final MockObjects mocks = initMocks();
 
-    ClusterResource clusterResource = new ClusterResource(mocks.context);
+    ClusterResource clusterResource = new ClusterResource(mocks.context, Executors.newFixedThreadPool(2));
     clusterResource.addOrUpdateCluster(mocks.uriInfo, Optional.of(SEED_HOST));
     doReturn(Arrays.asList(SEED_HOST + 1)).when(mocks.jmxProxy).getLiveNodes();
 
@@ -209,7 +210,7 @@ public final class ClusterResourceTest {
                 .build())
         .build();
 
-    ClusterResource clusterResource = new ClusterResource(mocks.context);
+    ClusterResource clusterResource = new ClusterResource(mocks.context, Executors.newFixedThreadPool(2));
     Response response = clusterResource.addOrUpdateCluster(mocks.uriInfo, Optional.of(SEED_HOST));
 
     assertEquals(HttpStatus.CREATED_201, response.getStatus());

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.Response;
@@ -102,7 +103,15 @@ public final class RepairRunResourceTest {
     //SegmentRunner.SEGMENT_RUNNERS.clear();
 
     context = new AppContext();
-    context.repairManager = RepairManager.create(context);
+
+    context.repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(THREAD_CNT),
+        REPAIR_TIMEOUT_S,
+        TimeUnit.SECONDS,
+        RETRY_DELAY_S,
+        TimeUnit.SECONDS);
+
     context.storage = new MemoryStorage();
     Cluster cluster = new Cluster(CLUSTER_NAME, PARTITIONER, Sets.newHashSet(SEED_HOST));
     context.storage.addCluster(cluster);
@@ -267,9 +276,6 @@ public final class RepairRunResourceTest {
   public void testTriggerAlreadyRunningRun() throws InterruptedException, ReaperException {
     DateTimeUtils.setCurrentMillisFixed(TIME_CREATE);
 
-    context.repairManager
-        .initializeThreadPool(THREAD_CNT, REPAIR_TIMEOUT_S, TimeUnit.SECONDS, RETRY_DELAY_S, TimeUnit.SECONDS);
-
     RepairRunResource resource = new RepairRunResource(context);
     Response response = addDefaultRepairRun(resource);
     assertTrue(response.getEntity().toString(), response.getEntity() instanceof RepairRunStatus);
@@ -287,8 +293,6 @@ public final class RepairRunResourceTest {
   @Test
   public void testTriggerNewRunAlreadyRunningRun() throws InterruptedException, ReaperException {
     DateTimeUtils.setCurrentMillisFixed(TIME_CREATE);
-    context.repairManager.initializeThreadPool(THREAD_CNT, REPAIR_TIMEOUT_S, TimeUnit.SECONDS,
-        RETRY_DELAY_S, TimeUnit.SECONDS);
     RepairRunResource resource = new RepairRunResource(context);
     Response response = addDefaultRepairRun(resource);
     assertTrue(response.getEntity().toString(), response.getEntity() instanceof RepairRunStatus);
@@ -347,8 +351,6 @@ public final class RepairRunResourceTest {
 
   @Test
   public void testTriggerRunMissingArgument() {
-    context.repairManager.initializeThreadPool(THREAD_CNT, REPAIR_TIMEOUT_S, TimeUnit.SECONDS,
-        RETRY_DELAY_S, TimeUnit.SECONDS);
     RepairRunResource resource = new RepairRunResource(context);
     Response response =
         addRepairRun(
@@ -370,8 +372,6 @@ public final class RepairRunResourceTest {
   @Test
   public void testPauseNotRunningRun() throws InterruptedException, ReaperException {
     DateTimeUtils.setCurrentMillisFixed(TIME_CREATE);
-    context.repairManager.initializeThreadPool(THREAD_CNT, REPAIR_TIMEOUT_S, TimeUnit.SECONDS,
-        RETRY_DELAY_S, TimeUnit.SECONDS);
     RepairRunResource resource = new RepairRunResource(context);
     Response response = addDefaultRepairRun(resource);
     assertTrue(response.getEntity().toString(), response.getEntity() instanceof RepairRunStatus);
@@ -404,10 +404,6 @@ public final class RepairRunResourceTest {
   @Test
   public void testModifyIntensity() throws ReaperException {
     DateTimeUtils.setCurrentMillisFixed(TIME_CREATE);
-
-    context.repairManager
-        .initializeThreadPool(THREAD_CNT, REPAIR_TIMEOUT_S, TimeUnit.SECONDS, RETRY_DELAY_S, TimeUnit.SECONDS);
-
     RepairRunResource resource = new RepairRunResource(context);
     Response response = addDefaultRepairRun(resource);
     assertTrue(response.getEntity().toString(), response.getEntity() instanceof RepairRunStatus);

--- a/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
@@ -26,6 +26,7 @@ import io.cassandrareaper.storage.MemoryStorage;
 
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import javax.management.JMException;
@@ -40,6 +41,9 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 
 public final class HeartTest {
+
+  private static final int REPAIR_TIMEOUT_S = 60;
+  private static final int RETRY_DELAY_S = 10;
 
   @Test
   public void testBeat_nullStorage() {
@@ -135,7 +139,14 @@ public final class HeartTest {
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.EACH);
 
-    context.repairManager = RepairManager.create(context);
+    context.repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        REPAIR_TIMEOUT_S,
+        TimeUnit.SECONDS,
+        RETRY_DELAY_S,
+        TimeUnit.SECONDS);
+
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 
@@ -158,7 +169,14 @@ public final class HeartTest {
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.EACH);
 
-    context.repairManager = RepairManager.create(context);
+    context.repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        REPAIR_TIMEOUT_S,
+        TimeUnit.SECONDS,
+        RETRY_DELAY_S,
+        TimeUnit.SECONDS);
+
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 
@@ -189,7 +207,14 @@ public final class HeartTest {
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.EACH);
     context.storage = Mockito.mock(CassandraStorage.class);
 
-    context.repairManager = RepairManager.create(context);
+    context.repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        REPAIR_TIMEOUT_S,
+        TimeUnit.SECONDS,
+        RETRY_DELAY_S,
+        TimeUnit.SECONDS);
+
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 
@@ -241,7 +266,14 @@ public final class HeartTest {
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.EACH);
     context.storage = Mockito.mock(CassandraStorage.class);
 
-    context.repairManager = RepairManager.create(context);
+    context.repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        REPAIR_TIMEOUT_S,
+        TimeUnit.SECONDS,
+        RETRY_DELAY_S,
+        TimeUnit.SECONDS);
+
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 
@@ -283,7 +315,14 @@ public final class HeartTest {
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.EACH);
     context.storage = Mockito.mock(CassandraStorage.class);
 
-    context.repairManager = RepairManager.create(context);
+    context.repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        REPAIR_TIMEOUT_S,
+        TimeUnit.SECONDS,
+        RETRY_DELAY_S,
+        TimeUnit.SECONDS);
+
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import com.datastax.driver.core.utils.UUIDs;
@@ -71,10 +72,17 @@ public final class RepairManagerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    RepairManager repairManager = RepairManager.create(context);
+
+    RepairManager repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        500,
+        TimeUnit.MILLISECONDS,
+        1,
+        TimeUnit.MILLISECONDS);
+
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
-    context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
     final RepairUnit cf = RepairUnit.builder()
         .clusterName(clusterName)
@@ -143,10 +151,17 @@ public final class RepairManagerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    RepairManager repairManager = RepairManager.create(context);
+
+    RepairManager repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        500,
+        TimeUnit.MILLISECONDS,
+        1,
+        TimeUnit.MILLISECONDS);
+
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
-    context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
     final RepairUnit cf = RepairUnit.builder()
         .clusterName(clusterName)
@@ -215,10 +230,17 @@ public final class RepairManagerTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.storage = storage;
-    RepairManager repairManager = RepairManager.create(context);
+
+    RepairManager repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        500,
+        TimeUnit.MILLISECONDS,
+        1,
+        TimeUnit.MILLISECONDS);
+
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
-    context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
     final RepairUnit cf = RepairUnit.builder()
         .clusterName(clusterName)
@@ -284,10 +306,17 @@ public final class RepairManagerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    RepairManager repairManager = RepairManager.create(context);
+
+    RepairManager repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        500,
+        TimeUnit.MILLISECONDS,
+        1,
+        TimeUnit.MILLISECONDS);
+
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
-    context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
 
     final RepairUnit cf = RepairUnit.builder()
         .clusterName(clusterName)
@@ -336,8 +365,14 @@ public final class RepairManagerTest {
     context.config = new ReaperApplicationConfiguration();
     context.storage = mock(IStorage.class);
     context.storage.addCluster(new Cluster(clusterName, null, Collections.<String>singleton("127.0.0.1")));
-    context.repairManager = RepairManager.create(context);
-    context.repairManager.initializeThreadPool(1, 500, TimeUnit.MILLISECONDS, 1, TimeUnit.MILLISECONDS);
+
+    context.repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        500,
+        TimeUnit.MILLISECONDS,
+        1,
+        TimeUnit.MILLISECONDS);
 
     final String ksName = "reaper";
     final Set<String> cfNames = Sets.newHashSet("reaper");

--- a/src/server/src/test/java/io/cassandrareaper/service/SnapshotManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SnapshotManagerTest.java
@@ -25,6 +25,7 @@ import io.cassandrareaper.storage.IStorage;
 
 import java.util.Arrays;
 import java.util.TreeSet;
+import java.util.concurrent.Executors;
 
 import com.google.common.base.Optional;
 import org.junit.Test;
@@ -49,7 +50,8 @@ public final class SnapshotManagerTest {
     context.config.setJmxConnectionTimeoutInSeconds(10);
     final JmxProxy jmx = mock(JmxProxy.class);
 
-    SnapshotManager snapshotManager = SnapshotManager.create(context);
+    SnapshotManager snapshotManager = SnapshotManager.create(context, Executors.newFixedThreadPool(2));
+
     context.jmxConnectionFactory =
         new JmxConnectionFactory() {
           @Override
@@ -70,7 +72,8 @@ public final class SnapshotManagerTest {
     context.config.setJmxConnectionTimeoutInSeconds(10);
     final JmxProxy jmx = mock(JmxProxy.class);
 
-    SnapshotManager snapshotManager = SnapshotManager.create(context);
+    SnapshotManager snapshotManager = SnapshotManager.create(context, Executors.newFixedThreadPool(2));
+
     context.jmxConnectionFactory =
         new JmxConnectionFactory() {
           @Override
@@ -95,7 +98,8 @@ public final class SnapshotManagerTest {
     context.config.setJmxConnectionTimeoutInSeconds(10);
     final JmxProxy jmx = mock(JmxProxy.class);
 
-    SnapshotManager snapshotManager = SnapshotManager.create(context);
+    SnapshotManager snapshotManager = SnapshotManager.create(context, Executors.newFixedThreadPool(2));
+
     context.jmxConnectionFactory =
         new JmxConnectionFactory() {
           @Override
@@ -117,7 +121,8 @@ public final class SnapshotManagerTest {
     context.config.setJmxConnectionTimeoutInSeconds(10);
     final JmxProxy jmx = mock(JmxProxy.class);
 
-    SnapshotManager snapshotManager = SnapshotManager.create(context);
+    SnapshotManager snapshotManager = SnapshotManager.create(context, Executors.newFixedThreadPool(2));
+
     context.jmxConnectionFactory =
         new JmxConnectionFactory() {
           @Override
@@ -146,7 +151,8 @@ public final class SnapshotManagerTest {
     final JmxProxy jmx = mock(JmxProxy.class);
     when(jmx.getLiveNodes()).thenReturn(Arrays.asList("127.0.0.1", "127.0.0.2"));
 
-    SnapshotManager snapshotManager = SnapshotManager.create(context);
+    SnapshotManager snapshotManager = SnapshotManager.create(context, Executors.newFixedThreadPool(2));
+
     context.jmxConnectionFactory =
         new JmxConnectionFactory() {
           @Override
@@ -180,7 +186,8 @@ public final class SnapshotManagerTest {
     final JmxProxy jmx = mock(JmxProxy.class);
     when(jmx.getLiveNodes()).thenReturn(Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
 
-    SnapshotManager snapshotManager = SnapshotManager.create(context);
+    SnapshotManager snapshotManager = SnapshotManager.create(context, Executors.newFixedThreadPool(2));
+
     context.jmxConnectionFactory =
         new JmxConnectionFactory() {
           @Override


### PR DESCRIPTION
This avoids executing late tasks, and the subsequent exceptions, created during reaper shutdowns (or flapping between reaper instances).

For example in the integration tests where GRIM_MIN and GRIM_MAX are set to different values to test a high-availability setup where instances are flapping a lot, this removes thousands of erroneous asynchronous executions and subsequent exceptions.