### PR TITLE
Add support for authentication in spreaper

### DIFF
--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -46,7 +46,7 @@ if "-vv" in sys.argv:
     log_level = logging.DEBUG
 if "-q" in sys.argv or "--quiet" in sys.argv:
     if logging.WARN != log_level:
-        print "--verbose and --quiet options can't both be specified"
+        print("--verbose and --quiet options can't both be specified")
         exit(1)
     quiet = True
 
@@ -73,7 +73,6 @@ class ReaperCaller(object):
             params = {}
         log.info("making HTTP %s to %s", http_method, the_url)
         if http_method == 'GET':
-            print("headers : {}".format(HEADERS))
             r = requests.get(the_url, params=params, cookies=cookies, headers=HEADERS)
         elif http_method == 'POST':
             r = requests.post(the_url, params=params, cookies=cookies, headers=HEADERS)
@@ -88,6 +87,8 @@ class ReaperCaller(object):
         log.info("HTTP %s return code %s with content of length %s",
                  http_method, r.status_code, len(str(r.text)))
         log.debug("Response content:\n%s", r.text)
+        if str(r.status_code) == "403":
+            printq("Access to this operation seems to be restricted. You may need to login and pass a JWT to access it.")
         if not str(r.status_code).startswith("2"):
             print r.text
         r.raise_for_status()
@@ -146,7 +147,7 @@ def _global_arguments(parser, command):
                        action="store_true")
     group.add_argument("-vv", help="extra output verbosity", action="store_true")
     group.add_argument("-q", "--quiet", help="unix mode", action="store_true")
-    group.add_argument("--username", default=None, help="Username to login with")
+    group.add_argument("--jwt", default=None, help="Session JSON Web Token obtained at login")
     parser.add_argument(command)
 
 
@@ -326,16 +327,17 @@ def _arguments_for_delete_snapshots(parser):
     parser.add_argument("--node", default=None,
                         help=("A single node to get the snapshot list from"))
 
+def _arguments_for_login(parser):
+    """Arguments needed to login"""
+    parser.add_argument("--username", help="Username to login with")
+
 def _parse_arguments(command, description, usage=None, extra_arguments=None):
     """Generic argument parsing done by every command"""
     parser = argparse.ArgumentParser(description=description, usage=usage)
     _global_arguments(parser, command)
     if extra_arguments:
         extra_arguments(parser)
-    if (command == "login"):
-        return parser.parse_known_args()
-    else:
-        return parser.parse_args()
+    return parser.parse_args()
 
 
 # === The actual CLI ========================================================================
@@ -356,6 +358,7 @@ REAPER_USAGE = SPREAPER_DESCRIPTION + """
 Usage: spreaper [<global_args>] <command> [<command_args>]
 
 <command> can be:
+    login           Login to Reaper.
     list-clusters   List all registered Cassandra clusters.
     list-runs       List registered repair runs.
     list-schedules  List registered repair schedules.
@@ -412,37 +415,16 @@ class ReaperCLI(object):
             exit(2)
 
     @staticmethod
-    def prepare_reaper_for_login(command, description, usage=None, extra_arguments=None):
-        (args, ignored) = _parse_arguments(command, description, usage, extra_arguments)
-        reaper = ReaperCaller(args.reaper_host, args.reaper_port, args.reaper_use_ssl)
-        return reaper, args
-
-    @staticmethod
     def prepare_reaper(command, description, usage=None, extra_arguments=None):
         args = _parse_arguments(command, description, usage, extra_arguments)
         reaper = ReaperCaller(args.reaper_host, args.reaper_port, args.reaper_use_ssl)
-        ReaperCLI.login(reaper, args)
+        ReaperCLI.addJwtHeader(args)
         return reaper, args
 
     @staticmethod
-    def login(reaper, args):
-        if (args.username != None):
-            reaper, args = ReaperCLI.prepare_reaper_for_login(
-                "login",
-                "Authenticate to Reaper"
-            )
-            password = ReaperCLI.get_password()
-            printq("# Logging in...")
-            payload = {'username':args.username, 'password':password, 'rememberMe':False}
-            reply = reaper.postFormData("login", 
-                                payload=payload)
-            # Use shiro's session id to request a JWT
-            COOKIES["JSESSIONID"] = reply.cookies["JSESSIONID"]
-            jwt = reaper.get("jwt")
-
-            # remove the session id and set the auth header with the JWT
-            COOKIES.pop("JSESSIONID", None)
-            HEADERS['Authorization'] = 'Bearer ' + jwt
+    def addJwtHeader(args):
+        if (args.jwt != None):
+            HEADERS['Authorization'] = 'Bearer ' + args.jwt
     
     @staticmethod
     def get_password():
@@ -455,6 +437,25 @@ class ReaperCLI(object):
         
         return password
 
+    def login(self):
+        reaper, args = ReaperCLI.prepare_reaper(
+            "login",
+            "Authenticate to Reaper",
+            extra_arguments=_arguments_for_login
+        )
+        password = ReaperCLI.get_password()
+        printq("# Logging in...")
+        payload = {'username':args.username, 'password':password, 'rememberMe':False}
+        reply = reaper.postFormData("login", 
+                            payload=payload)
+        # Use shiro's session id to request a JWT
+        COOKIES["JSESSIONID"] = reply.cookies["JSESSIONID"]
+        jwt = reaper.get("jwt")
+        printq("Add the following flag to all subsequent spreaper calls to use your authenticated session : --jwt {}".format(jwt))
+
+        # remove the session id and set the auth header with the JWT
+        COOKIES.pop("JSESSIONID", None)
+
     def ping(self):
         reaper, args = ReaperCLI.prepare_reaper(
             "ping",
@@ -462,7 +463,7 @@ class ReaperCLI(object):
         )
         printq("# Sending PING to Reaper...")
         answer = reaper.get("ping")
-        printq("# [Reply]", answer)
+        printq("# [Reply] {}".format(answer))
         printq("# Cassandra Reaper is answering in: {0}:{1}".format(args.reaper_host, args.reaper_port))
 
     def list_clusters(self):

--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -34,6 +34,8 @@ from json import encoder
 encoder.FLOAT_REPR = lambda o: format(o, '.3f')
 
 USER = getpass.getuser()
+COOKIES = {}
+HEADERS = {}
 DEFAULT_CAUSE = "manual spreaper run"
 
 log_level = logging.WARN
@@ -65,19 +67,22 @@ class ReaperCaller(object):
         self.base_url = "{0}://{1}:{2}".format(use_ssl and 'https' or 'http',
                                                str(host_name), int(host_port))
 
-    def _http_req(self, http_method, the_url, params=None):
+    def _http_req(self, http_method, the_url, cookies={}, params=None):
         http_method = http_method.upper()
         if params is None:
             params = {}
         log.info("making HTTP %s to %s", http_method, the_url)
         if http_method == 'GET':
-            r = requests.get(the_url, params=params)
+            print("headers : {}".format(HEADERS))
+            r = requests.get(the_url, params=params, cookies=cookies, headers=HEADERS)
         elif http_method == 'POST':
-            r = requests.post(the_url, params=params)
+            r = requests.post(the_url, params=params, cookies=cookies, headers=HEADERS)
+        elif http_method == 'POST_FORM':
+            r = requests.post(the_url, data=params)
         elif http_method == 'PUT':
-            r = requests.put(the_url, params=params)
+            r = requests.put(the_url, params=params, cookies=cookies, headers=HEADERS)
         elif http_method == 'DELETE':
-            r = requests.delete(the_url, params=params)
+            r = requests.delete(the_url, params=params, cookies=cookies, headers=HEADERS)
         else:
             assert False, "invalid HTTP method: {0}".format(http_method)
         log.info("HTTP %s return code %s with content of length %s",
@@ -89,23 +94,30 @@ class ReaperCaller(object):
         if 'Location' in r.headers:
           # any non 303/307 response with a 'Location' header, is a successful mutation pointing to the resource
           return self._http_req("GET", r.headers['Location'])
-        return r.text
+        if http_method == 'POST_FORM':
+            return r
+        else:
+            return r.text
 
     def get(self, endpoint):
         the_url = urlparse.urljoin(self.base_url, endpoint)
-        return self._http_req("GET", the_url)
+        return self._http_req("GET", the_url, cookies=COOKIES)
 
     def post(self, endpoint, **params):
         the_url = urlparse.urljoin(self.base_url, endpoint)
-        return self._http_req("POST", the_url, params)
+        return self._http_req("POST", the_url, params=params)
+    
+    def postFormData(self, endpoint, payload):
+        the_url = urlparse.urljoin(self.base_url, endpoint)
+        return self._http_req("POST_FORM", the_url, params=payload)
 
     def put(self, endpoint, **params):
         the_url = urlparse.urljoin(self.base_url, endpoint)
-        return self._http_req("PUT", the_url, params)
+        return self._http_req("PUT", the_url, params=params)
 
     def delete(self, endpoint, **params):
         the_url = urlparse.urljoin(self.base_url, endpoint)
-        return self._http_req("DELETE", the_url, params)
+        return self._http_req("DELETE", the_url, params=params)
 
 
 # === Arguments for commands ============================================================
@@ -134,6 +146,7 @@ def _global_arguments(parser, command):
                        action="store_true")
     group.add_argument("-vv", help="extra output verbosity", action="store_true")
     group.add_argument("-q", "--quiet", help="unix mode", action="store_true")
+    group.add_argument("--username", default=None, help="Username to login with")
     parser.add_argument(command)
 
 
@@ -313,15 +326,16 @@ def _arguments_for_delete_snapshots(parser):
     parser.add_argument("--node", default=None,
                         help=("A single node to get the snapshot list from"))
 
-
-
 def _parse_arguments(command, description, usage=None, extra_arguments=None):
     """Generic argument parsing done by every command"""
     parser = argparse.ArgumentParser(description=description, usage=usage)
     _global_arguments(parser, command)
     if extra_arguments:
         extra_arguments(parser)
-    return parser.parse_args()
+    if (command == "login"):
+        return parser.parse_known_args()
+    else:
+        return parser.parse_args()
 
 
 # === The actual CLI ========================================================================
@@ -398,10 +412,48 @@ class ReaperCLI(object):
             exit(2)
 
     @staticmethod
+    def prepare_reaper_for_login(command, description, usage=None, extra_arguments=None):
+        (args, ignored) = _parse_arguments(command, description, usage, extra_arguments)
+        reaper = ReaperCaller(args.reaper_host, args.reaper_port, args.reaper_use_ssl)
+        return reaper, args
+
+    @staticmethod
     def prepare_reaper(command, description, usage=None, extra_arguments=None):
         args = _parse_arguments(command, description, usage, extra_arguments)
         reaper = ReaperCaller(args.reaper_host, args.reaper_port, args.reaper_use_ssl)
+        ReaperCLI.login(reaper, args)
         return reaper, args
+
+    @staticmethod
+    def login(reaper, args):
+        if (args.username != None):
+            reaper, args = ReaperCLI.prepare_reaper_for_login(
+                "login",
+                "Authenticate to Reaper"
+            )
+            password = ReaperCLI.get_password()
+            printq("# Logging in...")
+            payload = {'username':args.username, 'password':password, 'rememberMe':False}
+            reply = reaper.postFormData("login", 
+                                payload=payload)
+            # Use shiro's session id to request a JWT
+            COOKIES["JSESSIONID"] = reply.cookies["JSESSIONID"]
+            jwt = reaper.get("jwt")
+
+            # remove the session id and set the auth header with the JWT
+            COOKIES.pop("JSESSIONID", None)
+            HEADERS['Authorization'] = 'Bearer ' + jwt
+    
+    @staticmethod
+    def get_password():
+        password = None
+        # Use the password from the file if it exists or prompt the user for it
+        if (os.path.exists(os.path.expanduser('~/.reaper'))):
+            password = file(os.path.expanduser('~/.reaper'),'rU').readline().rstrip("\r\n")
+        else:
+            password = getpass.getpass()
+        
+        return password
 
     def ping(self):
         reaper, args = ReaperCLI.prepare_reaper(

--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2014-2017 Spotify AB
-# Copyright 2016-2018 The Last Pickle Ltd
+# Copyright 2016-2019 The Last Pickle Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import getpass
 import json
 import logging
 import os
+import subprocess
 import urllib
 import urlparse
 
@@ -88,7 +89,8 @@ class ReaperCaller(object):
                  http_method, r.status_code, len(str(r.text)))
         log.debug("Response content:\n%s", r.text)
         if str(r.status_code) == "403":
-            printq("Access to this operation seems to be restricted. You may need to login and pass a JWT to access it.")
+            printq("Access to this operation seems to be restricted. Please login before making any call to the API:")
+            printq("spreaper login <username>")
         if not str(r.status_code).startswith("2"):
             print r.text
         r.raise_for_status()
@@ -147,7 +149,7 @@ def _global_arguments(parser, command):
                        action="store_true")
     group.add_argument("-vv", help="extra output verbosity", action="store_true")
     group.add_argument("-q", "--quiet", help="unix mode", action="store_true")
-    group.add_argument("--jwt", default=None, help="Session JSON Web Token obtained at login")
+    group.add_argument("--jwt", default=None, help="JSON Web Token (JWT) to authenticate with")
     parser.add_argument(command)
 
 
@@ -329,7 +331,7 @@ def _arguments_for_delete_snapshots(parser):
 
 def _arguments_for_login(parser):
     """Arguments needed to login"""
-    parser.add_argument("--username", help="Username to login with")
+    parser.add_argument("username", help="Username to login with")
 
 def _parse_arguments(command, description, usage=None, extra_arguments=None):
     """Generic argument parsing done by every command"""
@@ -418,24 +420,49 @@ class ReaperCLI(object):
     def prepare_reaper(command, description, usage=None, extra_arguments=None):
         args = _parse_arguments(command, description, usage, extra_arguments)
         reaper = ReaperCaller(args.reaper_host, args.reaper_port, args.reaper_use_ssl)
-        ReaperCLI.addJwtHeader(args)
+        jwt = ReaperCLI.get_jwt(args)
+        ReaperCLI.addJwtHeader(jwt)
         return reaper, args
 
     @staticmethod
-    def addJwtHeader(args):
-        if (args.jwt != None):
-            HEADERS['Authorization'] = 'Bearer ' + args.jwt
+    def addJwtHeader(jwt):
+        if (jwt != None):
+            HEADERS['Authorization'] = 'Bearer ' + jwt
     
     @staticmethod
     def get_password():
         password = None
         # Use the password from the file if it exists or prompt the user for it
-        if (os.path.exists(os.path.expanduser('~/.reaper'))):
-            password = file(os.path.expanduser('~/.reaper'),'rU').readline().rstrip("\r\n")
+        if (os.path.exists(os.path.expanduser('~/.reaper/credentials'))):
+            password = file(os.path.expanduser('~/.reaper/credentials'),'rU').readline().rstrip("\r\n")
         else:
             password = getpass.getpass()
         
         return password
+    
+    @staticmethod
+    def get_jwt(args):
+        jwt = None
+        if args.jwt == None:
+            # Use the password from the file if it exists or prompt the user for it
+            if (os.path.exists(os.path.expanduser('~/.reaper/jwt'))):
+                jwt = file(os.path.expanduser('~/.reaper/jwt'),'rU').readline().rstrip("\r\n")
+        else:
+            jwt = args.jwt
+        
+        return jwt
+
+    @staticmethod
+    def save_jwt(jwt):
+        try:
+            os.makedirs(os.path.expanduser('~/.reaper'))
+            os.chmod(os.path.expanduser('~/.reaper'),0700)
+        except OSError:
+            pass
+        with open(os.path.expanduser('~/.reaper/jwt'),'w+') as f:
+            f.write(jwt)
+            os.chmod(os.path.expanduser('~/.reaper/jwt'),0600)
+            printq("# JWT saved")
 
     def login(self):
         reaper, args = ReaperCLI.prepare_reaper(
@@ -451,7 +478,8 @@ class ReaperCLI(object):
         # Use shiro's session id to request a JWT
         COOKIES["JSESSIONID"] = reply.cookies["JSESSIONID"]
         jwt = reaper.get("jwt")
-        printq("Add the following flag to all subsequent spreaper calls to use your authenticated session : --jwt {}".format(jwt))
+        printq("You are now authenticated to Reaper.")
+        ReaperCLI.save_jwt(jwt)
 
         # remove the session id and set the auth header with the JWT
         COOKIES.pop("JSESSIONID", None)
@@ -461,6 +489,7 @@ class ReaperCLI(object):
             "ping",
             "Test connectivity to the Reaper service."
         )
+        printq("# JWT: {}".format(os.environ.get("REAPER_JWT")))
         printq("# Sending PING to Reaper...")
         answer = reaper.get("ping")
         printq("# [Reply] {}".format(answer))

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
@@ -52,7 +52,8 @@ public final class ShiroJwtVerifyingFilter extends AccessControlFilter {
         String user = claims.getBody().getSubject();
         return Strings.hasText(user);
       } catch (JwtException | IllegalArgumentException e) {
-        LOG.error("Failed validating JWT: " + jwt, e);
+        LOG.error("Failed validating JWT {} from {}", jwt, httpRequest.getRemoteAddr());
+        LOG.debug("exception", e);
       }
     }
     return false;


### PR DESCRIPTION
spreaper will now accept --username and --password for all operations.
A login will be performed before running the desired command and the login JSESSIONID cookie will be added to all HTTP requests.