### PR TITLE
Restore compatibility with Cassandra 1.2 & 2.0

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/Table.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/Table.java
@@ -21,12 +21,22 @@ import com.google.common.base.Preconditions;
 
 public final class Table {
 
+  /**
+   * Default compaction strategy, used when the strategy cannot be retrieved from JMX. The
+   * information is only available since Cassandra 2.1
+   */
+  private static final String DEFAULT_COMPACTION_STRATEGY = "SizeTieredCompactionStrategy";
+
   private final String name;
   private final String compactionStrategy;
 
   private Table(Builder builder) {
     this.name = builder.name;
-    this.compactionStrategy = builder.compactionStrategy;
+    if (builder.compactionStrategy != null) {
+      this.compactionStrategy = builder.compactionStrategy;
+    } else {
+      this.compactionStrategy = DEFAULT_COMPACTION_STRATEGY;
+    }
   }
 
   public String getName() {
@@ -41,6 +51,7 @@ public final class Table {
     return new Builder();
   }
 
+  @Override
   public String toString() {
     return String.format("{name=%s, compactionStrategy=%s}", name, compactionStrategy);
   }
@@ -69,7 +80,6 @@ public final class Table {
 
     public Table build() {
       Preconditions.checkNotNull(name, "`.withName(..)` must be called before `.build()`");
-      Preconditions.checkNotNull(compactionStrategy, "`.withCompactionStrategy(..)` must be called before `.build()`");
       return new Table(this);
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/core/Table.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/Table.java
@@ -25,7 +25,7 @@ public final class Table {
    * Default compaction strategy, used when the strategy cannot be retrieved from JMX. The
    * information is only available since Cassandra 2.1
    */
-  private static final String DEFAULT_COMPACTION_STRATEGY = "SizeTieredCompactionStrategy";
+  private static final String DEFAULT_COMPACTION_STRATEGY = "UNKNOWN";
 
   private final String name;
   private final String compactionStrategy;

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
@@ -140,7 +140,7 @@ final class JmxProxyImpl implements JmxProxy {
   }
 
   /**
-   * @see JmxProxy#connect(Optional, String, int, String, String, EC2MultiRegionAddressTranslator)
+   * @see #connect(String, int, String, String, EC2MultiRegionAddressTranslator, int, MetricRegistry)
    */
   static JmxProxy connect(
       String host,
@@ -537,8 +537,7 @@ final class JmxProxyImpl implements JmxProxy {
 
     Preconditions.checkNotNull(ssProxy, "Looks like the proxy is not connected");
     String cassandraVersion = getCassandraVersion();
-    boolean canUseDatacenterAware = false;
-    canUseDatacenterAware = versionCompare(cassandraVersion, "2.0.12") >= 0;
+    final boolean canUseDatacenterAware = versionCompare(cassandraVersion, "2.0.12") >= 0;
 
     String msg = String.format(
         "Triggering repair of range (%s,%s] for keyspace \"%s\" on "

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
@@ -93,6 +93,32 @@ public final class RepairUnitServiceTest {
   }
 
   @Test
+  public void getTablesToRepairDefaultCompactionStrategyTable() throws ReaperException {
+    JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
+
+    when(context.jmxConnectionFactory.connectAny(cluster))
+          .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
+          .thenReturn(proxy);
+
+    when(proxy.getTablesForKeyspace(Mockito.anyString()))
+          .thenReturn(Sets.newHashSet(
+                Table.builder().withName("table1").build(),
+                Table.builder().withName("table2").build(),
+                Table.builder().withName("table3").build()));
+
+    RepairUnit unit = RepairUnit.builder()
+          .clusterName(cluster.getName())
+          .keyspaceName("test")
+          .blacklistedTables(Sets.newHashSet("table1"))
+          .incrementalRepair(false)
+          .repairThreadCount(4)
+          .build(UUIDs.timeBased());
+
+    assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(proxy, cluster, unit));
+  }
+
+  @Test
   public void getTablesToRepairRemoveOneTableWithTwcsTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
 


### PR DESCRIPTION
Fixes #629.

As [`ColumnFamilyStoreMBean.getCompactionParameters()`](https://github.com/apache/cassandra/blob/9bb75358dfdf1b9824f9a454e70ee2c02bc64a45/src/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java#L331) is only available since Cassandra 2.1, this PR restore compatibility with older versions which doesn't expose this method. 

On such versions, the default compaction strategy is used (`TimeWindowCompactionStrategy` & `DateTieredCompactionStrategy` strategies are not available for those versions).

This PR also configures Travis CI to run integration tests with Cassandra versions 1.2.19 & 2.0.17 (hopefully since I have no clue how to test this).

I've manually deployed this version on my cluster running Cassandra 1.2.19 and so far it's running repairs properly.