### PR TITLE
cassandra-reaper-pom files must also be uploaded to bintray

### DIFF
--- a/src/ci/descriptor-maven-snapshot.json
+++ b/src/ci/descriptor-maven-snapshot.json
@@ -33,6 +33,10 @@
             {"includePattern": "src/server/pom.xml", "uploadPattern": "io/cassandrareaper/cassandra-reaper/VERSION/cassandra-reaper-VERSION.pom",
                 "matrixParams": { "override": 1 }
             }
+            ,
+            {"includePattern": "src/pom.xml", "uploadPattern": "io/cassandrareaper/cassandra-reaper-pom/VERSION/cassandra-reaper-pom-VERSION.pom",
+                "matrixParams": { "override": 1 }
+            }
         ],
     "publish": true
 }

--- a/src/ci/descriptor-maven.json
+++ b/src/ci/descriptor-maven.json
@@ -33,6 +33,10 @@
             {"includePattern": "src/server/pom.xml", "uploadPattern": "io/cassandrareaper/cassandra-reaper/VERSION/cassandra-reaper-VERSION.pom",
                 "matrixParams": { "override": 1 }
             }
+            ,
+            {"includePattern": "src/pom.xml", "uploadPattern": "io/cassandrareaper/cassandra-reaper-pom/VERSION/cassandra-reaper-pom-VERSION.pom",
+                "matrixParams": { "override": 1 }
+            }
         ],
     "publish": true
 }


### PR DESCRIPTION
manually fixed jfrog bintray packages for past releases :: https://bintray.com/thelastpickle/reaper-maven/cassandra-reaper-pom