### PR TITLE
Fix for #613 when driver class is missing from config

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -67,6 +67,7 @@ import io.dropwizard.setup.Environment;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.MetricsServlet;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.flywaydb.core.Flyway;
@@ -332,7 +333,13 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
         || "database".equalsIgnoreCase(config.getStorageType())) {
       // create DBI instance
       final DBIFactory factory = new DBIFactory();
-
+      if (StringUtils.isEmpty(config.getDataSourceFactory().getDriverClass())
+          && "postgres".equalsIgnoreCase(config.getStorageType())) {
+        config.getDataSourceFactory().setDriverClass("org.postgresql.Driver");
+      } else if (StringUtils.isEmpty(config.getDataSourceFactory().getDriverClass())
+          && "h2".equalsIgnoreCase(config.getStorageType())) {
+        config.getDataSourceFactory().setDriverClass("org.h2.Driver");
+      }
       // instanciate store
       storage = new PostgresStorage(factory.build(environment, config.getDataSourceFactory(), "postgresql"));
       initDatabase(config);

--- a/src/server/src/test/resources/cassandra-reaper-postgres-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-postgres-at.yaml
@@ -61,7 +61,6 @@ jmxCredentials:
 
 # database section will be ignored if storageType is set to "memory"
 postgres:
-  driverClass: org.postgresql.Driver
   user: postgres
   password:
   url: jdbc:postgresql://127.0.0.1/reaper


### PR DESCRIPTION
When using h2 or postgres as storage, Reaper will expect a driver class to be passed and a classloader failure triggers if it's missing. This patch enforces the DriverClass if it's missing for both h2 and postgres and avoid the exception.