### PR TITLE
Remove used options "localJmxMode" from docs

### DIFF
--- a/docs/docs/configuration/reaper_specific/index.html
+++ b/docs/docs/configuration/reaper_specific/index.html
@@ -517,16 +517,6 @@ To match the example above, it could be something like : <code>10.0.10.5@cluster
 
 <p><br/></p>
 
-<h3 id="localjmxmode"><code>localJmxMode</code></h3>
-
-<p>Type: <em>Boolean</em></p>
-
-<p>Default: <em>false</em></p>
-
-<p>Activates the mode where JMX is only accessible from localhost. If set to true, one Reaper instance must be running on each Cassandra node.</p>
-
-<p><br/></p>
-
 <h3 id="logging"><code>logging</code></h3>
 
 <p>Settings to configure Reaper logging.</p>

--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -215,16 +215,6 @@ Optional mapping of custom JMX ports to use for individual hosts. The used defau
 
 <br/>
 
-### `localJmxMode`
-
-Type: *Boolean*
-
-Default: *false*
-
-Activates the mode where JMX is only accessible from localhost. If set to true, one Reaper instance must be running on each Cassandra node.
-
-<br/>
-
 ### `logging`
 
 Settings to configure Reaper logging.


### PR DESCRIPTION
As discussed in https://github.com/thelastpickle/cassandra-reaper/issues/643, the "localJmxMode" options is unused. It may confused new user who first use Reaper.
