### PR TITLE
Cast mbean attribute ValidationExecutor ActiveTasks and PendingTasks to Number object (instead of Integer or Long)

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
@@ -502,10 +502,12 @@ final class JmxProxyImpl implements JmxProxy {
     // Check if AntiEntropySession is actually running on the node
     try {
       int activeCount
-          = (Integer) mbeanServer.getAttribute(new ObjectName(VALIDATION_ACTIVE_OBJECT_NAME), VALUE_ATTRIBUTE);
+          = ((Number) mbeanServer.getAttribute(new ObjectName(VALIDATION_ACTIVE_OBJECT_NAME), VALUE_ATTRIBUTE))
+              .intValue();
 
-      long pendingCount
-          = (Long) mbeanServer.getAttribute(new ObjectName(VALIDATION_PENDING_OBJECT_NAME), VALUE_ATTRIBUTE);
+      int pendingCount
+          = ((Number) mbeanServer.getAttribute(new ObjectName(VALIDATION_PENDING_OBJECT_NAME), VALUE_ATTRIBUTE))
+              .intValue();
 
       return activeCount + pendingCount != 0;
     } catch (IOException ignored) {


### PR DESCRIPTION

PendingTasks was a Long before Cassandra-4.0, and a Integer in Cassandra-4.0

See https://github.com/apache/cassandra/commit/d5ae2ae481545b1fb2332b46013088f2f8cea636#diff-2ffafcbdf4add10684d1f0c9f019a1d8L243 for the commit it changed in Cassandra.