### PR TITLE
WIP – Pass the currentCluster param through to the `/repair_run` REST endpoint

### DIFF
--- a/src/ui/app/observable.js
+++ b/src/ui/app/observable.js
@@ -200,7 +200,8 @@ export const repairs = Rx.Observable.merge(
     updateRepairIntensityResult
   ).map(s =>
     s.flatMap(t => Rx.Observable.fromPromise($.ajax({
-        url: `${URL_PREFIX}/repair_run`
+        url: `${URL_PREFIX}/repair_run`,
+        data: { cluster: s.currentCluster }
       }).promise())
     ).map(arr=>arr.reverse())
 );


### PR DESCRIPTION
This will reduce load and latency of the query.