### PR TITLE
Downgrade the enforced Maven version to 3.3.8 to allow the Docker build to work again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,8 +315,8 @@
         <version.jdk>1.8</version.jdk>
         <!-- travis of July 2018 was still using _151 -->
         <build.jdk.minimum>1.8.0-151</build.jdk.minimum>
-        <!-- travis of July 2018 was still using maven-3.5.2 -->
-        <maven.version.minimum>3.5.2</maven.version.minimum>
+        <!-- travis of July 2018 was still using maven-3.5.2 but our Docker image for building packages ships with 3.3.8 -->
+        <maven.version.minimum>3.3.8</maven.version.minimum>
         <surefireArgLine></surefireArgLine>
 
         <!--


### PR DESCRIPTION
The Docker build uses an image that sports the 3.3.8 version of Maven.
Since there doesn't seem to be a pressing issue that requires Maven 3.5.2, I think it's the easiest way to handle this issue.