### PR TITLE
Add configuration support for enabling an addressTranslator in cassandra persistence options

### DIFF
--- a/src/server/src/main/docker/configure-persistence.sh
+++ b/src/server/src/main/docker/configure-persistence.sh
@@ -51,6 +51,13 @@ cat <<EOT >> /etc/cassandra-reaper.yml
     type: jdk
 EOT
 fi
+
+if [ "true" = "${REAPER_CASS_ADDRESS_TRANSLATOR_ENABLED}" ]; then
+cat <<EOT >> /etc/cassandra-reaper.yml
+  addressTranslator:
+    type: ${REAPER_CASS_ADDRESS_TRANSLATOR_TYPE}
+EOT
+fi
 # END cassandra persistence options
 
     ;;


### PR DESCRIPTION
@adejanovski re https://github.com/thelastpickle/cassandra-reaper/issues/564 and in particular https://github.com/thelastpickle/cassandra-reaper/issues/564#issuecomment-425049540

Is this what you mean?

For example:

```
REAPER_CASS_ADDRESS_TRANSLATOR_ENABLED=true
REAPER_CASS_ADDRESS_TRANSLATOR_TYPE=ec2MultiRegion
```
