### PR TITLE
Fix (improve pass rate of) integration tests  …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,6 @@ aliases:
               ccm create test_2_2 --no-switch -v 2.2.13
               ccm create test_3_0 --no-switch -v 3.0.17
               ccm create test_3_11 --no-switch -v 3.11.3
-              # 4.0 builds are ignored until new ccm version is released and available in pip
-              #   see comment below under "workflows"
-              #ccm create test_trunk --no-switch -v git:trunk
 
         - save_cache:
             paths:
@@ -78,18 +75,17 @@ aliases:
                 ccm create test -v $CASSANDRA_VERSION
                 ccm populate --vnodes -n $NODES_PER_DC:$NODES_PER_DC
                 for i in `seq 1 $(($NODES_PER_DC *2))` ; do
-                  if [ "$i" -le "$NODES_PER_DC" ] ; then
-                    sed -i 's/etc\/cassandra\/jmxremote.password/home\/circleci\/.local\/jmxremote.password/' ~/.ccm/test/node$i/conf/cassandra-env.sh
+                  if [ "$i" -gt "$NODES_PER_DC" ] && [ echo "$JOB_COMMAND" | grep -q "Pskip-tests-needing-all-nodes-reachable" ] ; then
+                    # scenarios that are not tagged with @all_nodes_reachable will be tested with an unreachable DC2
+                    sed -i 's/etc\/cassandra\/jmxremote.password/home\/circleci\/.local\/jmxremote.blank.password/' ~/.ccm/test/node$i/conf/cassandra-env.sh
                   else
-                    if  echo "$JOB_COMMAND" | grep -q "Pskip-tests-needing-all-nodes-reachable"  ; then
-                      # scenarios that are not tagged with @all_nodes_reachable can be tested against an unreachable DC2
-                      sed -i 's/etc\/cassandra\/jmxremote.password/home\/circleci\/.local\/jmxremote.blank.password/' ~/.ccm/test/node$i/conf/cassandra-env.sh
-                    else
-                      # @all_nodes_reachable scenarios need all datacenters+nodes reachable
-                      sed -i 's/etc\/cassandra\/jmxremote.password/home\/circleci\/.local\/jmxremote.password/' ~/.ccm/test/node$i/conf/cassandra-env.sh
-                    fi
+                    sed -i 's/etc\/cassandra\/jmxremote.password/home\/circleci\/.local\/jmxremote.password/' ~/.ccm/test/node$i/conf/cassandra-env.sh
                   fi
-                  sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="136m"/' ~/.ccm/test/node$i/conf/cassandra-env.sh
+                  if echo "$CASSANDRA_VERSION" | grep -q "trunk" ; then
+                    sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="200m"/' ~/.ccm/test/node$i/conf/cassandra-env.sh
+                  else
+                    sed -i 's/#MAX_HEAP_SIZE="4G"/MAX_HEAP_SIZE="136m"/' ~/.ccm/test/node$i/conf/cassandra-env.sh
+                  fi
                   sed -i 's/#HEAP_NEWSIZE="800M"/HEAP_NEWSIZE="112M"/' ~/.ccm/test/node$i/conf/cassandra-env.sh
                   sed -i 's/LOCAL_JMX=yes/LOCAL_JMX=no/' ~/.ccm/test/node$i/conf/cassandra-env.sh
                   sed -i 's/_timeout_in_ms:.*/_timeout_in_ms: 60000/' ~/.ccm/test/node$i/conf/cassandra.yaml
@@ -190,7 +186,7 @@ jobs:
     c_2-1_one-reaper:
       environment:
         CASSANDRA_VERSION: 2.1.20
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
       <<: *default_job
     c_2-1_two-reapers:
       environment:
@@ -200,7 +196,7 @@ jobs:
     c_2-1_flapping-reapers:
       environment:
         CASSANDRA_VERSION: 2.1.20
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx400m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
       <<: *default_job
     c_2-1_one-reaper__all_nodes_reachable:
       environment:
@@ -242,7 +238,7 @@ jobs:
     c_2-2_one-reaper:
       environment:
         CASSANDRA_VERSION: 2.2.13
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
       <<: *default_job
     c_2-2_two-reapers:
       environment:
@@ -252,7 +248,7 @@ jobs:
     c_2-2_flapping-reapers:
       environment:
         CASSANDRA_VERSION: 2.2.13
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx400m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
       <<: *default_job
     c_2-2_one-reaper__all_nodes_reachable:
       environment:
@@ -294,7 +290,7 @@ jobs:
     c_3-0_one-reaper:
       environment:
         CASSANDRA_VERSION: 3.0.17
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
       <<: *default_job
     c_3-0_two-reapers:
       environment:
@@ -304,7 +300,7 @@ jobs:
     c_3-0_flapping-reapers:
       environment:
         CASSANDRA_VERSION: 3.0.17
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx400m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
       <<: *default_job
     c_3-0_one-reaper__all_nodes_reachable:
       environment:
@@ -346,7 +342,7 @@ jobs:
     c_3-11_one-reaper:
       environment:
         CASSANDRA_VERSION: 3.11.3
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
       <<: *default_job
     c_3-11_two-reapers:
       environment:
@@ -356,7 +352,7 @@ jobs:
     c_3-11_flapping-reapers:
       environment:
         CASSANDRA_VERSION: 3.11.3
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx400m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
       <<: *default_job
     c_3-11_one-reaper__all_nodes_reachable:
       environment:
@@ -387,55 +383,65 @@ jobs:
       <<: *default_job
     c_4-0_memory:
       environment:
-        CASSANDRA_VERSION: git:trunk
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
         JOB_COMMAND: mvn surefire:test -B -DsurefireArgLine="-Xmx256m" -Dtest=ReaperIT -Pskip-tests-needing-all-nodes-reachable
       <<: *default_job
     c_4-0_h2:
       environment:
-        CASSANDRA_VERSION: git:trunk
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
         JOB_COMMAND: mvn surefire:test -B -DsurefireArgLine="-Xmx256m" -Dtest=ReaperH2IT -Pskip-tests-needing-all-nodes-reachable
       <<: *default_job
     c_4-0_one-reaper:
       environment:
-        CASSANDRA_VERSION: git:trunk
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable
       <<: *default_job
     c_4-0_two-reapers:
       environment:
-        CASSANDRA_VERSION: git:trunk
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=2
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=2
       <<: *default_job
     c_4-0_flapping-reapers:
       environment:
-        CASSANDRA_VERSION: git:trunk
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx398m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx400m" -Dtest=ReaperCassandraIT -Pskip-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
       <<: *default_job
     c_4-0_one-reaper__all_nodes_reachable:
       environment:
-        CASSANDRA_VERSION: git:trunk
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Ponly-tests-needing-all-nodes-reachable
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Ponly-tests-needing-all-nodes-reachable
       <<: *default_job
     c_4-0_two-reapers__all_nodes_reachable:
       environment:
-        CASSANDRA_VERSION: git:trunk
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx384m" -Dtest=ReaperCassandraIT -Ponly-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=2
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Ponly-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=2
       <<: *default_job
     c_4-0_flapping-reapers__all_nodes_reachable:
       environment:
-        CASSANDRA_VERSION: git:trunk
-        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx398m" -Dtest=ReaperCassandraIT -Ponly-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
+        JOB_COMMAND: mvn -B surefire:test -DsurefireArgLine="-Xmx256m" -Dtest=ReaperCassandraIT -Ponly-tests-needing-all-nodes-reachable -Dgrim.reaper.min=2 -Dgrim.reaper.max=4
       <<: *default_job
     c_4-0_upgrades:
       environment:
-        CASSANDRA_VERSION: git:trunk
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
         CUCUMBER_OPTIONS: "-t ~@all_nodes_reachable"
-        JOB_COMMAND: mvn -B -DsurefireArgLine="-Xmx384m" resources:testResources surefire:test -Pintegration-upgrade-tests -Dtest=ReaperCassandraIT
+        JOB_COMMAND: mvn -B -DsurefireArgLine="-Xmx256m" resources:testResources surefire:test -Pintegration-upgrade-tests -Dtest=ReaperCassandraIT
       <<: *default_job
     c_4-0_upgrades__all_nodes_reachable:
       environment:
-        CASSANDRA_VERSION: git:trunk
+        CASSANDRA_VERSION: github:apache/trunk
+        NODES_PER_DC: 1
         CUCUMBER_OPTIONS: "-t @all_nodes_reachable"
-        JOB_COMMAND: mvn -B -DsurefireArgLine="-Xmx384m" resources:testResources surefire:test -Pintegration-upgrade-tests -Dtest=ReaperCassandraIT
+        JOB_COMMAND: mvn -B -DsurefireArgLine="-Xmx256m" resources:testResources surefire:test -Pintegration-upgrade-tests -Dtest=ReaperCassandraIT
       <<: *default_job
 workflows:
   version: 2
@@ -640,47 +646,45 @@ workflows:
 #          requires:
 #            - build
 #            - c_3-11_upgrades
-# 4.0 builds are ignored until new ccm version is released and available in pip
-#   see comment above as well under "Download dependencies"
-#      - c_4-0_memory:
-#          requires:
-#            - build
-#      - c_4-0_h2:
-#          requires:
-#            - build
-#            - c_4-0_memory
-#      - c_4-0_one-reaper:
-#          requires:
-#            - build
-#            - c_4-0_memory
-#      - c_4-0_two-reapers:
-#          requires:
-#            - build
-#            - c_4-0_memory
-#            - c_4-0_one-reaper
-#      - c_4-0_one-reaper__all_nodes_reachable:
-#          requires:
-#            - build
-#            - c_4-0_memory
-#      - c_4-0_two-reapers__all_nodes_reachable:
-#          requires:
-#            - build
-#            - c_4-0_memory
-#            - c_4-0_one-reaper__all_nodes_reachable
+      - c_4-0_memory:
+          requires:
+            - build
+      - c_4-0_h2:
+          requires:
+            - build
+            - c_4-0_memory
+      - c_4-0_one-reaper:
+          requires:
+            - build
+            - c_4-0_memory
+      - c_4-0_two-reapers:
+          requires:
+            - build
+            - c_4-0_memory
+            - c_4-0_one-reaper
+      - c_4-0_one-reaper__all_nodes_reachable:
+          requires:
+            - build
+            - c_4-0_memory
+      - c_4-0_two-reapers__all_nodes_reachable:
+          requires:
+            - build
+            - c_4-0_memory
+            - c_4-0_one-reaper__all_nodes_reachable
 # FIXME -- the following requires more memory than free OSS CircleCI offers
-#      - c_4-0_flapping-reapers__all_nodes_reachable:
-#          requires:
-#            - build
-#            - c_4-0_memory
-#            - c_4-0_one-reaper__all_nodes_reachable
-#            - c_4-0_two-reapers__all_nodes_reachable
-#      - c_4-0_flapping-reapers:
-#          requires:
-#            - build
-#            - c_4-0_memory
-#            - c_4-0_one-reaper
-#            - c_4-0_two-reapers
-#            - c_4-0_flapping-reapers__all_nodes_reachable
+      - c_4-0_flapping-reapers__all_nodes_reachable:
+          requires:
+            - build
+            - c_4-0_memory
+            - c_4-0_one-reaper__all_nodes_reachable
+            - c_4-0_two-reapers__all_nodes_reachable
+      - c_4-0_flapping-reapers:
+          requires:
+            - build
+            - c_4-0_memory
+            - c_4-0_one-reaper
+            - c_4-0_two-reapers
+# Upgrade Integration Tests are broken due to classloading issues around org.glassfish.jersey.internal.spi.AutoDiscoverable
 #      - c_4-0_upgrades:
 #          requires:
 #            - build

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,6 @@ jobs:
   fast_finish: true
   allow_failures:
   - env: TEST_TYPE=docker
-  # 4.0 builds are ignored until new ccm version is released and available in pip
-  #  when fixed, uncomment in .circleci/config.yaml too
-  - env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk
-  - env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk GRIM_MIN=1 GRIM_MAX=1
-  - env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk GRIM_MIN=2 GRIM_MAX=2
-  - env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk GRIM_MIN=2 GRIM_MAX=4
-  - env: TEST_TYPE=upgrade CASSANDRA_VERSION=git:trunk CO="-t @all_nodes_reachable"
-  - env: TEST_TYPE=upgrade CASSANDRA_VERSION=git:trunk CO="-t ~@all_nodes_reachable"
   include:
     - stage: Integration Tests
       name: Memory, H2 and Postgresql reaping Cassandra 1.2.19
@@ -72,7 +64,7 @@ jobs:
       env: TEST_TYPE=ccm CASSANDRA_VERSION=3.11.4
     - stage: Integration Tests
       name: Memory, H2 and Postgresql reaping Cassandra 4.0
-      env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk
+      env: TEST_TYPE=ccm CASSANDRA_VERSION=github:apache/trunk
     - stage: Integration Tests
       name: Cassandra 2.1.20
       env: TEST_TYPE=ccm CASSANDRA_VERSION=2.1.20 GRIM_MIN=1 GRIM_MAX=1
@@ -87,7 +79,7 @@ jobs:
       env: TEST_TYPE=ccm CASSANDRA_VERSION=3.11.3 GRIM_MIN=1 GRIM_MAX=1
     - stage: Integration Tests
       name: Cassandra 4.0
-      env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk GRIM_MIN=1 GRIM_MAX=1
+      env: TEST_TYPE=ccm CASSANDRA_VERSION=github:apache/trunk GRIM_MIN=1 GRIM_MAX=1
     - stage: Distributed Reaper Integration Tests
       name: Two Reapers on Cassandra 2.1.20
       env: TEST_TYPE=ccm CASSANDRA_VERSION=2.1.20 GRIM_MIN=2 GRIM_MAX=2
@@ -102,7 +94,7 @@ jobs:
       env: TEST_TYPE=ccm CASSANDRA_VERSION=3.11.3 GRIM_MIN=2 GRIM_MAX=2
     - stage: Distributed Reaper Integration Tests
       name: Two Reapers on Cassandra 4.0
-      env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk GRIM_MIN=2 GRIM_MAX=2
+      env: TEST_TYPE=ccm CASSANDRA_VERSION=github:apache/trunk GRIM_MIN=2 GRIM_MAX=2
     - stage: Flapping Distributed Reaper Integration Tests
       name: Four Flapping Reaper on Cassandra 2.1.20
       env: TEST_TYPE=ccm CASSANDRA_VERSION=2.1.20 GRIM_MIN=2 GRIM_MAX=4
@@ -117,7 +109,7 @@ jobs:
       env: TEST_TYPE=ccm CASSANDRA_VERSION=3.11.3 GRIM_MIN=2 GRIM_MAX=4
     - stage: Flapping Distributed Reaper Integration Tests
       name: Four Flapping Reaper on Cassandra 4.0
-      env: TEST_TYPE=ccm CASSANDRA_VERSION=git:trunk GRIM_MIN=2 GRIM_MAX=4
+      env: TEST_TYPE=ccm CASSANDRA_VERSION=github:apache/trunk GRIM_MIN=2 GRIM_MAX=4
 # Upgrade Integration Tests are broken due to classloading issues around org.glassfish.jersey.internal.spi.AutoDiscoverable
 #    - stage: Upgrade Integration Tests
 #      name: Upgrading Reaper on Cassandra 2.1.20 (all_nodes_reachable)
@@ -145,10 +137,10 @@ jobs:
 #      env: TEST_TYPE=upgrade CASSANDRA_VERSION=3.11.3 CO="-t ~@all_nodes_reachable"
 #    - stage: Upgrade Integration Tests
 #      name: Upgrading Reaper on Cassandra 4.0 (all_nodes_reachable)
-#      env: TEST_TYPE=upgrade CASSANDRA_VERSION=git:trunk CO="-t @all_nodes_reachable"
+#      env: TEST_TYPE=upgrade CASSANDRA_VERSION=github:apache/trunk CO="-t @all_nodes_reachable"
 #    - stage: Upgrade Integration Tests
 #      name: Upgrading Reaper on Cassandra 4.0
-#      env: TEST_TYPE=upgrade CASSANDRA_VERSION=git:trunk CO="-t ~@all_nodes_reachable"
+#      env: TEST_TYPE=upgrade CASSANDRA_VERSION=github:apache/trunk CO="-t ~@all_nodes_reachable"
     - stage: Docker
       env: TEST_TYPE=docker
     - stage: Deploy

--- a/src/docs/content/docs/api.md
+++ b/src/docs/content/docs/api.md
@@ -96,7 +96,7 @@ This operation expects that a call was previously made to `/login` and that the 
   * Returns the list of segments of the repair run.
   
   
-* **GET     /repair_run/{id}/segments/abort/{segment_id}**
+* **POST     /repair_run/{id}/segments/abort/{segment_id}**
   * Expected query parameters: *None*
   * Aborts a running segment and puts it back in NOT_STARTED state. The segment will be processed again later during the lifetime of the repair run.
   

--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -839,7 +839,7 @@ class ReaperCLI(object):
             extra_arguments=_arguments_for_abort_segment
         )
         printq("# Aborting a segment with run id: {0} and segment id {1}".format(args.run_id, args.segment_id))
-        reaper.get("repair_run/{0}/segments/abort/{1}".format(args.run_id, args.segment_id))
+        reaper.post("repair_run/{0}/segments/abort/{1}".format(args.run_id, args.segment_id))
         printq("# Segment '{0}' aborted".format(args.segment_id))
 
     def start_schedule(self):

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -580,7 +580,7 @@ public final class RepairRunResource {
   /**
    * @return Aborts a running segment.
    */
-  @GET
+  @POST
   @Path("/{id}/segments/abort/{segment_id}")
   public Response getRepairRunSegments(
       @PathParam("id") UUID repairRunId, @PathParam("segment_id") UUID segmentId) {
@@ -769,7 +769,7 @@ public final class RepairRunResource {
     return Response.status(Response.Status.NOT_FOUND).entity("Repair run %s" + runId + " not found").build();
   }
 
-  @GET
+  @POST
   @Path("/purge")
   public Response purgeRepairRuns() throws ReaperException {
     int purgedRepairs = PurgeService.create(context).purgeDatabase();

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -379,16 +379,17 @@ public final class RepairRunResource {
       }
 
       final RepairRun.RunState newState = parseRunState(stateStr.get());
-      if (isUnitAlreadyRepairing(repairRun.get())) {
-        String errMsg = "repair unit already has run " + repairRun.get().getRepairUnitId() + " in RUNNING state";
-        LOG.error(errMsg);
-        return Response.status(Status.CONFLICT).entity(errMsg).build();
-      }
-
       final RunState oldState = repairRun.get().getRunState();
       if (oldState == newState) {
         String msg = "given \"state\" " + stateStr + " is same as the current run state";
         return Response.noContent().entity(msg).location(buildRepairRunUri(uriInfo, repairRun.get())).build();
+      }
+      if ((isStarting(oldState, newState) || isResuming(oldState, newState) || isRetrying(oldState, newState))
+          && isUnitAlreadyRepairing(repairRun.get())) {
+
+        String errMsg = "repair unit already has run " + repairRun.get().getRepairUnitId() + " in RUNNING state";
+        LOG.error(errMsg);
+        return Response.status(Status.CONFLICT).entity(errMsg).build();
       }
 
       if (isStarting(oldState, newState)) {

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -498,18 +498,20 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
       Cluster cluster,
       LazyInitializer<Set<String>> busyHosts) {
 
-    try {
-      Map<String, String> dcByNode = getDCsByNodeForRepairSegment(coordinator, cluster, segment, keyspace);
+    if (RepairSegment.State.NOT_STARTED == segment.getState()) {
+      try {
+        Map<String, String> dcByNode = getDCsByNodeForRepairSegment(coordinator, cluster, segment, keyspace);
 
-      return !isRepairRunningOnNodes(segment, dcByNode, keyspace, cluster)
-          && nodesReadyForNewRepair(coordinator, segment, dcByNode, busyHosts);
+        return !isRepairRunningOnNodes(segment, dcByNode, keyspace, cluster)
+            && nodesReadyForNewRepair(coordinator, segment, dcByNode, busyHosts);
 
-    } catch (RuntimeException e) {
-      LOG.warn("SegmentRunner couldn't get token ranges from coordinator: ", e);
-      String msg = "SegmentRunner couldn't get token ranges from coordinator";
-      repairRunner.updateLastEvent(msg);
-      return false;
+      } catch (RuntimeException e) {
+        LOG.warn("SegmentRunner couldn't get token ranges from coordinator: ", e);
+        String msg = "SegmentRunner couldn't get token ranges from coordinator";
+        repairRunner.updateLastEvent(msg);
+      }
     }
+    return false;
   }
 
   static boolean okToRepairSegment(

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -1381,7 +1381,7 @@ public final class BasicSteps {
                 await().with().pollInterval(1, SECONDS).atMost(2, MINUTES).until(
                     () -> {
                       Response abort = runner.callReaper(
-                              "GET", // TODO – this should be a POST
+                              "POST",
                               "/repair_run/"
                                   + testContext.getCurrentRepairId()
                                   + "/segments/abort/"

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -118,7 +118,7 @@ Feature: Using Reaper
     Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
     Then reseting one segment sets its state to not started
-    And the last added repair run is deleted
+    And all added repair runs are deleted for the last added cluster
     And deleting the last added cluster fails
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
@@ -142,7 +142,7 @@ Feature: Using Reaper
     And we wait for at least 1 segments to be repaired
     Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
-    And the last added repair run is deleted
+    And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
   ${cucumber.upgrade-versions}
@@ -164,7 +164,7 @@ Feature: Using Reaper
     And we wait for at least 1 segments to be repaired
     Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
-    And the last added repair run is deleted
+    And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
  ${cucumber.upgrade-versions}
@@ -186,7 +186,7 @@ Feature: Using Reaper
     When reaper is upgraded to latest
     Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
-    And the last added repair run is deleted
+    And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
   ${cucumber.upgrade-versions}

--- a/src/ui/app/jsx/segment-list.jsx
+++ b/src/ui/app/jsx/segment-list.jsx
@@ -345,7 +345,7 @@ const Segment = React.createClass({
         this.props.notify("Aborting segment " + this.props.segment.id, "warning", this.props.segment.id);
         $.ajax({
             url: this.props.urlPrefix + '/repair_run/' + encodeURIComponent(this.props.segment.runId) + '/segments/abort/' + encodeURIComponent(this.props.segment.id),
-            method: 'GET',
+            method: 'POST',
             component: this,
             success: function(data) {
                 this.component.props.notify("Successfully aborted segment " + this.component.props.segment.id, "success", this.component.props.segment.id)


### PR DESCRIPTION

Fix (improve pass rate of) integration tests  …
 - Travis/CircleCI: restore working integration tests against Cassandra trunk (switch from git: to github:)
 – CircleCI: simplify bash conditional, adjust circleci memory values
 - In BasicSteps++
  -- improve the TestContext class. separate schedule and repair IDs, detect duplicates, separate context instance for each scenario run
  -- extra debug for repair start/finsh and segment completion timeouts
  -- improve logging in RepairRunner and BasicSteps
  -- pick up the correct running repair (multiple can start from a schedule, but only one will keep running)
  -- Assertions .`withFailMessage(..)` method has to always be called before the asserting method

And…

 - Improves the preventation of multiple scheduled repair runs starting at the same time.
 -  Don't start a segment repair if it is already started, running, or done.
- In BasicSteps when waiting on a scheduled repair run to start, abort any duplicate repair runs that occur (which can in an at-least-once eventually consistent design).
 - The purge and abort segment REST endpoints are actions, not idempotent reads, so should be POST instead of GET method requests.