### PR TITLE
Small fix for webUI auth.

### DIFF
--- a/src/server/src/main/docker/configure-webui-authentication.sh
+++ b/src/server/src/main/docker/configure-webui-authentication.sh
@@ -38,6 +38,7 @@ fi
 
 if [ ! -z "${REAPER_AUTH_USER}" ]; then
 cat <<EOT2 >> /etc/shiro.ini
+
 ${REAPER_AUTH_USER} = ${REAPER_AUTH_PASSWORD}
 EOT2
 fi


### PR DESCRIPTION
There is no next line before the username so it creates wrong entry.  For example for user: foo
The entry in shiro.ini looks like this:
[users]foo = bar

Causing: 
```
java.lang.IllegalArgumentException: There is no filter with name '"foo"' to apply to chain [[users]"foo"] in the pool of available Filters.
```

Adding next line in cat solves it :)