### PR TITLE
Change UI run_repair API call to be more performant

### DIFF
--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -70,7 +70,9 @@ const repairForm = React.createClass({
 
   _getClusterStatus: function() {
     let clusterName = this.state.clusterName;
-    $.ajax({
+
+    if (clusterName !== null) {
+      $.ajax({
           url: this.state.urlPrefix + '/cluster/' + encodeURIComponent(clusterName),
           method: 'GET',
           component: this,
@@ -79,15 +81,16 @@ const repairForm = React.createClass({
             this.component._getSuggestions();
           }
       });
-    $.ajax({
-      url: this.state.urlPrefix + '/cluster/' + encodeURIComponent(clusterName) + '/tables',
-      method: 'GET',
-      component: this,
-      complete: function(data) {
-        this.component.setState({clusterTables: $.parseJSON(data.responseText)});
-        this.component._getKeyspaceSuggestions();
-      }
-    });
+        $.ajax({
+        url: this.state.urlPrefix + '/cluster/' + encodeURIComponent(clusterName) + '/tables',
+        method: 'GET',
+        component: this,
+        complete: function(data) {
+          this.component.setState({clusterTables: $.parseJSON(data.responseText)});
+          this.component._getKeyspaceSuggestions();
+        }
+      });
+    }
   },
 
   _getSuggestions: function() {
@@ -133,7 +136,6 @@ const repairForm = React.createClass({
   _handleChange: function(e) {
     var v = e.target.value;
     var n = e.target.id.substring(3); // strip in_ prefix
-    console.log(n + " = " + v)
 
     // update state
     const state = this.state;
@@ -149,8 +151,7 @@ const repairForm = React.createClass({
   },
 
   _checkValidity: function() {
-    console.log("Keyspaces : " + this.state.keyspaceList.length);
-    const valid = this.state.keyspaceList.length > 0 && this.state.clusterName && this.state.owner 
+    const valid = this.state.keyspaceList.length > 0 && this.state.clusterName && this.state.owner
                                       && ((this.state.datacenterList.length>0 && this.state.nodeList.length==0)
                                       || (this.state.datacenterList.length==0 && this.state.nodeList.length > 0) || (this.state.datacenterList.length==0  && this.state.nodeList==0) );
     this.setState({submitEnabled: valid});

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -271,11 +271,11 @@ const repairList = React.createClass({
       obs.subscribeOnNext(names => this.setState({clusterNames: names}))
     );
 
-    this._repairsSubscription = this.props.repairs.subscribeOnNext(obs =>
+    this._repairsSubscription = this.props.repairs.subscribeOnNext();
+
+    this._repairRunSubscription = this.props.repairRunResult.subscribeOnNext(obs =>
       obs.subscribeOnNext(repairs => {
-        const sortedRepairs = Array.from(repairs);
-        sortedRepairs.sort((a, b) => a.id - b.id);
-        this.setState({repairs: sortedRepairs});
+        this.setState({repairs: repairs});
       })
     );
 
@@ -283,10 +283,19 @@ const repairList = React.createClass({
     this.updateWindowDimensions();
   },
 
+  componentDidMount: function() {
+   var intervalId = setInterval(this._handleTimer, 2000);
+  },
+
   componentWillUnmount: function() {
-    this._repairsSubscription.dispose();
     this._clustersSubscription.dispose();
+    this._repairsSubscription.dispose();
+    this._repairRunSubscription.dispose();
     window.removeEventListener('resize', this.updateWindowDimensions);
+  },
+
+  _handleTimer: function() {
+     this.props.repairRunSubject.onNext({ clusterName: this.state.currentCluster });
   },
 
   updateWindowDimensions: function() {

--- a/src/ui/app/jsx/repair-screen.jsx
+++ b/src/ui/app/jsx/repair-screen.jsx
@@ -35,7 +35,9 @@ const repairScreen = React.createClass({
     updateStatusSubject: React.PropTypes.object.isRequired,
     updateIntensitySubject: React.PropTypes.object.isRequired,
     repairs: React.PropTypes.object.isRequired,
-    statusObservableTimer: React.PropTypes.object.isRequired
+    statusObservableTimer: React.PropTypes.object.isRequired,
+    repairRunResult: React.PropTypes.object.isRequired,
+    repairRunSubject: React.PropTypes.object.isRequired
   },
 
   getInitialState: function() {
@@ -48,9 +50,9 @@ const repairScreen = React.createClass({
 
   render: function() {
 
-  const navStyle = {
-    marginBottom: 0
-  };
+    const navStyle = {
+      marginBottom: 0
+    };
 
     return (
     <div id="wrapper">
@@ -90,7 +92,9 @@ const repairScreen = React.createClass({
                               updateStatusSubject={this.props.updateStatusSubject}
                               updateIntensitySubject={this.props.updateIntensitySubject}
                               currentCluster={this.state.currentCluster}
-                              changeCurrentCluster={this.changeCurrentCluster}> </RepairList>
+                              changeCurrentCluster={this.changeCurrentCluster}
+                              repairRunSubject={this.props.repairRunSubject}
+                              repairRunResult={this.props.repairRunResult}> </RepairList>
                 </div>
             </div>
 

--- a/src/ui/app/observable.js
+++ b/src/ui/app/observable.js
@@ -156,7 +156,7 @@ export const addRepairSubject = new Rx.Subject();
 export const deleteRepairSubject = new Rx.Subject();
 export const updateRepairStatusSubject = new Rx.Subject();
 export const updateRepairIntensitySubject = new Rx.Subject();
-
+export const repairRunSubject = new Rx.Subject();
 
 export const addRepairResult = addRepairSubject.map(repair => {
   console.info("Starting repair for cluster: " + repair.clusterName);
@@ -191,9 +191,16 @@ export const updateRepairIntensityResult = updateRepairIntensitySubject.map(repa
   }).promise());
 }).share();
 
+export const repairRunResult = repairRunSubject.map(repair => {
+  const params = $.param(repair);
+  return Rx.Observable.fromPromise($.ajax({
+    url: `${URL_PREFIX}/repair_run?${params}`,
+    method: 'GET'
+  }).promise());
+}).share();
 
 export const repairs = Rx.Observable.merge(
-    Rx.Observable.timer(0, POLLING_INTERVAL).map(t => Rx.Observable.just({})),
+    repairRunResult,
     addRepairResult,
     deleteRepairResult,
     updateRepairStatusResult,

--- a/src/ui/app/repair.js
+++ b/src/ui/app/repair.js
@@ -30,7 +30,8 @@ import {
   clusterNames, deleteSubject, deleteResult, updateStatusSubject,
   addClusterSubject, addClusterResult, deleteClusterSubject,
   deleteClusterResult, updateRepairIntensitySubject,
-  logoutSubject, logoutResult
+  logoutSubject, logoutResult,
+  repairRunResult, repairRunSubject
 } from "observable";
 
 jQuery(document).ready(function($){
@@ -55,6 +56,8 @@ jQuery(document).ready(function($){
     deleteResult: deleteRepairResult,
     updateStatusSubject: updateRepairStatusSubject,
     updateIntensitySubject: updateRepairIntensitySubject,
+    repairRunResult: repairRunResult,
+    repairRunSubject: repairRunSubject,
     statusObservableTimer}),
     document.getElementById('wrapper')
   );

--- a/src/ui/start-webpack.sh
+++ b/src/ui/start-webpack.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-webpack-dev-server --host 0.0.0.0 --port 8000 --content-base build/ -d
+./node_modules/.bin/webpack-dev-server --host 0.0.0.0 --port 8000 --content-base build/ -d


### PR DESCRIPTION
- Moved run_repair polling from observer into an interval timer in the repair-list
- Replaced run_repair polling with repairRunSubject and repairRunResult
- Updated call to run_repair by timer to include clusterName as a parameter argument
- Removed repair props from repair UI components