### PR TITLE
Remove stateless services from context

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/AppContext.java
+++ b/src/server/src/main/java/io/cassandrareaper/AppContext.java
@@ -15,7 +15,6 @@
 package io.cassandrareaper;
 
 import io.cassandrareaper.jmx.JmxConnectionFactory;
-import io.cassandrareaper.service.PurgeManager;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.SnapshotManager;
 import io.cassandrareaper.storage.IStorage;
@@ -47,7 +46,6 @@ public final class AppContext {
   public ReaperApplicationConfiguration config;
   public MetricRegistry metricRegistry = new MetricRegistry();
   public SnapshotManager snapshotManager;
-  public PurgeManager purgeManager;
 
   private static String initialiseInstanceAddress() {
     String reaperInstanceAddress;

--- a/src/server/src/main/java/io/cassandrareaper/AppContext.java
+++ b/src/server/src/main/java/io/cassandrareaper/AppContext.java
@@ -18,7 +18,6 @@ import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.service.PurgeManager;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.SnapshotManager;
-import io.cassandrareaper.service.StreamManager;
 import io.cassandrareaper.storage.IStorage;
 
 import java.net.InetAddress;
@@ -49,7 +48,6 @@ public final class AppContext {
   public MetricRegistry metricRegistry = new MetricRegistry();
   public SnapshotManager snapshotManager;
   public PurgeManager purgeManager;
-  public StreamManager streamManager;
 
   private static String initialiseInstanceAddress() {
     String reaperInstanceAddress;

--- a/src/server/src/main/java/io/cassandrareaper/AppContext.java
+++ b/src/server/src/main/java/io/cassandrareaper/AppContext.java
@@ -16,7 +16,6 @@ package io.cassandrareaper;
 
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.service.RepairManager;
-import io.cassandrareaper.service.SnapshotManager;
 import io.cassandrareaper.storage.IStorage;
 
 import java.net.InetAddress;
@@ -45,7 +44,6 @@ public final class AppContext {
   public JmxConnectionFactory jmxConnectionFactory;
   public ReaperApplicationConfiguration config;
   public MetricRegistry metricRegistry = new MetricRegistry();
-  public SnapshotManager snapshotManager;
 
   private static String initialiseInstanceAddress() {
     String reaperInstanceAddress;

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -32,7 +32,6 @@ import io.cassandrareaper.service.PurgeManager;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.SchedulingManager;
 import io.cassandrareaper.service.SnapshotManager;
-import io.cassandrareaper.service.StreamManager;
 import io.cassandrareaper.storage.CassandraStorage;
 import io.cassandrareaper.storage.IDistributedStorage;
 import io.cassandrareaper.storage.IStorage;
@@ -159,8 +158,6 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     context.snapshotManager = SnapshotManager.create(
         context,
         environment.lifecycle().executorService("SnapshotManager").minThreads(5).maxThreads(5).build());
-
-    context.streamManager = StreamManager.create(context);
 
     int repairThreads = config.getRepairRunThreadCount();
     LOG.info("initializing runner thread pool with {} threads", repairThreads);

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -31,7 +31,6 @@ import io.cassandrareaper.service.AutoSchedulingManager;
 import io.cassandrareaper.service.PurgeManager;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.SchedulingManager;
-import io.cassandrareaper.service.SnapshotManager;
 import io.cassandrareaper.storage.CassandraStorage;
 import io.cassandrareaper.storage.IDistributedStorage;
 import io.cassandrareaper.storage.IStorage;
@@ -155,10 +154,6 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
         .addServlet("prometheusMetrics", new MetricsServlet(CollectorRegistry.defaultRegistry))
         .addMapping("/prometheusMetrics");
 
-    context.snapshotManager = SnapshotManager.create(
-        context,
-        environment.lifecycle().executorService("SnapshotManager").minThreads(5).maxThreads(5).build());
-
     int repairThreads = config.getRepairRunThreadCount();
     LOG.info("initializing runner thread pool with {} threads", repairThreads);
 
@@ -233,7 +228,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     environment.jersey().register(addRepairRunResource);
     final RepairScheduleResource addRepairScheduleResource = new RepairScheduleResource(context);
     environment.jersey().register(addRepairScheduleResource);
-    final SnapshotResource snapshotResource = new SnapshotResource(context);
+    final SnapshotResource snapshotResource = new SnapshotResource(context, environment);
     environment.jersey().register(snapshotResource);
 
     final NodeStatsResource nodeStatsResource = new NodeStatsResource(context);

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -256,7 +256,6 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
       AutoSchedulingManager.start(context);
     }
 
-    context.purgeManager = PurgeManager.create(context);
     initializeJmxSeedsForAllClusters();
     LOG.info("resuming pending repair runs");
 
@@ -303,10 +302,12 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
   }
 
   private void schedulePurge(ScheduledExecutorService scheduler) {
+    final PurgeManager purgeManager = PurgeManager.create(context);
+
     scheduler.scheduleWithFixedDelay(
         () -> {
           try {
-            int purgedRuns = context.purgeManager.purgeDatabase();
+            int purgedRuns = purgeManager.purgeDatabase();
             LOG.info("Purged {} repair runs from history", purgedRuns);
           } catch (RuntimeException e) {
             LOG.error("Failed purging repair runs from history", e);

--- a/src/server/src/main/java/io/cassandrareaper/resources/NodeStatsResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/NodeStatsResource.java
@@ -20,6 +20,7 @@ import io.cassandrareaper.core.Node;
 import io.cassandrareaper.core.StreamSession;
 import io.cassandrareaper.service.CompactionService;
 import io.cassandrareaper.service.MetricsGrabber;
+import io.cassandrareaper.service.StreamManager;
 
 import java.util.List;
 
@@ -42,11 +43,13 @@ public final class NodeStatsResource {
   private static final Logger LOG = LoggerFactory.getLogger(NodeStatsResource.class);
 
   private final AppContext context;
+  private final StreamManager streamManager;
   private final MetricsGrabber metricsGrabber;
   private final CompactionService compactionService;
 
   public NodeStatsResource(AppContext context) {
     this.context = context;
+    this.streamManager = StreamManager.create(context);
     this.metricsGrabber = MetricsGrabber.create(context);
     this.compactionService = CompactionService.create(context);
   }
@@ -126,7 +129,7 @@ public final class NodeStatsResource {
   ) {
     try {
       Node node = Node.builder().withClusterName(clusterName).withHostname(host).build();
-      List<StreamSession> streams = context.streamManager.listStreams(node);
+      List<StreamSession> streams = streamManager.listStreams(node);
       return Response.ok().entity(streams).build();
     } catch (ReaperException e) {
       LOG.error(e.getMessage(), e);

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -24,6 +24,7 @@ import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.resources.view.RepairRunStatus;
+import io.cassandrareaper.service.PurgeManager;
 import io.cassandrareaper.service.RepairRunService;
 import io.cassandrareaper.service.RepairUnitService;
 
@@ -760,7 +761,7 @@ public final class RepairRunResource {
   @GET
   @Path("/purge")
   public Response purgeRepairRuns() {
-    int purgedRepairs = context.purgeManager.purgeDatabase();
+    int purgedRepairs = PurgeManager.create(context).purgeDatabase();
     return Response.ok().entity(purgedRepairs).build();
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
@@ -19,7 +19,6 @@ import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
-import io.cassandrareaper.service.StreamManager;
 import io.cassandrareaper.service.TestRepairConfiguration;
 import io.cassandrareaper.storage.MemoryStorage;
 
@@ -251,7 +250,6 @@ public final class ClusterResourceTest {
     AppContext context = new AppContext();
     context.storage = new MemoryStorage();
     context.config = TestRepairConfiguration.defaultConfig();
-    context.streamManager = StreamManager.create(context);
 
     UriInfo uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(SAMPLE_URI));

--- a/src/server/src/test/java/io/cassandrareaper/service/PurgeManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/PurgeManagerTest.java
@@ -51,7 +51,6 @@ public final class PurgeManagerTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.config.setPurgeRecordsAfterInDays(1);
-    context.purgeManager = PurgeManager.create(context);
 
     // Create storage mock
     context.storage = mock(IStorage.class);
@@ -80,7 +79,7 @@ public final class PurgeManagerTest {
     when(context.storage.getRepairRunsForCluster(anyString(), any())).thenReturn(repairRuns);
 
     // Invoke the purge manager
-    int purged = context.purgeManager.purgeDatabase();
+    int purged = PurgeManager.create(context).purgeDatabase();
 
     // Check that runs were removed
     assertEquals(9, purged);
@@ -91,7 +90,6 @@ public final class PurgeManagerTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.config.setNumberOfRunsToKeepPerUnit(5);
-    context.purgeManager = PurgeManager.create(context);
 
     // Create storage mock
     context.storage = mock(IStorage.class);
@@ -120,7 +118,7 @@ public final class PurgeManagerTest {
     when(context.storage.getRepairRunsForCluster(anyString(), any())).thenReturn(repairRuns);
 
     // Invoke the purge manager
-    int purged = context.purgeManager.purgeDatabase();
+    int purged = PurgeManager.create(context).purgeDatabase();
 
     // Check that runs were removed
     assertEquals(15, purged);
@@ -131,7 +129,6 @@ public final class PurgeManagerTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.config.setPurgeRecordsAfterInDays(1);
-    context.purgeManager = PurgeManager.create(context);
 
     // Create storage mock
     context.storage = mock(IStorage.class);
@@ -160,7 +157,7 @@ public final class PurgeManagerTest {
     when(context.storage.getRepairRunsForCluster(anyString(), any())).thenReturn(repairRuns);
 
     // Invoke the purge manager
-    int purged = context.purgeManager.purgeDatabase();
+    int purged = PurgeManager.create(context).purgeDatabase();
 
     // Check that runs were removed
     assertEquals(0, purged);


### PR DESCRIPTION
A number of stateless services have crept into the application context `AppContext` class.

We want to avoid cyclic dependency between `AppContext` and service classes. It should be only a `AppContext` <- service-class relationship.
The only current exception to that it our state service `RepairManager` that is contextual to a number other services.

This PR can't be merged (into master) until #517 is first merged.