### PR TITLE
In SegmentRunner immediately release the segment lead once the segment repair is done

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -138,18 +138,20 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
 
   @Override
   public void run() {
+    boolean ran = false;
     if (takeLead()) {
       try {
-        if (runRepair()) {
-          long delay = intensityBasedDelayMillis(intensity);
-          try {
-            Thread.sleep(delay);
-          } catch (InterruptedException e) {
-            LOG.warn("Slept shorter than intended delay.");
-          }
-        }
+        ran = runRepair();
       } finally {
         releaseLead();
+      }
+    }
+    if (ran) {
+      long delay = intensityBasedDelayMillis(intensity);
+      try {
+        Thread.sleep(delay);
+      } catch (InterruptedException e) {
+        LOG.warn("Slept shorter than intended delay.");
       }
     }
   }


### PR DESCRIPTION
 The intensity pause can happen afterwards.

This removes the following erroneous exceptions
```
java.lang.AssertionError: Could not release lead on segment fc24804a-6c1e-11e9-8690-db9605b58a82
    at io.cassandrareaper.storage.CassandraStorage.releaseLead(CassandraStorage.java:1240)
    at io.cassandrareaper.service.SegmentRunner.releaseLead(SegmentRunner.java:1148)
    at io.cassandrareaper.service.SegmentRunner.run(SegmentRunner.java:152)
```