### PR TITLE
Improve how repair segments check whether they can start or not

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -130,9 +130,11 @@ public final class RepairSegment {
   }
 
   public enum State {
+    // don't change order or insert items (ordial is used in db)
     NOT_STARTED,
     RUNNING,
-    DONE
+    DONE,
+    STARTED
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")

--- a/src/server/src/main/java/io/cassandrareaper/jmx/ClusterFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/ClusterFacade.java
@@ -440,9 +440,7 @@ public final class ClusterFacade {
    */
   public boolean nodeIsAccessibleThroughJmx(String nodeDc, String node) {
     return DatacenterAvailability.ALL == context.config.getDatacenterAvailability()
-        || DatacenterAvailability.LOCAL == context.config.getDatacenterAvailability()
-        || (DatacenterAvailability.EACH == context.config.getDatacenterAvailability()
-            && context.jmxConnectionFactory.getAccessibleDatacenters().contains(nodeDc));
+        || context.jmxConnectionFactory.getAccessibleDatacenters().contains(nodeDc);
   }
 
   /**

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -43,7 +43,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
@@ -69,7 +68,7 @@ public final class RepairManager implements AutoCloseable {
 
   private RepairManager(
       AppContext context,
-      Supplier<ClusterFacade> clusterFacadeSupplier,
+      ClusterFacade clusterFacade,
       ScheduledExecutorService executor,
       long repairTimeout,
       TimeUnit repairTimeoutTimeUnit,
@@ -77,7 +76,7 @@ public final class RepairManager implements AutoCloseable {
       TimeUnit retryDelayTimeUnit)  {
 
     this.context = context;
-    this.clusterFacade = clusterFacadeSupplier.get();
+    this.clusterFacade = clusterFacade;
     this.heart = Heart.create(context);
     this.repairTimeoutMillis = repairTimeoutTimeUnit.toMillis(repairTimeout);
     this.retryDelayMillis = retryDelayTimeUnit.toMillis(retryDelay);
@@ -89,7 +88,7 @@ public final class RepairManager implements AutoCloseable {
   @VisibleForTesting
   static RepairManager create(
       AppContext context,
-      Supplier<ClusterFacade> clusterFacadeSupplier,
+      ClusterFacade clusterFacadeSupplier,
       ScheduledExecutorService executor,
       long repairTimeout,
       TimeUnit repairTimeoutTimeUnit,
@@ -116,7 +115,7 @@ public final class RepairManager implements AutoCloseable {
 
     return create(
         context,
-        () -> ClusterFacade.create(context),
+        ClusterFacade.create(context),
         executor,
         repairTimeout,
         repairTimeoutTimeUnit,
@@ -365,7 +364,7 @@ public final class RepairManager implements AutoCloseable {
 
       LOG.info("scheduling repair for repair run #{}", runId);
       try {
-        RepairRunner newRunner = RepairRunner.create(context, runId);
+        RepairRunner newRunner = RepairRunner.create(context, runId, clusterFacade);
         repairRunners.put(runId, newRunner);
         executor.submit(newRunner);
       } catch (ReaperException e) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -105,7 +105,6 @@ import systems.composable.dropwizard.cassandra.retry.RetryPolicyFactory;
 
 public final class CassandraStorage implements IStorage, IDistributedStorage {
 
-  private static final int LEAD_DURATION = 600;
   /* Simple stmts */
   private static final String SELECT_CLUSTER = "SELECT * FROM cluster";
   private static final String SELECT_REPAIR_SCHEDULE = "SELECT * FROM repair_schedule_v1";
@@ -389,10 +388,10 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     takeLeadPrepStmt = session
         .prepare(
             "INSERT INTO leader(leader_id, reaper_instance_id, reaper_instance_host, last_heartbeat)"
-                + "VALUES(?, ?, ?, " + timeUdf + "(now())) IF NOT EXISTS USING TTL ?");
+                + "VALUES(?, ?, ?, " + timeUdf + "(now())) IF NOT EXISTS");
     renewLeadPrepStmt = session
         .prepare(
-            "UPDATE leader USING TTL ? SET reaper_instance_id = ?, reaper_instance_host = ?,"
+            "UPDATE leader SET reaper_instance_id = ?, reaper_instance_host = ?,"
                 + " last_heartbeat = " + timeUdf + "(now()) WHERE leader_id = ? IF reaper_instance_id = ?");
     releaseLeadPrepStmt = session.prepare("DELETE FROM leader WHERE leader_id = ? IF reaper_instance_id = ?");
     forceReleaseLeadPrepStmt = session.prepare("DELETE FROM leader WHERE leader_id = ?");
@@ -853,6 +852,9 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
               segment.getRunId(),
               segment.getId(),
               segment.hasEndTime() ? segment.getEndTime().toDate() : null));
+
+    } else if (State.STARTED == segment.getState()) {
+      updateRepairSegmentBatch.setConsistencyLevel(ConsistencyLevel.EACH_QUORUM);
     }
     session.execute(updateRepairSegmentBatch);
     return true;
@@ -937,12 +939,15 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   public Collection<RepairSegment> getSegmentsWithState(UUID runId, State segmentState) {
     Collection<RepairSegment> segments = Lists.newArrayList();
 
-    ResultSet segmentsIdResultSet = null != getRepairSegmentsByRunIdAndStatePrepStmt
-        ? session.execute(getRepairSegmentsByRunIdAndStatePrepStmt.bind(runId, segmentState.ordinal()))
+    Statement statement = null != getRepairSegmentsByRunIdAndStatePrepStmt
+        ? getRepairSegmentsByRunIdAndStatePrepStmt.bind(runId, segmentState.ordinal())
         // legacy mode for Cassandra-2 backends
-        : session.execute(getRepairSegmentsByRunIdPrepStmt.bind(runId));
+        : getRepairSegmentsByRunIdPrepStmt.bind(runId);
 
-    for (Row segmentRow : segmentsIdResultSet) {
+    if (State.STARTED == segmentState) {
+      statement = statement.setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM);
+    }
+    for (Row segmentRow : session.execute(statement)) {
       if (segmentRow.getInt("segment_state") == segmentState.ordinal()) {
         segments.add(createRepairSegmentFromRow(segmentRow));
       }
@@ -1212,14 +1217,9 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   @Override
   public boolean takeLead(UUID leaderId) {
-    return takeLead(leaderId, LEAD_DURATION);
-  }
-
-  @Override
-  public boolean takeLead(UUID leaderId, int ttl) {
     LOG.debug("Trying to take lead on segment {}", leaderId);
     ResultSet lwtResult = session.execute(
-        takeLeadPrepStmt.bind(leaderId, AppContext.REAPER_INSTANCE_ID, AppContext.REAPER_INSTANCE_ADDRESS, ttl));
+        takeLeadPrepStmt.bind(leaderId, AppContext.REAPER_INSTANCE_ID, AppContext.REAPER_INSTANCE_ADDRESS));
 
     if (lwtResult.wasApplied()) {
       LOG.debug("Took lead on segment {}", leaderId);
@@ -1233,14 +1233,8 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
   @Override
   public boolean renewLead(UUID leaderId) {
-    return renewLead(leaderId, LEAD_DURATION);
-  }
-
-  @Override
-  public boolean renewLead(UUID leaderId, int ttl) {
     ResultSet lwtResult = session.execute(
         renewLeadPrepStmt.bind(
-            ttl,
             AppContext.REAPER_INSTANCE_ID,
             AppContext.REAPER_INSTANCE_ADDRESS,
             leaderId,
@@ -1287,7 +1281,6 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   private boolean hasLeadOnSegment(UUID leaderId) {
     ResultSet lwtResult = session.execute(
         renewLeadPrepStmt.bind(
-            LEAD_DURATION,
             AppContext.REAPER_INSTANCE_ID,
             AppContext.REAPER_INSTANCE_ADDRESS,
             leaderId,

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -32,11 +32,7 @@ public interface IDistributedStorage {
 
   boolean takeLead(UUID leaderId);
 
-  boolean takeLead(UUID leaderId, int ttl);
-
   boolean renewLead(UUID leaderId);
-
-  boolean renewLead(UUID leaderId, int ttl);
 
   List<UUID> getLeaders();
 

--- a/src/server/src/test/java/io/cassandrareaper/jmx/ClusterFacadeTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/ClusterFacadeTest.java
@@ -38,13 +38,12 @@ public class ClusterFacadeTest {
     final AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.jmxConnectionFactory = Mockito.mock(JmxConnectionFactory.class);
+
     Mockito.when(context.jmxConnectionFactory.getAccessibleDatacenters())
-        .thenReturn(new HashSet<String>(Arrays.asList("dc1")));
+        .thenReturn(new HashSet<>(Arrays.asList("dc1")));
 
     context.config.setDatacenterAvailability(DatacenterAvailability.ALL);
-    assertTrue(
-        ClusterFacade.create(context)
-            .nodeIsAccessibleThroughJmx("dc1", "127.0.0.1"));
+    assertTrue( ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc1", "127.0.0.1"));
     assertTrue(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc2", "127.0.0.2"));
   }
 
@@ -53,13 +52,13 @@ public class ClusterFacadeTest {
     final AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.jmxConnectionFactory = Mockito.mock(JmxConnectionFactory.class);
+
     Mockito.when(context.jmxConnectionFactory.getAccessibleDatacenters())
-        .thenReturn(new HashSet<String>(Arrays.asList("dc1")));
+        .thenReturn(new HashSet<>(Arrays.asList("dc1")));
 
     context.config.setDatacenterAvailability(DatacenterAvailability.LOCAL);
-    assertTrue(
-        ClusterFacade.create(context).nodeIsAccessibleThroughJmx(
-            "dc2", "127.0.0.2")); // it's in another DC but LOCAL allows attempting it
+    // it's in another DC so LOCAL disallows attempting it
+    assertFalse(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc2", "127.0.0.2"));
     // Should be accessible, same DC
     assertTrue(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc1", "127.0.0.2"));
   }
@@ -69,13 +68,13 @@ public class ClusterFacadeTest {
     final AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.jmxConnectionFactory = Mockito.mock(JmxConnectionFactory.class);
+
     Mockito.when(context.jmxConnectionFactory.getAccessibleDatacenters())
-        .thenReturn(new HashSet<String>(Arrays.asList("dc1")));
+        .thenReturn(new HashSet<>(Arrays.asList("dc1")));
 
     context.config.setDatacenterAvailability(DatacenterAvailability.EACH);
-    assertFalse(
-        ClusterFacade.create(context).nodeIsAccessibleThroughJmx(
-            "dc2", "127.0.0.2")); // Should not be accessible as it's in another DC
+    // Should not be accessible as it's in another DC
+    assertFalse(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc2", "127.0.0.2"));
     // Should be accessible, same DC
     assertTrue(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc1", "127.0.0.2"));
   }

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -41,12 +41,12 @@ Feature: Using Reaper
     And that we are going to use "127.0.0.1@test" as cluster seed host
     And reaper has no cluster in storage
     When an add-cluster request is made to reaper
-    And we can collect the tpstats from the seed node
-    And we can collect the dropped messages stats from the seed node
-    And we can collect the client request metrics from the seed node
     Then reaper has the last added cluster in storage
     And the seed node has vnodes
     And reaper has 0 scheduled repairs for the last added cluster
+    And we can collect the tpstats from the seed node
+    And we can collect the dropped messages stats from the seed node
+    And we can collect the client request metrics from the seed node
     When a new daily "full" repair schedule is added for the last added cluster and keyspace "booya"
     Then reaper has 1 scheduled repairs for the last added cluster
     When reaper is upgraded to latest

--- a/src/ui/app/jsx/segment-list.jsx
+++ b/src/ui/app/jsx/segment-list.jsx
@@ -133,7 +133,7 @@ const SegmentList = React.createClass({
         }
 
       if(this.state.segments !== null) {
-          runningSegments = this.state.segments.filter(segment => segment.state === 'RUNNING');
+          runningSegments = this.state.segments.filter(segment => segment.state === 'RUNNING' || segment.state === 'STARTED');
           rowsRunning = runningSegments.sort(compareByStartDate).map(segment =>
               <tbody key={segment.id+'-rows'}>
               <Segment segment={segment} key={segment.id+'-head'} urlPrefix={this.state.urlPrefix} refreshSegments={this._refreshSegments} notify={this._toast}/>
@@ -368,7 +368,7 @@ const Segment = React.createClass({
                 <td>{this.props.segment.failCount}</td>
                 <td><Button bsStyle='primary'>{this.props.segment.state}</Button></td>
             </tr>
-        } else if (this.props.segment.state === 'RUNNING') {
+        } else if (this.props.segment.state === 'RUNNING' || this.props.segment.state === 'STARTED') {
             return  <tr>
                 <td>{this.props.segment.id}</td>
                 <td>{this.props.segment.tokenRange.baseRange.start}</td>


### PR DESCRIPTION
Improve how repair segments check whether they can start or not
 - simplify (reduce) logic in SegmentRunner.canRepair(..)
 - incremental repairs really checking for running repairs will have to use metrics grabbing as well
 - introduce State.STARTED
 - use strict consistency when changing a repair segment from NOT_STARTED to STARTED state

ref: https://github.com/thelastpickle/cassandra-reaper/pull/622/files#r262413082