### PR TITLE
Documentation fix for snapshots API

### DIFF
--- a/docs/docs/api/index.html
+++ b/docs/docs/api/index.html
@@ -611,7 +611,7 @@ Delete all the related repair runs before calling this endpoint.
 <br /></li>
 </ul></li>
 
-<li><p><strong>GET /snapshot/{clusterName}</strong></p>
+<li><p><strong>GET /snapshot/cluster/{clusterName}</strong></p>
 
 <ul>
 <li>Expected query parameters: <em>None</em></li>

--- a/src/docs/content/docs/api.md
+++ b/src/docs/content/docs/api.md
@@ -189,7 +189,7 @@ Returns OK if all goes well NOT_MODIFIED if new state is the same as the old one
   * Lists snapshots for the given host in the given cluster.
   
   
-* **GET /snapshot/{clusterName}**
+* **GET /snapshot/cluster/{clusterName}**
   * Expected query parameters: *None*
   * Lists all snapshots for the the given cluster.
   


### PR DESCRIPTION
Current documentation shows **/snapshot/{clusterName}/** as an endpoint for listing all snapshots in cluster while it's **/snapshot/cluster/{clusterName}/** according to SnapshotResource.java:

```
  /**
   * Endpoint used to create a snapshot.
   *
   * @return nothing in case everything is ok, and a status code 500 in case of errors.
   */
  @POST
  @Path("/cluster/{clusterName}")
  public Response createSnapshotClusterWide(
```