### PR TITLE
Fix `IStorage.getRepairUnit(builder)` implementations to include matching on incremental boolean parameter, and deleting (all related) units only when deleting the cluster

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
@@ -158,6 +158,11 @@ public final class RepairRun implements Comparable<RepairRun> {
     return Objects.hash(this.id, this.repairUnitId);
   }
 
+  @Override
+  public String toString() {
+    return String.format("%s[%s] for %s", getClass().getSimpleName(), id.toString(), clusterName);
+  }
+
   public enum RunState {
     NOT_STARTED,
     RUNNING,

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
@@ -130,6 +130,11 @@ public final class RepairSchedule {
     return new Builder(this);
   }
 
+  @Override
+  public String toString() {
+    return String.format("%s[%s]", getClass().getSimpleName(), id.toString());
+  }
+
   public enum State {
     ACTIVE,
     PAUSED,

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairUnit.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairUnit.java
@@ -171,7 +171,7 @@ public final class RepairUnit {
       hash *= 59;
       hash +=  Objects.hashCode(this.columnFamilies);
       hash *= 59;
-      hash +=  (this.incrementalRepair ? 1 : 0);
+      hash +=  (this.incrementalRepair ? 2 : 1);
       hash *= 59;
       hash +=  Objects.hashCode(this.nodes);
       hash *= 59;
@@ -190,7 +190,7 @@ public final class RepairUnit {
         return false;
       }
 
-      return this.incrementalRepair == ((Builder) obj).incrementalRepair
+      return Objects.equals(this.incrementalRepair, ((Builder) obj).incrementalRepair)
           && Objects.equals(this.clusterName, ((Builder) obj).clusterName)
           && Objects.equals(this.keyspaceName, ((Builder) obj).keyspaceName)
           && Objects.equals(this.columnFamilies, ((Builder) obj).columnFamilies)

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -201,7 +201,7 @@ public final class RepairRunResource {
               .blacklistedTables(blacklistedTableNames)
               .repairThreadCount(repairThreadCountParam.or(context.config.getRepairThreadCount()));
 
-      RepairUnit theRepairUnit = repairUnitService.getNewOrExistingRepairUnit(cluster, builder);
+      RepairUnit theRepairUnit = repairUnitService.getOrCreateRepairUnit(cluster, builder);
 
       if (theRepairUnit.getIncrementalRepair() != incrementalRepair) {
         String msg = String.format(

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -114,7 +114,7 @@ public final class ClusterRepairScheduler {
 
     RepairSchedule repairSchedule = repairScheduleService.storeNewRepairSchedule(
             cluster,
-            repairUnitService.getNewOrExistingRepairUnit(cluster, builder),
+            repairUnitService.getOrCreateRepairUnit(cluster, builder),
             context.config.getScheduleDaysBetween(),
             nextActivationTime,
             REPAIR_OWNER,

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -15,50 +15,43 @@
 package io.cassandrareaper.service;
 
 import io.cassandrareaper.AppContext;
-import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
-import io.cassandrareaper.jmx.JmxProxy;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public final class RepairScheduleService {
 
-  private static final Logger LOG = LoggerFactory.getLogger(RepairScheduleService.class);
-
   private final AppContext context;
+  private final RepairUnitService repairUnitService;
 
   private RepairScheduleService(AppContext context) {
     this.context = context;
+    this.repairUnitService = RepairUnitService.create(context);
   }
 
   public static RepairScheduleService create(AppContext context) {
     return new RepairScheduleService(context);
   }
 
-  public Optional<RepairSchedule> conflictingRepairSchedule(Cluster cluster, RepairUnit repairUnit) {
+  public Optional<RepairSchedule> conflictingRepairSchedule(Cluster cluster, RepairUnit.Builder repairUnit) {
 
     Collection<RepairSchedule> repairSchedules = context.storage
-        .getRepairSchedulesForClusterAndKeyspace(repairUnit.getClusterName(), repairUnit.getKeyspaceName());
+        .getRepairSchedulesForClusterAndKeyspace(repairUnit.clusterName, repairUnit.keyspaceName);
 
     for (RepairSchedule sched : repairSchedules) {
       RepairUnit repairUnitForSched = context.storage.getRepairUnit(sched.getRepairUnitId());
-      Preconditions.checkState(repairUnitForSched.getClusterName().equals(repairUnit.getClusterName()));
-      Preconditions.checkState(repairUnitForSched.getKeyspaceName().equals(repairUnit.getKeyspaceName()));
+      Preconditions.checkState(repairUnitForSched.getClusterName().equals(repairUnit.clusterName));
+      Preconditions.checkState(repairUnitForSched.getKeyspaceName().equals(repairUnit.keyspaceName));
 
-      if (isConflictingSchedules(cluster, repairUnitForSched, repairUnit)) {
+      if (repairUnitService.conflictingUnits(cluster, repairUnitForSched, repairUnit)) {
         return Optional.of(sched);
       }
     }
@@ -84,7 +77,7 @@ public final class RepairScheduleService {
       Double intensity) {
 
     Preconditions.checkArgument(
-        !conflictingRepairSchedule(cluster, repairUnit).isPresent(),
+        !conflictingRepairSchedule(cluster, repairUnit.with()).isPresent(),
         "A repair schedule already exists for cluster \"%s\", keyspace \"%s\", and column families: %s",
         cluster.getName(),
         repairUnit.getKeyspaceName(),
@@ -99,35 +92,5 @@ public final class RepairScheduleService {
         .owner(owner);
 
     return context.storage.addRepairSchedule(scheduleBuilder);
-  }
-
-  private boolean isConflictingSchedules(Cluster cluster, RepairUnit unit0, RepairUnit unit1) {
-    Preconditions.checkState(unit0.getKeyspaceName().equals(unit1.getKeyspaceName()));
-
-    Set<String> tables = unit0.getColumnFamilies().isEmpty() || unit1.getColumnFamilies().isEmpty()
-        ? getTableNamesForKeyspace(cluster, unit0.getKeyspaceName())
-        : Collections.emptySet();
-
-    // a conflict exists if any table is listed to be repaired by both repair units
-    return !Sets.intersection(listRepairTables(unit0, tables), listRepairTables(unit1, tables)).isEmpty();
-  }
-
-  private Set<String> getTableNamesForKeyspace(Cluster cluster, String keyspace) {
-    try {
-      JmxProxy jmxProxy
-          = context.jmxConnectionFactory.connectAny(cluster, context.config.getJmxConnectionTimeoutInSeconds());
-
-      return jmxProxy.getTableNamesForKeyspace(keyspace);
-    } catch (ReaperException e) {
-      LOG.warn("unknown table list to cluster {} keyspace", cluster.getName(), keyspace, e);
-      return Collections.emptySet();
-    }
-  }
-
-  private static Set<String> listRepairTables(RepairUnit unit, Set<String> allTables) {
-    // subtract blacklisted tables from all tables (or those explicitly listed)
-    Set<String> tables = Sets.newHashSet(unit.getColumnFamilies().isEmpty() ? allTables : unit.getColumnFamilies());
-    tables.removeAll(unit.getBlacklistedTables());
-    return tables;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairUnitService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairUnitService.java
@@ -17,10 +17,17 @@ package io.cassandrareaper.service;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
+import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.jmx.JmxProxy;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +46,7 @@ public final class RepairUnitService {
     return new RepairUnitService(context);
   }
 
-  public RepairUnit getNewOrExistingRepairUnit(Cluster cluster, RepairUnit.Builder params) {
+  public RepairUnit getOrCreateRepairUnit(Cluster cluster, RepairUnit.Builder params) {
     if (params.incrementalRepair) {
       try {
         JmxProxy jmxProxy
@@ -54,6 +61,65 @@ public final class RepairUnitService {
       }
     }
     Optional<RepairUnit> repairUnit = context.storage.getRepairUnit(params);
-    return repairUnit.isPresent() ? repairUnit.get() : context.storage.addRepairUnit(params);
+    return repairUnit.isPresent() ? repairUnit.get() : createRepairUnit(cluster, params);
+  }
+
+  private RepairUnit createRepairUnit(Cluster cluster, RepairUnit.Builder builder) {
+    Preconditions.checkArgument(
+        !unitConflicts(cluster, builder),
+        "unit conflicts with existing in " + builder.clusterName + ":" + builder.keyspaceName);
+
+    return context.storage.addRepairUnit(builder);
+  }
+
+  private boolean unitConflicts(Cluster cluster, RepairUnit.Builder builder) {
+
+    Collection<RepairSchedule> repairSchedules = context.storage
+        .getRepairSchedulesForClusterAndKeyspace(builder.clusterName, builder.keyspaceName);
+
+    for (RepairSchedule sched : repairSchedules) {
+      RepairUnit repairUnitForSched = context.storage.getRepairUnit(sched.getRepairUnitId());
+      Preconditions.checkState(repairUnitForSched.getClusterName().equals(builder.clusterName));
+      Preconditions.checkState(repairUnitForSched.getKeyspaceName().equals(builder.keyspaceName));
+
+      if (conflictingUnits(cluster, repairUnitForSched, builder)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  boolean conflictingUnits(Cluster cluster, RepairUnit unit, RepairUnit.Builder builder) {
+    if (unit.with().equals(builder)) {
+      return true;
+    }
+
+    Preconditions.checkState(unit.getKeyspaceName().equals(builder.keyspaceName));
+
+    Set<String> tables = unit.getColumnFamilies().isEmpty() || builder.columnFamilies.isEmpty()
+        ? getTableNamesForKeyspace(cluster, unit.getKeyspaceName())
+        : Collections.emptySet();
+
+    // a conflict exists if any table is listed to be repaired by both repair units
+    return !Sets.intersection(listRepairTables(unit.with(), tables), listRepairTables(builder, tables)).isEmpty();
+  }
+
+  private Set<String> getTableNamesForKeyspace(Cluster cluster, String keyspace) {
+    try {
+      return context
+          .jmxConnectionFactory.connectAny(cluster, context.config.getJmxConnectionTimeoutInSeconds())
+          .getTableNamesForKeyspace(keyspace);
+
+    } catch (ReaperException e) {
+      LOG.warn("unknown table list to cluster {} keyspace", cluster.getName(), keyspace, e);
+      return Collections.emptySet();
+    }
+  }
+
+  private static Set<String> listRepairTables(RepairUnit.Builder builder, Set<String> allTables) {
+    // subtract blacklisted tables from all tables (or those explicitly listed)
+    Set<String> tables = Sets.newHashSet(builder.columnFamilies.isEmpty() ? allTables : builder.columnFamilies);
+    tables.removeAll(builder.blacklistedTables);
+    return tables;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -101,10 +101,12 @@ public interface IStoragePostgreSql {
           + SQL_REPAIR_UNIT_ALL_FIELDS
           + " FROM repair_unit "
           + "WHERE cluster_name = :clusterName AND keyspace_name = :keyspaceName "
-          + "AND column_families = :columnFamilies AND nodes = :nodes AND datacenters = :datacenters "
+          + "AND column_families = :columnFamilies AND incremental_repair = :incrementalRepair "
+          + "AND nodes = :nodes AND datacenters = :datacenters "
           + "AND blackListed_tables = :blacklisted_tables AND repair_thread_count = :repairThreadCount";
 
   String SQL_DELETE_REPAIR_UNIT = "DELETE FROM repair_unit WHERE id = :id";
+  String SQL_DELETE_REPAIR_UNITS = "DELETE FROM repair_unit WHERE cluster_name = :clusterName";
 
   // RepairSegmen
   //
@@ -309,6 +311,7 @@ public interface IStoragePostgreSql {
       @Bind("clusterName") String clusterName,
       @Bind("keyspaceName") String keyspaceName,
       @Bind("columnFamilies") Collection<String> columnFamilies,
+      @Bind("incrementalRepair") boolean incrementalRepair,
       @Bind("nodes") Collection<String> nodes,
       @Bind("datacenters") Collection<String> datacenters,
       @Bind("blacklisted_tables") Collection<String> blacklistedTables,
@@ -322,6 +325,10 @@ public interface IStoragePostgreSql {
   @SqlUpdate(SQL_DELETE_REPAIR_UNIT)
   int deleteRepairUnit(
       @Bind("id") long repairUnitId);
+
+  @SqlUpdate(SQL_DELETE_REPAIR_UNITS)
+  int deleteRepairUnits(
+      @Bind("clusterName") String clusterName);
 
   @SqlBatch(SQL_INSERT_REPAIR_SEGMENT)
   @BatchChunkSize(500)


### PR DESCRIPTION

 - Memory and Postgresql was broken in integration scenario: "Adding a scheduled full repair and a scheduled incremental repair for the same keyspace"
 - Also add failure message to precondition check in RepairScheduleResource.addRepairSchedule(..), which was what caught the failure in the above integration scenario.
 - tighter constraints on re-using existing repair units, and only creating units that will be used.