### PR TITLE
 Fix integration test failure when attempting to delete undeleted cluster

### DIFF
--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -723,12 +723,20 @@ public final class BasicSteps {
   @And("^deleting the last added cluster fails$")
   public void deleting_the_last_added_cluster_fails() throws Throwable {
     synchronized (BasicSteps.class) {
-      callAndExpect(
-          "DELETE",
-          "/cluster/" + TestContext.TEST_CLUSTER,
-          EMPTY_PARAMS,
-          Optional.absent(),
-          Response.Status.CONFLICT);
+      await().with().pollInterval(1, SECONDS).atMost(1, MINUTES).until(() -> {
+        try {
+          callAndExpect(
+              "DELETE",
+              "/cluster/" + TestContext.TEST_CLUSTER,
+              EMPTY_PARAMS,
+              Optional.absent(),
+              Response.Status.CONFLICT);
+        } catch (AssertionError ex) {
+          LOG.warn(ex.getMessage());
+          return false;
+        }
+        return true;
+      });
     }
   }
 


### PR DESCRIPTION
If a cluster is deleted too quickly after a schedule/repair has been created, rather than the ClusterResource catch it, it will get caught as an assertion failure in CassandraStorage.

Allow integration tests to retry, so to let the ClusterResource throw the correct error response.