### PR TITLE
[node-stats] Add missing React keys to prevent exceptions

### DIFF
--- a/src/ui/app/jsx/client-request-latency.jsx
+++ b/src/ui/app/jsx/client-request-latency.jsx
@@ -129,7 +129,7 @@ const ClientRequestLatency = React.createClass({
         return 0;})
         .filter(metric => metric.type == "Latency")
         .map(clientRequest => 
-          <tr>
+          <tr key={clientRequest.name}>
             <td>{clientRequest.name}</td>
             <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP50}><span>{roundLatency(clientRequest.p50, 3)}</span></OverlayTrigger></td>
             <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP75}><span>{roundLatency(clientRequest.p75, 3)}</span></OverlayTrigger></td>
@@ -150,7 +150,7 @@ const ClientRequestLatency = React.createClass({
         return 0;})
         .filter(metric => metric.type != "Latency")
         .map(clientRequest => 
-          <tr>
+          <tr key={clientRequest.name + clientRequest.type}>
             <td >{clientRequest.name} {clientRequest.type}</td>
             <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP50}><span>{roundLatency(clientRequest.p50, 3)}</span></OverlayTrigger></td>
             <td style={alignRightStyle}><OverlayTrigger placement="top" overlay={tooltipP75}><span>{roundLatency(clientRequest.p75, 3)}</span></OverlayTrigger></td>

--- a/src/ui/app/jsx/dropped-messages.jsx
+++ b/src/ui/app/jsx/dropped-messages.jsx
@@ -62,7 +62,7 @@ const DroppedMessages = React.createClass({
       const droppedMessagesBody = this.state.droppedMessages.sort((a, b) => {if(a.name < b.name) return -1;
       if(a.name > b.name) return 1;
       return 0;}).map(pool => 
-        <tr>
+        <tr key={pool.name}>
           <td>{pool.name}</td>
           <td style={alignRightStyle}>{pool.count}</td>
           <td style={alignRightStyle}>{pool.oneMinuteRate}</td>

--- a/src/ui/app/jsx/tpstats.jsx
+++ b/src/ui/app/jsx/tpstats.jsx
@@ -62,7 +62,7 @@ const TpStats = React.createClass({
       const tpstatsBody = this.state.tpstats.sort((a, b) => {if(a.name < b.name) return -1;
       if(a.name > b.name) return 1;
       return 0;}).map(pool => 
-        <tr>
+        <tr key={pool.name} >
           <td >{pool.name}</td>
           <td style={alignRightStyle}>{pool.activeTasks}</td>
           <td style={alignRightStyle}>{pool.pendingTasks}</td>


### PR DESCRIPTION
We are currently missing some keys for certain rows in the node stats tables. As a result, there are some js exceptions:
<img width="1671" alt="screen shot 2018-08-09 at 10 04 44" src="https://user-images.githubusercontent.com/2589903/43894326-6764f9fc-9bda-11e8-8312-52672e2d0656.png">

This PR adds the keys so the exceptions no longer happen.