### PR TITLE
Fix for NPE when a segment is aborted

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
@@ -170,11 +170,6 @@ public final class RepairRunStatus {
                 new Duration(startTime.toInstant(), currentTime.toInstant()).getMillis(),
                 true,
                 false);
-      } else if (state == RepairRun.RunState.ABORTED) {
-        duration = DurationFormatUtils.formatDurationWords(
-                new Duration(startTime.toInstant(), pauseTime.toInstant()).getMillis(),
-                true,
-                false);
       } else if (endTime != null) {
         duration = DurationFormatUtils.formatDurationWords(
                 new Duration(startTime.toInstant(), endTime.toInstant()).getMillis(), true, false);

--- a/src/server/src/test/java/io/cassandrareaper/core/RepairRunTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/core/RepairRunTest.java
@@ -1,0 +1,210 @@
+/*
+ *
+ * Copyright 2019-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import io.cassandrareaper.core.RepairRun.RunState;
+
+import java.util.UUID;
+
+import org.apache.cassandra.repair.RepairParallelism;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public final class RepairRunTest {
+
+  @Test(expected = IllegalStateException.class)
+  public void testNotStartedWithStartTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.NOT_STARTED)
+                                   .startTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test
+  public void testNotStartedWithNoStartTime() {
+    RepairRun repairRun = RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.NOT_STARTED)
+                                   .build(UUID.randomUUID());
+
+    assertEquals(RunState.NOT_STARTED, repairRun.getRunState());
+
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testRunningWithNoStartTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.RUNNING)
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test
+  public void testRunningWithStartTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.RUNNING)
+                                   .startTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testRunningWithEndTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.RUNNING)
+                                   .startTime(DateTime.now())
+                                   .endTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testRunningWithPauseTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.RUNNING)
+                                   .startTime(DateTime.now())
+                                   .pauseTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test
+  public void testPausedWithPauseTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.PAUSED)
+                                   .startTime(DateTime.now())
+                                   .pauseTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testPausedWithNoPauseTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.PAUSED)
+                                   .startTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testPausedWithEndTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.PAUSED)
+                                   .startTime(DateTime.now())
+                                   .pauseTime(DateTime.now())
+                                   .endTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAbortedWithPauseTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.ABORTED)
+                                   .startTime(DateTime.now())
+                                   .pauseTime(DateTime.now())
+                                   .endTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test
+  public void testAborted() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.ABORTED)
+                                   .startTime(DateTime.now())
+                                   .endTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAbortedWithNoEndTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.ABORTED)
+                                   .startTime(DateTime.now())
+                                   .pauseTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testDoneWithPauseTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.DONE)
+                                   .startTime(DateTime.now())
+                                   .pauseTime(DateTime.now())
+                                   .endTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test
+  public void testDone() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.DONE)
+                                   .startTime(DateTime.now())
+                                   .endTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testDoneWithNoEndTime() {
+    RepairRun.builder("test", UUID.randomUUID())
+                                   .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .intensity(1.0)
+                                   .segmentCount(10)
+                                   .runState(RunState.DONE)
+                                   .startTime(DateTime.now())
+                                   .pauseTime(DateTime.now())
+                                   .build(UUID.randomUUID());
+  }
+}

--- a/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
@@ -164,6 +164,6 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1); // repair thread count
 
-    assertEquals("30 seconds", repairStatus.getDuration());
+    assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }
 }


### PR DESCRIPTION
Fixes #671

We need to have a pause time on aborted runs so that we can compute the duration in the UI (uses the same code path as paused repairs).
Added tests for most combinations that are subject to preconditions.