### PR TITLE
Restore compatibility with Cassandra 1.2 (fixes #579)

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
@@ -160,7 +160,7 @@ final class JmxProxyImpl implements JmxProxy {
     final HostAndPort hostAndPort = HostAndPort.fromString(host);
 
     return connect(
-          hostAndPort.getHostText(),
+          hostAndPort.getHost(),
           hostAndPort.getPortOrDefault(JMX_PORT),
           username,
           password,

--- a/src/server/src/main/java/io/cassandrareaper/jmx/StreamsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/StreamsProxy.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import javax.management.openmbean.CompositeData;
 
 import com.google.common.base.Preconditions;
-
+import com.google.common.collect.ImmutableSet;
 
 
 public final class StreamsProxy {
@@ -40,6 +40,10 @@ public final class StreamsProxy {
   }
 
   public Set<CompositeData> listStreams() {
-    return proxy.getStreamManagerMBean().getCurrentStreams();
+    if (proxy.getStreamManagerMBean().isPresent()) {
+      return proxy.getStreamManagerMBean().get().getCurrentStreams();
+    } else {
+      return ImmutableSet.of();
+    }
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/jmx/JmxProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/JmxProxyTest.java
@@ -19,6 +19,8 @@ package io.cassandrareaper.jmx;
 
 import io.cassandrareaper.ReaperException;
 
+import java.util.Optional;
+
 import javax.management.MBeanServerConnection;
 
 import com.google.common.base.Preconditions;
@@ -48,7 +50,7 @@ public final class JmxProxyTest {
 
   public static void mockGetStreamManagerMBean(JmxProxy proxy, StreamManagerMBean streamingManagerMBean) {
     Preconditions.checkArgument(proxy instanceof JmxProxyImpl, "only JmxProxyImpl is supported");
-    Mockito.when(((JmxProxyImpl)proxy).getStreamManagerMBean()).thenReturn(streamingManagerMBean);
+    Mockito.when(((JmxProxyImpl)proxy).getStreamManagerMBean()).thenReturn(Optional.of(streamingManagerMBean));
   }
 
   public static void mockGetEndpointSnitchInfoMBean(JmxProxy proxy, EndpointSnitchInfoMBean endpointSnitchInfoMBean) {


### PR DESCRIPTION
the StreamManagerMBean mbean has been added to Cassandra 2.0 only. This PR attempts to not connect to this nonexistent mbean on clusters below 2.0.

I successfully ran unit tests but please note that I haven't tested this change against a real cluster. So it needs a strong review :wink: 