### PR TITLE
Remove mention of `copyright grant` or any implied notion of a CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,32 @@
+# Contributing to Reaper
 
-## Contributing Code
+If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request (on a branch other than `master`).
 
-Reaper is licensed under the Apache 2.0 License. See `NOTICE.md` for more information on the license.
+When submitting code, please abide by the code style, most of which is enforced by [CheckStyle](https://github.com/thelastpickle/cassandra-reaper/blob/master/src/server/checkstyle.xml).
 
-All contributions (code, documentation, or anything else) to Reaper imply a copyright grant to `The Last Pickle Ltd`.
+## License
 
-Larger contributions will require an explicit contributor license agreement.
+By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/thelastpickle/cassandra-reaper/blob/master/LICENSE
+
+All files are released with the Apache 2.0 license.
+If you are adding a new file it should have a header like below. 
+
+```
+/**
+ * Copyright 2018-2018 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ */
+ ```


### PR DESCRIPTION
Copyright assignment was not the intention with the standardising the license headers through the project.
As @danielkza describes, it's option (b) in [this comment](https://github.com/thelastpickle/cassandra-reaper/issues/561#issuecomment-423852079) that is the project's goal.