### PR TITLE
[streams] Show tables using tags, so they are nicely separated

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/StreamSessionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/StreamSessionFactory.java
@@ -119,7 +119,16 @@ public final class StreamSessionFactory {
                                  "127.0.0.3", "192.168.0.2", "IN",
                                  1024L, 512L, ImmutableList.of(new Stream.TableProgress("ks.t", 512L, 1024L)),
                                  0L, 0L, ImmutableList.of(),
-                                 false, true)
+                                 false, true),
+
+        // multi-table stream
+        "127.0.0.3-IN-127.0.0.8",
+        StreamFactory.testStream("127.0.0.3-IN-127.0.0.8",
+                                 "127.0.0.3", "127.0.0.8", "IN",
+                                 2048L, 650L, ImmutableList.of(new Stream.TableProgress("ks.t1", 512L, 1024L),
+                                                               new Stream.TableProgress("ks.t2", 128L, 1024L)),
+                                 0L, 0L, ImmutableList.of(),
+                                 false, false)
     );
 
     return StreamSession.builder()

--- a/src/ui/app/jsx/stream.jsx
+++ b/src/ui/app/jsx/stream.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ProgressBar from 'react-bootstrap/lib/ProgressBar';
 import Table from 'react-bootstrap/lib/Table';
 import {DeleteStatusMessageMixin, humanFileSize, getUrlPrefix, toast} from "jsx/mixin";
+import { WithContext as ReactTags } from 'react-tag-input';
 
 const Stream = React.createClass({
     propTypes: {
@@ -14,6 +15,12 @@ const Stream = React.createClass({
         return {communicating: false, collapsed: true};
     },
 
+    _tableTags: function(tables) {
+        const tags = tables.reduce((sum, item) => sum.concat({id: item, text: item}), [])
+        return (
+            <ReactTags tags={tags} readOnly={true} />
+        );
+    },
 
     render: function() {
 
@@ -38,6 +45,8 @@ const Stream = React.createClass({
             var directionText = "To: ";
         };
 
+        const tableTags = this._tableTags(tables)
+
         const peerWidth = {
             width: "10%"
         }
@@ -55,7 +64,7 @@ const Stream = React.createClass({
             <tr>
                 <td style={peerWidth}> <strong>{directionText} </strong> {stream.peer} </td>
                 <td style={planWidth}> <strong>PlanId: </strong> {this.props.planId} </td>
-                <td style={tableWidth}> <strong>Tables: </strong> {tables} </td>
+                <td style={tableWidth}> <strong>Tables: </strong> {tableTags} </td>
                 <td style={barWidth}> <ProgressBar now={progress} active={isActive} label={label} bsStyle={style} key={stream.id} /> </td>
             </tr>
         );


### PR DESCRIPTION
This PR fixes how the the UI shows tables involved in a stream.

Previously, the tables were concatenated without any delimiters:
![screen shot 2018-08-08 at 17 27 37](https://user-images.githubusercontent.com/2589903/43843596-9bcb641a-9b30-11e8-9320-2e1701012aa2.png)

After this PR, tables are going to be show using (read-only) tags:
![screen shot 2018-08-08 at 17 28 11](https://user-images.githubusercontent.com/2589903/43843629-aa2044cc-9b30-11e8-8124-fa4181a909be.png)
