### PR TITLE
ISSUE-475: Remove deprecated 'database' keyword

### DIFF
--- a/src/packaging/resource/cassandra-reaper.yaml
+++ b/src/packaging/resource/cassandra-reaper.yaml
@@ -71,13 +71,6 @@ server:
   requestLog:
     appenders: []
 
-database:
-  # PostgreSQL JDBC settings
-  driverClass: org.postgresql.Driver
-  user: postgres
-  password: postgres
-  url: jdbc:postgresql://127.0.0.1/reaper
-
 autoScheduling:
   enabled: false
   initialDelayPeriod: PT15S

--- a/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
@@ -44,14 +44,7 @@ jmxCredentials:
     username: cassandra
     password: cassandrapassword
 
-# database section will be ignored if storageType is set to "memory"
-#h2:
-  # H2 JDBC settings
-#  url: jdbc:h2:/tmp/reaper-db;MODE=PostgreSQL
-#  user:
-#  password:
-
-database:
+h2:
   # H2 JDBC settings
   driverClass: org.h2.Driver
   url: jdbc:h2:/tmp/reaper-db/db;MODE=PostgreSQL


### PR DESCRIPTION
- Remove deprecated 'database' keyword from cassandra-reaper.yaml files