### PR TITLE
Travis: enable integration tests under versions 1.2.19 & 2.0.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,13 @@ jobs:
   - env: TEST_TYPE=upgrade CASSANDRA_VERSION=git:trunk CO="-t ~@all_nodes_reachable"
   include:
     - stage: Integration Tests
-      name: Memory, H2 and Postgresql
+      name: Memory, H2 and Postgresql on Cassandra 1.2.19
+      env: TEST_TYPE=ccm CASSANDRA_VERSION=1.2.19 CUCUMBER_OPTIONS="--tags ~@cassandra_2_1_onwards"
+    - stage: Integration Tests
+      name: Memory, H2 and Postgresql on Cassandra 2.0.17
+      env: TEST_TYPE=ccm CASSANDRA_VERSION=2.0.17 CUCUMBER_OPTIONS="--tags ~@cassandra_2_1_onwards"
+    - stage: Integration Tests
+      name: Memory, H2 and Postgresql on Cassandra 2.1.20
       env: TEST_TYPE=ccm CASSANDRA_VERSION=2.1.20
     - stage: Integration Tests
       name: Cassandra 2.1.20
@@ -70,7 +76,7 @@ jobs:
       name: Cassandra 4.0
       env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk GRIM_MIN=1 GRIM_MAX=1
     - stage: Distributed Reaper Integration Tests
-      name: Two Reapers on  Cassandra 2.1.20
+      name: Two Reapers on Cassandra 2.1.20
       env: TEST_TYPE=ccm CASSANDRA_VERSION=2.1.20 GRIM_MIN=2 GRIM_MAX=2
     - stage: Distributed Reaper Integration Tests
       name: Two Reapers on Cassandra 2.2.13

--- a/src/server/src/test/resources/cassandra-reaper-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-at.yaml
@@ -29,10 +29,7 @@ jmxConnectionTimeoutInSeconds: 300
 datacenterAvailability: LOCAL
 
 logging:
-  level: INFO
-  loggers:
-    io.cassandrareaper: DEBUG
-    com.datastax.driver: WARN
+  level: WARN
   appenders:
     - type: console
 

--- a/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
@@ -28,9 +28,7 @@ jmxConnectionTimeoutInSeconds: 300
 datacenterAvailability: LOCAL
 
 logging:
-  level: INFO
-  loggers:
-    io.cassandrareaper: DEBUG
+  level: WARN
   appenders:
     - type: console
 

--- a/src/server/src/test/resources/cassandra-reaper-postgres-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-postgres-at.yaml
@@ -28,9 +28,7 @@ jmxConnectionTimeoutInSeconds: 300
 datacenterAvailability: LOCAL
 
 logging:
-  level: INFO
-  loggers:
-    io.cassandrareaper: DEBUG
+  level: WARN
   appenders:
     - type: console
 

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -215,6 +215,7 @@ Feature: Using Reaper
   ${cucumber.upgrade-versions}
 
   @all_nodes_reachable
+  @cassandra_2_1_onwards
   Scenario Outline: Create a cluster, create a cluster wide snapshot and delete it
     Given that reaper <version> is running
     And that we are going to use "127.0.0.1@test" as cluster seed host
@@ -234,6 +235,7 @@ Feature: Using Reaper
 
 
   @all_nodes_reachable
+  @cassandra_2_1_onwards
   Scenario Outline: Create a cluster, create a snapshot on a single host and delete it
     Given that reaper <version> is running
     And that we are going to use "127.0.0.1@test" as cluster seed host

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -84,6 +84,7 @@ Feature: Using Reaper
   ${cucumber.upgrade-versions}
 
   @all_nodes_reachable
+  @cassandra_2_1_onwards
   Scenario Outline: Adding a scheduled full repair and a scheduled incremental repair for the same keyspace
     Given that reaper <version> is running
     And that we are going to use "127.0.0.1@test" as cluster seed host
@@ -133,7 +134,7 @@ Feature: Using Reaper
     And reaper has 0 repairs for the last added cluster
     When a new repair is added for the last added cluster and keyspace "booya" with the table "booya2" blacklisted
     And the last added repair has table "booya2" in the blacklist
-    And the last added repair has table "booya_twcs" in the blacklist
+    And the last added repair has twcs table "booya_twcs" in the blacklist
     When reaper is upgraded to latest
     And the last added repair has table "booya2" in the blacklist
     And deleting the last added cluster fails
@@ -169,6 +170,7 @@ Feature: Using Reaper
  ${cucumber.upgrade-versions}
 
   @all_nodes_reachable
+  @cassandra_2_1_onwards
   Scenario Outline: Create a cluster and an incremental repair run and delete them
     Given that reaper <version> is running
     And that we are going to use "127.0.0.1@test" as cluster seed host
@@ -190,6 +192,7 @@ Feature: Using Reaper
   ${cucumber.upgrade-versions}
 
   @all_nodes_reachable
+  @cassandra_2_1_onwards
   Scenario Outline: Create a cluster and one incremental repair run and one full repair run
     Given that reaper <version> is running
     And that we are going to use "127.0.0.1@test" as cluster seed host


### PR DESCRIPTION
As discussed under #629 we may want to extend integration tests to run with older Cassandra versions.

~~As of now the tests will fail since they attempt to start an incremental repair which is only supported from versions 2.1 onwards.~~