### PR TITLE
Fix ui left node status and token count

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxy.java
@@ -127,5 +127,4 @@ public interface JmxProxy extends NotificationListener {
   void close();
 
   void removeRepairStatusHandler(int repairNo);
-
 }

--- a/src/server/src/main/java/io/cassandrareaper/jmx/StorageServiceProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/StorageServiceProxy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018-2018 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.jmx;
+
+
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Preconditions;
+import org.apache.cassandra.service.StorageServiceMBean;
+
+
+
+public final class StorageServiceProxy {
+
+  private final JmxProxyImpl proxy;
+  private final StorageServiceMBean ssProxy;
+
+  private StorageServiceProxy(JmxProxyImpl proxy) {
+    this.proxy = proxy;
+    this.ssProxy = proxy.getStorageServiceMBean();
+  }
+
+  public static StorageServiceProxy create(JmxProxy proxy) {
+    Preconditions.checkArgument(proxy instanceof JmxProxyImpl, "only JmxProxyImpl is supported");
+    return new StorageServiceProxy((JmxProxyImpl)proxy);
+  }
+
+  public Map<String, List<String>> getTokensByNode() {
+    Preconditions.checkNotNull(ssProxy, "Looks like the proxy is not connected");
+
+    Map<String, String> tokenToEndpointMap = ssProxy.getTokenToEndpointMap();
+    return tokenToEndpointMap
+        .entrySet()
+        .stream()
+        .collect(
+            Collectors.groupingBy(
+                Entry::getValue, Collectors.mapping(Entry::getKey, Collectors.toList())));
+
+  }
+
+
+}

--- a/src/server/src/main/java/io/cassandrareaper/resources/NodeStatsResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/NodeStatsResource.java
@@ -21,11 +21,14 @@ import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.core.StreamSession;
+import io.cassandrareaper.jmx.JmxProxy;
+import io.cassandrareaper.jmx.StorageServiceProxy;
 import io.cassandrareaper.service.CompactionService;
 import io.cassandrareaper.service.MetricsService;
 import io.cassandrareaper.service.StreamService;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -155,6 +158,34 @@ public final class NodeStatsResource {
     try {
       Node node = Node.builder().withClusterName(clusterName).withHostname(host).build();
       return Response.ok().entity(compactionService.listActiveCompactions(node)).build();
+    } catch (RuntimeException | ReaperException e) {
+      LOG.error(e.getMessage(), e);
+      return Response.serverError().entity(e.getMessage()).build();
+    }
+  }
+
+  /**
+   * Endpoint used to list the tokens owned by a node.
+   *
+   * @return a list of tokens.
+   */
+  @GET
+  @Path("/tokens/{clusterName}/{host}")
+  public Response listTokens(
+      @Context UriInfo uriInfo,
+      @PathParam("clusterName") String clusterName,
+      @PathParam("host") String host)
+      throws InterruptedException {
+
+    try {
+      JmxProxy jmxProxy
+          = context.jmxConnectionFactory.connect(
+              Node.builder().withClusterName(clusterName).withHostname(host).build(),
+              context.config.getJmxConnectionTimeoutInSeconds());
+
+      StorageServiceProxy ssProxy = StorageServiceProxy.create(jmxProxy);
+      Map<String, List<String>> tokens = ssProxy.getTokensByNode();
+      return Response.ok().entity(tokens.get(host)).build();
     } catch (RuntimeException | ReaperException e) {
       LOG.error(e.getMessage(), e);
       return Response.serverError().entity(e.getMessage()).build();

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
@@ -153,8 +153,11 @@ public final class NodesStatus {
           tokens.orElse(NOT_AVAILABLE),
           load.orElse(0.0));
 
-      endpoints.add(endpoint.orElse(NOT_AVAILABLE));
-      endpointStates.add(endpointState);
+      if (!status.orElse(NOT_AVAILABLE).toLowerCase().contains("left")) {
+        // Only add nodes that haven't left the cluster (they could still appear in Gossip state for a while)
+        endpoints.add(endpoint.orElse(NOT_AVAILABLE));
+        endpointStates.add(endpointState);
+      }
     }
 
     Map<String, Map<String, List<EndpointState>>> endpointsByDcAndRack = Maps.newHashMap();

--- a/src/server/src/test/java/io/cassandrareaper/SimpleReaperClient.java
+++ b/src/server/src/test/java/io/cassandrareaper/SimpleReaperClient.java
@@ -184,4 +184,8 @@ public final class SimpleReaperClient {
     return parseJSON(json, new TypeReference<List<MetricsHistogram>>() {});
   }
 
+  public static List<String> parseTokenListJSON(String json) {
+    return parseJSON(json, new TypeReference<List<String>>() {});
+  }
+
 }

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -1532,6 +1532,30 @@ public final class BasicSteps {
     }
   }
 
+  @And("^the seed node has vnodes$")
+  public void the_seed_node_has_vnodes() {
+    synchronized (BasicSteps.class) {
+      RUNNERS
+          .parallelStream()
+          .forEach(
+              runner -> {
+                Response response
+                    = runner.callReaper(
+                        "GET",
+                        "/node/tokens/"
+                            + TestContext.TEST_CLUSTER
+                            + "/"
+                            + TestContext.SEED_HOST.split("@")[0],
+                        EMPTY_PARAMS);
+                assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+                String responseData = response.readEntity(String.class);
+                List<String> tokens = SimpleReaperClient.parseTokenListJSON(responseData);
+
+                assertTrue(tokens.size() >= 1);
+              });
+    }
+  }
+
   private static int httpStatus(String statusCodeDescriptions) {
     String enumName = statusCodeDescriptions.toUpperCase().replace(' ', '_');
     return Response.Status.valueOf(enumName).getStatusCode();

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -40,6 +40,7 @@ Feature: Using Reaper to launch repairs and schedule them
     And we can collect the dropped messages stats from the seed node
     And we can collect the client request metrics from the seed node
     Then reaper has the last added cluster in storage
+    And the seed node has vnodes
     And reaper has 0 scheduled repairs for the last added cluster
     When a new daily "full" repair schedule is added for the last added cluster and keyspace "booya"
     Then reaper has 1 scheduled repairs for the last added cluster


### PR DESCRIPTION
This PR brings two things in separate commits : 
- Remove nodes that left the cluster from the cluster view in the UI
- Fix the token count in the node detail screen and allow to display the list of tokens