### PR TITLE
Add 'tables' column to repair_run table

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
@@ -17,7 +17,9 @@
 
 package io.cassandrareaper.core;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import com.google.common.base.Preconditions;
@@ -45,6 +47,7 @@ public final class RepairRun implements Comparable<RepairRun> {
   private final String lastEvent;
   private final int segmentCount;
   private final RepairParallelism repairParallelism;
+  private final Set<String> tables;
 
   private RepairRun(Builder builder, UUID id) {
     this.id = id;
@@ -61,6 +64,7 @@ public final class RepairRun implements Comparable<RepairRun> {
     this.lastEvent = builder.lastEvent;
     this.segmentCount = builder.segmentCount;
     this.repairParallelism = builder.repairParallelism;
+    this.tables = builder.tables;
   }
 
   public static Builder builder(String clusterName, UUID repairUnitId) {
@@ -121,6 +125,10 @@ public final class RepairRun implements Comparable<RepairRun> {
 
   public RepairParallelism getRepairParallelism() {
     return repairParallelism;
+  }
+
+  public Set<String> getTables() {
+    return tables;
   }
 
   public Builder with() {
@@ -199,6 +207,7 @@ public final class RepairRun implements Comparable<RepairRun> {
     private String lastEvent = "no events";
     private Integer segmentCount;
     private RepairParallelism repairParallelism;
+    private Set<String> tables;
 
     private Builder(String clusterName, UUID repairUnitId) {
       this.clusterName = clusterName;
@@ -219,6 +228,7 @@ public final class RepairRun implements Comparable<RepairRun> {
       lastEvent = original.lastEvent;
       segmentCount = original.segmentCount;
       repairParallelism = original.repairParallelism;
+      tables = original.tables;
     }
 
     public Builder runState(RunState runState) {
@@ -279,10 +289,16 @@ public final class RepairRun implements Comparable<RepairRun> {
       return this;
     }
 
+    public Builder tables(Set<String> tables) {
+      this.tables = Collections.unmodifiableSet(tables);
+      return this;
+    }
+
     public RepairRun build(UUID id) {
       Preconditions.checkState(null != repairParallelism, "repairParallelism(..) must be called before build(..)");
       Preconditions.checkState(null != intensity, "intensity(..) must be called before build(..)");
       Preconditions.checkState(null != segmentCount, "segmentCount(..) must be called before build(..)");
+      Preconditions.checkState(null != tables, "tables(..) must be called before build(..)");
 
       Preconditions.checkState(
           RunState.NOT_STARTED == runState || null != startTime,

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
@@ -201,7 +201,7 @@ public final class RepairRunStatus {
         repairRun.getId(),
         repairRun.getClusterName(),
         repairUnit.getKeyspaceName(),
-        repairUnit.getColumnFamilies(),
+        repairRun.getTables(),
         segmentsRepaired,
         repairRun.getSegmentCount(),
         repairRun.getRunState(),

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -60,9 +60,11 @@ public final class RepairRunService {
   private static final Logger LOG = LoggerFactory.getLogger(RepairRunService.class);
 
   private final AppContext context;
+  private final RepairUnitService repairUnitService;
 
   private RepairRunService(AppContext context) {
     this.context = context;
+    this.repairUnitService = RepairUnitService.create(context);
   }
 
   public static RepairRunService create(AppContext context) {
@@ -105,7 +107,8 @@ public final class RepairRunService {
         .segmentCount(segments)
         .repairParallelism(repairParallelism)
         .cause(cause.orElse("no cause specified"))
-        .owner(owner);
+        .owner(owner)
+        .tables(repairUnitService.getTablesToRepair(cluster, repairUnit));
 
     // the last preparation step is to generate actual repair segments
     List<RepairSegment.Builder> segmentBuilders = repairUnit.getIncrementalRepair()

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -461,7 +461,7 @@ public final class MemoryStorage implements IStorage {
                 run.getId(),
                 clusterName,
                 unit.getKeyspaceName(),
-                unit.getColumnFamilies(),
+                run.getTables(),
                 segmentsRepaired,
                 totalSegments,
                 run.getRunState(),

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -28,6 +28,7 @@ import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.service.RepairParameters;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -67,18 +68,18 @@ public interface IStoragePostgreSql {
   //
   String SQL_REPAIR_RUN_ALL_FIELDS_NO_ID = "cluster_name, repair_unit_id, cause, owner, state, creation_time, "
       + "start_time, end_time, pause_time, intensity, last_event, "
-      + "segment_count, repair_parallelism";
+      + "segment_count, repair_parallelism, tables";
   String SQL_REPAIR_RUN_ALL_FIELDS = "repair_run.id, " + SQL_REPAIR_RUN_ALL_FIELDS_NO_ID;
   String SQL_INSERT_REPAIR_RUN = "INSERT INTO repair_run ("
       + SQL_REPAIR_RUN_ALL_FIELDS_NO_ID
       + ") VALUES "
       + "(:clusterName, :repairUnitId, :cause, :owner, :runState, :creationTime, "
       + ":startTime, :endTime, :pauseTime, :intensity, :lastEvent, :segmentCount, "
-      + ":repairParallelism)";
+      + ":repairParallelism, :tables)";
   String SQL_UPDATE_REPAIR_RUN = "UPDATE repair_run SET cause = :cause, owner = :owner, state = :runState, "
       + "start_time = :startTime, end_time = :endTime, pause_time = :pauseTime, "
       + "intensity = :intensity, last_event = :lastEvent, segment_count = :segmentCount, "
-      + "repair_parallelism = :repairParallelism WHERE id = :id";
+      + "repair_parallelism = :repairParallelism, tables = :tables WHERE id = :id";
   String SQL_GET_REPAIR_RUN = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS + " FROM repair_run WHERE id = :id";
   String SQL_GET_REPAIR_RUNS_FOR_CLUSTER = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS
       + " FROM repair_run WHERE cluster_name = :clusterName ORDER BY id desc LIMIT :limit";
@@ -132,7 +133,7 @@ public interface IStoragePostgreSql {
   String SQL_GET_REPAIR_SEGMENTS_FOR_RUN_WITH_STATE = "SELECT " + SQL_REPAIR_SEGMENT_ALL_FIELDS
       + " FROM repair_segment WHERE " + "run_id = :runId AND state = :state";
   String SQL_GET_RUNNING_REPAIRS_FOR_CLUSTER
-      = "SELECT start_token, end_token, token_ranges, keyspace_name, column_families, repair_parallelism "
+      = "SELECT start_token, end_token, token_ranges, keyspace_name, column_families, repair_parallelism, tables "
           + "FROM repair_segment "
           + "JOIN repair_run ON run_id = repair_run.id "
           + "JOIN repair_unit ON repair_run.repair_unit_id = repair_unit.id "
@@ -210,7 +211,7 @@ public interface IStoragePostgreSql {
           + "(SELECT COUNT(*) FROM repair_segment WHERE run_id = repair_run.id) AS segments_total, "
           + "repair_run.state, repair_run.start_time, "
           + "repair_run.end_time, cause, owner, last_event, creation_time, "
-          + "pause_time, intensity, repair_parallelism, incremental_repair, repair_thread_count "
+          + "pause_time, intensity, repair_parallelism, tables, incremental_repair, repair_thread_count "
           + "FROM repair_run "
           + "JOIN repair_unit ON repair_unit_id = repair_unit.id "
           + "WHERE repair_unit.cluster_name = :clusterName "
@@ -235,6 +236,17 @@ public interface IStoragePostgreSql {
   String SQL_GET_SNAPSHOT = "SELECT cluster, snapshot_name, owner, cause, creation_time "
           + " FROM snapshot WHERE cluster = :clusterName AND snapshot_name = :snapshotName";
 
+
+  static String[] parseStringArray(Object obj) {
+    String[] values = null;
+    if (obj instanceof String[]) {
+      values = (String[]) obj;
+    } else if (obj instanceof Object[]) {
+      Object[] ocf = (Object[]) obj;
+      values = Arrays.copyOf(ocf, ocf.length, String[].class);
+    }
+    return values;
+  }
 
   @SqlQuery("SELECT CURRENT_TIMESTAMP")
   String getCurrentDate();

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
@@ -21,7 +21,6 @@ import io.cassandrareaper.core.RepairUnit;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 
 import com.google.common.collect.Sets;
 import org.skife.jdbi.v2.StatementContext;
@@ -32,19 +31,19 @@ public final class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
   @Override
   public RepairUnit map(int index, ResultSet rs, StatementContext ctx) throws SQLException {
 
-    String[] columnFamilies = parseStringArray(rs.getArray("column_families").getArray());
+    String[] columnFamilies = IStoragePostgreSql.parseStringArray(rs.getArray("column_families").getArray());
 
     String[] nodes = rs.getArray("nodes") == null
             ? new String[] {}
-            : parseStringArray(rs.getArray("nodes").getArray());
+            : IStoragePostgreSql.parseStringArray(rs.getArray("nodes").getArray());
 
     String[] datacenters = rs.getArray("datacenters") == null
             ? new String[] {}
-            : parseStringArray(rs.getArray("datacenters").getArray());
+            : IStoragePostgreSql.parseStringArray(rs.getArray("datacenters").getArray());
 
     String[] blacklistedTables = rs.getArray("blacklisted_tables") == null
             ? new String[] {}
-            : parseStringArray(rs.getArray("blacklisted_tables").getArray());
+            : IStoragePostgreSql.parseStringArray(rs.getArray("blacklisted_tables").getArray());
 
     RepairUnit.Builder builder = RepairUnit.builder()
             .clusterName(rs.getString("cluster_name"))
@@ -57,17 +56,5 @@ public final class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
             .repairThreadCount(rs.getInt("repair_thread_count"));
 
     return builder.build(UuidUtil.fromSequenceId(rs.getLong("id")));
-  }
-
-  private String[] parseStringArray(Object obj) {
-    String[] values = null;
-    if (obj instanceof String[]) {
-      values = (String[]) obj;
-    } else if (obj instanceof Object[]) {
-      Object[] ocf = (Object[]) obj;
-      values = Arrays.copyOf(ocf, ocf.length, String[].class);
-    }
-
-    return values;
   }
 }

--- a/src/server/src/main/resources/db/cassandra/020_repair_run_tables.cql
+++ b/src/server/src/main/resources/db/cassandra/020_repair_run_tables.cql
@@ -1,0 +1,18 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to allow segments to contain several token ranges
+
+ALTER TABLE repair_run ADD tables set<text> STATIC;

--- a/src/server/src/main/resources/db/h2/V14_0_0__repair_run_tables.sql
+++ b/src/server/src/main/resources/db/h2/V14_0_0__repair_run_tables.sql
@@ -1,0 +1,20 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to handle the new segment count per node
+--
+
+ALTER TABLE repair_run
+ADD tables ARRAY;

--- a/src/server/src/main/resources/db/postgres/V14_0_0__repair_run_tables.sql
+++ b/src/server/src/main/resources/db/postgres/V14_0_0__repair_run_tables.sql
@@ -1,0 +1,20 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to handle the new segment count per node
+--
+
+ALTER TABLE "repair_run"
+ADD "tables" TEXT [];

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -1002,13 +1002,13 @@ public final class BasicSteps {
                     || VersionNumber.parse("2.1").compareTo(lowestNodeVersion) > 0) {
 
                   Assertions
-                      .assertThat(runs.get(0).getBlacklistedTables().contains(twcsTable))
-                      .isFalse();
+                      .assertThat(runs.get(0).getColumnFamilies().contains(twcsTable))
+                      .isTrue();
                 } else {
                   // auto TWCS blacklisting was only added in Reaper 1.4.0, and requires Cassandra >= 2.1
                   Assertions
-                      .assertThat(runs.get(0).getBlacklistedTables().contains(twcsTable))
-                      .isTrue();
+                      .assertThat(runs.get(0).getColumnFamilies().contains(twcsTable))
+                      .isFalse();
                 }
               });
     }

--- a/src/server/src/test/java/io/cassandrareaper/core/RepairRunTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/core/RepairRunTest.java
@@ -19,8 +19,10 @@ package io.cassandrareaper.core;
 
 import io.cassandrareaper.core.RepairRun.RunState;
 
+import java.util.Set;
 import java.util.UUID;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.junit.Test;
@@ -29,10 +31,13 @@ import static org.junit.Assert.assertEquals;
 
 public final class RepairRunTest {
 
+  private static final Set<String> TABLES = ImmutableSet.of("table1");
+
   @Test(expected = IllegalStateException.class)
   public void testNotStartedWithStartTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.NOT_STARTED)
@@ -44,6 +49,7 @@ public final class RepairRunTest {
   public void testNotStartedWithNoStartTime() {
     RepairRun repairRun = RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.NOT_STARTED)
@@ -57,6 +63,7 @@ public final class RepairRunTest {
   public void testRunningWithNoStartTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.RUNNING)
@@ -67,6 +74,7 @@ public final class RepairRunTest {
   public void testRunningWithStartTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.RUNNING)
@@ -78,6 +86,7 @@ public final class RepairRunTest {
   public void testRunningWithEndTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.RUNNING)
@@ -90,6 +99,7 @@ public final class RepairRunTest {
   public void testRunningWithPauseTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.RUNNING)
@@ -102,6 +112,7 @@ public final class RepairRunTest {
   public void testPausedWithPauseTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.PAUSED)
@@ -114,6 +125,7 @@ public final class RepairRunTest {
   public void testPausedWithNoPauseTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.PAUSED)
@@ -125,6 +137,7 @@ public final class RepairRunTest {
   public void testPausedWithEndTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.PAUSED)
@@ -138,6 +151,7 @@ public final class RepairRunTest {
   public void testAbortedWithPauseTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.ABORTED)
@@ -151,6 +165,7 @@ public final class RepairRunTest {
   public void testAborted() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.ABORTED)
@@ -163,6 +178,7 @@ public final class RepairRunTest {
   public void testAbortedWithNoEndTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.ABORTED)
@@ -175,6 +191,7 @@ public final class RepairRunTest {
   public void testDoneWithPauseTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.DONE)
@@ -188,6 +205,7 @@ public final class RepairRunTest {
   public void testDone() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.DONE)
@@ -200,6 +218,7 @@ public final class RepairRunTest {
   public void testDoneWithNoEndTime() {
     RepairRun.builder("test", UUID.randomUUID())
                                    .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+                                   .tables(TABLES)
                                    .intensity(1.0)
                                    .segmentCount(10)
                                    .runState(RunState.DONE)

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -53,6 +53,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Maps;
 import org.joda.time.DateTimeUtils;
 import org.junit.Before;
@@ -301,12 +302,10 @@ public final class RepairRunResourceTest {
     assertTrue(response.getEntity().toString(), response.getEntity() instanceof RepairRunStatus);
     RepairRunStatus repairRunStatus = (RepairRunStatus) response.getEntity();
 
-    assertTrue("Blacklisted should contain 'table1'", repairRunStatus.getBlacklistedTables().contains("table1"));
-    assertTrue("Blacklisted should contain 'table2'", repairRunStatus.getBlacklistedTables().contains("table2"));
-    assertFalse("Blacklisted shouldn't contain 'table3'", repairRunStatus.getBlacklistedTables().contains("table3"));
-    assertFalse("ColumnFamilies shouldn't contain 'table1'", repairRunStatus.getColumnFamilies().contains("table1"));
-    assertFalse("ColumnFamilies shouldn't contain 'table2'", repairRunStatus.getColumnFamilies().contains("table2"));
-    assertFalse("ColumnFamilies shouldn't contain 'table3'", repairRunStatus.getColumnFamilies().contains("table3"));
+    Assertions.assertThat(repairRunStatus.getBlacklistedTables()).isEmpty();
+    assertFalse("Tables shouldn't contain 'table1'", repairRunStatus.getColumnFamilies().contains("table1"));
+    assertFalse("Tables shouldn't contain 'table2'", repairRunStatus.getColumnFamilies().contains("table2"));
+    assertTrue("Tables shouldn't contain 'table3'", repairRunStatus.getColumnFamilies().contains("table3"));
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/service/PurgeServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/PurgeServiceTest.java
@@ -29,9 +29,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
@@ -49,6 +51,7 @@ public final class PurgeServiceTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(PurgeServiceTest.class);
   private static final String CLUSTER_NAME = "test";
+  private static final Set<String> TABLES = ImmutableSet.of("table1");
 
   @Test
   public void testPurgeByDate() throws InterruptedException, ReaperException {
@@ -75,6 +78,7 @@ public final class PurgeServiceTest {
               .intensity(0.9)
               .segmentCount(10)
               .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+              .tables(TABLES)
               .endTime(startTime.plusSeconds(1))
               .runState(RunState.DONE)
               .build(UUIDs.timeBased()));
@@ -114,6 +118,7 @@ public final class PurgeServiceTest {
               .intensity(0.9)
               .segmentCount(10)
               .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+              .tables(TABLES)
               .endTime(startTime.plusSeconds(1))
               .runState(RunState.DONE)
               .build(UUIDs.timeBased()));
@@ -153,6 +158,7 @@ public final class PurgeServiceTest {
               .intensity(0.9)
               .segmentCount(10)
               .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+              .tables(TABLES)
               .pauseTime(startTime.plusSeconds(1))
               .runState(RunState.PAUSED)
               .build(UUIDs.timeBased()));

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.fest.assertions.api.Assertions;
@@ -49,6 +50,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class RepairManagerTest {
+
+  private static final Set<String> TABLES = ImmutableSet.of("table1");
 
   /**
    * Verifies that when a RUNNING segment exists that has no leader it will get aborted. Will happen
@@ -101,6 +104,7 @@ public final class RepairManagerTest {
             .intensity(intensity)
             .segmentCount(1)
             .repairParallelism(RepairParallelism.PARALLEL)
+            .tables(TABLES)
             .build(UUIDs.timeBased());
 
     final RepairSegment segment = RepairSegment.builder(
@@ -179,6 +183,7 @@ public final class RepairManagerTest {
             .intensity(intensity)
             .segmentCount(1)
             .repairParallelism(RepairParallelism.PARALLEL)
+            .tables(TABLES)
             .build(UUIDs.timeBased());
 
     final RepairSegment segment = RepairSegment.builder(
@@ -257,6 +262,7 @@ public final class RepairManagerTest {
             .intensity(intensity)
             .segmentCount(1)
             .repairParallelism(RepairParallelism.PARALLEL)
+            .tables(TABLES)
             .build(UUIDs.timeBased());
 
     final RepairSegment segment = RepairSegment.builder(
@@ -332,6 +338,7 @@ public final class RepairManagerTest {
             .intensity(intensity)
             .segmentCount(1)
             .repairParallelism(RepairParallelism.PARALLEL)
+            .tables(TABLES)
             .build(UUIDs.timeBased());
 
     final RepairSegment segment = RepairSegment.builder(
@@ -396,6 +403,7 @@ public final class RepairManagerTest {
             .intensity(intensity)
             .segmentCount(1)
             .repairParallelism(RepairParallelism.PARALLEL)
+            .tables(TABLES)
             .build(UUIDs.timeBased());
 
     when(context.storage.updateRepairRun(any())).thenReturn(true);

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
@@ -90,7 +90,7 @@ public final class RepairUnitServiceTest {
         .repairThreadCount(4)
         .build(UUIDs.timeBased());
 
-    assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(proxy, cluster, unit));
+    assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(cluster, unit));
   }
 
   @Test
@@ -117,7 +117,7 @@ public final class RepairUnitServiceTest {
           .repairThreadCount(4)
           .build(UUIDs.timeBased());
 
-    assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(proxy, cluster, unit));
+    assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(cluster, unit));
   }
 
   @Test
@@ -143,7 +143,7 @@ public final class RepairUnitServiceTest {
         .repairThreadCount(4)
         .build(UUIDs.timeBased());
 
-    assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(proxy, cluster, unit));
+    assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(cluster, unit));
   }
 
   @Test
@@ -170,7 +170,7 @@ public final class RepairUnitServiceTest {
         .repairThreadCount(4)
         .build(UUIDs.timeBased());
 
-    assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(proxy, cluster, unit));
+    assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(cluster, unit));
   }
 
   @Test
@@ -197,7 +197,7 @@ public final class RepairUnitServiceTest {
         .repairThreadCount(4)
         .build(UUIDs.timeBased());
 
-    assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(proxy, cluster, unit));
+    assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(cluster, unit));
   }
 
   @Test
@@ -225,7 +225,7 @@ public final class RepairUnitServiceTest {
         .repairThreadCount(4)
         .build(UUIDs.timeBased());
 
-    assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(proxy, cluster, unit));
+    assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(cluster, unit));
   }
 
   @Test
@@ -253,7 +253,7 @@ public final class RepairUnitServiceTest {
         .repairThreadCount(4)
         .build(UUIDs.timeBased());
 
-    assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(proxy, cluster, unit));
+    assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(cluster, unit));
   }
 
   @Test(expected = IllegalStateException.class)
@@ -280,7 +280,7 @@ public final class RepairUnitServiceTest {
         .repairThreadCount(4)
         .build(UUIDs.timeBased());
 
-    service.getTablesToRepair(proxy, cluster, unit);
+    service.getTablesToRepair(cluster, unit);
   }
 
   @Test(expected = IllegalStateException.class)
@@ -309,6 +309,6 @@ public final class RepairUnitServiceTest {
         .repairThreadCount(4)
         .build(UUIDs.timeBased());
 
-    service.getTablesToRepair(proxy, cluster, unit);
+    service.getTablesToRepair(cluster, unit);
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -46,6 +46,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -53,6 +54,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
@@ -81,6 +83,9 @@ import static org.mockito.Mockito.when;
 public final class SegmentRunnerTest {
   // TODO: Clean up tests. There's a lot of code duplication across these tests.
 
+  private static final Set<String> TABLES = ImmutableSet.of("table1");
+  private static final Set<String> COORDS = Collections.singleton("");
+
   @Before
   public void setUp() throws Exception {
     SegmentRunner.SEGMENT_RUNNERS.clear();
@@ -104,7 +109,11 @@ public final class SegmentRunnerTest {
                 .repairThreadCount(1));
 
     RepairRun run = context.storage.addRepairRun(
-            RepairRun.builder("reaper", cf.getId()) .intensity(0.5) .segmentCount(1) .repairParallelism(PARALLEL),
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(PARALLEL)
+                .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
@@ -184,8 +193,8 @@ public final class SegmentRunnerTest {
 
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
-    SegmentRunner sr = SegmentRunner.create(
-        context, clusterFacade, segmentId, Collections.singleton(""), 100, 0.5, PARALLEL, "reaper", ru, rr);
+    SegmentRunner sr = SegmentRunner
+        .create(context, clusterFacade, segmentId, COORDS, 100, 0.5, PARALLEL, "reaper", ru, TABLES, rr);
 
     sr.run();
 
@@ -210,7 +219,11 @@ public final class SegmentRunnerTest {
                 .repairThreadCount(1));
 
     RepairRun run = storage.addRepairRun(
-            RepairRun.builder("reaper", cf.getId()).intensity(0.5).segmentCount(1).repairParallelism(PARALLEL),
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(PARALLEL)
+                .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
@@ -324,8 +337,8 @@ public final class SegmentRunnerTest {
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
 
-    SegmentRunner sr = SegmentRunner.create(
-        context, clusterFacade, segmentId, Collections.singleton(""), 5000, 0.5, PARALLEL, "reaper", ru, rr);
+    SegmentRunner sr = SegmentRunner
+        .create(context, clusterFacade, segmentId, COORDS, 5000, 0.5, PARALLEL, "reaper", ru, TABLES, rr);
 
     sr.run();
 
@@ -350,7 +363,11 @@ public final class SegmentRunnerTest {
                 .repairThreadCount(1));
 
     RepairRun run = storage.addRepairRun(
-            RepairRun.builder("reaper", cf.getId()).intensity(0.5).segmentCount(1).repairParallelism(PARALLEL),
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(PARALLEL)
+                .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
@@ -454,8 +471,8 @@ public final class SegmentRunnerTest {
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
 
-    SegmentRunner sr = SegmentRunner.create(
-        context, clusterFacade, segmentId, Collections.singleton(""), 5000, 0.5, PARALLEL, "reaper", ru, rr);
+    SegmentRunner sr = SegmentRunner
+        .create(context, clusterFacade, segmentId, COORDS, 5000, 0.5, PARALLEL, "reaper", ru, TABLES, rr);
 
     sr.run();
 
@@ -481,7 +498,11 @@ public final class SegmentRunnerTest {
                 .repairThreadCount(1));
 
     RepairRun run = storage.addRepairRun(
-            RepairRun.builder("reaper", cf.getId()).intensity(0.5).segmentCount(1).repairParallelism(PARALLEL),
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(PARALLEL)
+                .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
@@ -580,8 +601,8 @@ public final class SegmentRunnerTest {
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
 
-    SegmentRunner sr = SegmentRunner.create(
-            context, clusterFacade, segmentId, Collections.singleton(""), 5000, 0.5, PARALLEL, "reaper", ru, rr);
+    SegmentRunner sr = SegmentRunner
+        .create(context, clusterFacade, segmentId, COORDS, 5000, 0.5, PARALLEL, "reaper", ru, TABLES, rr);
 
     sr.run();
 
@@ -608,7 +629,11 @@ public final class SegmentRunnerTest {
                 .repairThreadCount(1));
 
     RepairRun run = storage.addRepairRun(
-            RepairRun.builder("reaper", cf.getId()).intensity(0.5).segmentCount(1).repairParallelism(PARALLEL),
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(PARALLEL)
+                .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
@@ -707,8 +732,8 @@ public final class SegmentRunnerTest {
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
 
-    SegmentRunner sr = SegmentRunner.create(
-            context, clusterFacade, segmentId, Collections.singleton(""), 5000, 0.5, PARALLEL, "reaper", ru, rr);
+    SegmentRunner sr = SegmentRunner
+        .create(context, clusterFacade, segmentId, COORDS, 5000, 0.5, PARALLEL, "reaper", ru, TABLES, rr);
 
     sr.run();
 
@@ -736,7 +761,11 @@ public final class SegmentRunnerTest {
                 .repairThreadCount(1));
 
     RepairRun run = storage.addRepairRun(
-            RepairRun.builder("reaper", cf.getId()).intensity(0.5).segmentCount(1).repairParallelism(PARALLEL),
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(PARALLEL)
+                .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
@@ -835,8 +864,8 @@ public final class SegmentRunnerTest {
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
 
-    SegmentRunner sr = SegmentRunner.create(
-            context, clusterFacade, segmentId, Collections.singleton(""), 5000, 0.5, PARALLEL, "reaper", ru, rr);
+    SegmentRunner sr = SegmentRunner
+        .create(context, clusterFacade, segmentId, COORDS, 5000, 0.5, PARALLEL, "reaper", ru, TABLES, rr);
 
     sr.run();
 
@@ -865,7 +894,11 @@ public final class SegmentRunnerTest {
                 .repairThreadCount(1));
 
     RepairRun run = storage.addRepairRun(
-            RepairRun.builder("reaper", cf.getId()).intensity(0.5).segmentCount(1).repairParallelism(PARALLEL),
+            RepairRun.builder("reaper", cf.getId())
+                .intensity(0.5)
+                .segmentCount(1)
+                .repairParallelism(PARALLEL)
+                .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
                     Segment.builder()
@@ -964,8 +997,8 @@ public final class SegmentRunnerTest {
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
 
-    SegmentRunner sr = SegmentRunner.create(
-            context, clusterFacade, segmentId, Collections.singleton(""), 5000, 0.5, PARALLEL, "reaper", ru, rr);
+    SegmentRunner sr = SegmentRunner
+        .create(context, clusterFacade, segmentId, COORDS, 5000, 0.5, PARALLEL, "reaper", ru, TABLES, rr);
 
     sr.run();
 
@@ -1034,6 +1067,7 @@ public final class SegmentRunnerTest {
             DATACENTER_AWARE,
             "test",
             mock(RepairUnit.class),
+            TABLES,
             mock(RepairRunner.class));
 
     Pair<String, Callable<Optional<NodeMetrics>>> result = segmentRunner.getNodeMetrics("node-some", "dc1", "dc2");
@@ -1082,6 +1116,7 @@ public final class SegmentRunnerTest {
             DATACENTER_AWARE,
             "test",
             mock(RepairUnit.class),
+            TABLES,
             mock(RepairRunner.class));
 
     Pair<String, Callable<Optional<NodeMetrics>>> result = segmentRunner.getNodeMetrics("node-some", "dc1", "dc1");

--- a/src/ui/app/jsx/mixin.jsx
+++ b/src/ui/app/jsx/mixin.jsx
@@ -15,6 +15,9 @@
 //  limitations under the License.
 
 import React from "react";
+import Button from 'react-bootstrap/lib/Button';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
 
 export const RowDeleteMixin = {
 
@@ -109,6 +112,31 @@ export const CFsListRender = React.createClass({
             </div>
         )
     }
+});
+
+export const CFsCountListRender = React.createClass({
+  render: function() {
+      return (
+          <div className="ReactTags__tags">
+            <div className="ReactTags__selected">
+              <OverlayTrigger
+                key={this.props.id}
+                placement="top"
+                overlay={
+                  <Tooltip id={`tooltip-bottom`}>
+                    {this.props.list.sort().map(function(table){
+                      return <div>{table}</div>;
+                    })
+                    }
+                  </Tooltip>
+                }
+              >
+                <Button variant="secondary" className="btn btn-xs">{this.props.list.length>0?this.props.list.length:"All"} table{this.props.list.length==1?"":"s"}</Button>
+              </OverlayTrigger>
+            </div>
+          </div>
+      )
+  }
 });
 
 export const humanFileSize = function(bytes, si) {

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -16,7 +16,7 @@
 
 import React from "react";
 import moment from "moment";
-import {RowDeleteMixin, RowAbortMixin, StatusUpdateMixin, DeleteStatusMessageMixin, CFsListRender} from "jsx/mixin";
+import {RowDeleteMixin, RowAbortMixin, StatusUpdateMixin, DeleteStatusMessageMixin, CFsListRender, CFsCountListRender} from "jsx/mixin";
 import ProgressBar from 'react-bootstrap/lib/ProgressBar';
 import Button from 'react-bootstrap/lib/Button';
 import Modal from 'react-bootstrap/lib/Modal';
@@ -81,7 +81,7 @@ const TableRow = React.createClass({
         <td data-toggle="collapse" data-target={rowID}>{this.props.row.state}</td>
         <td data-toggle="collapse" data-target={rowID}>{this.props.row.cluster_name}</td>
         <td data-toggle="collapse" data-target={rowID}>{this.props.row.keyspace_name}</td>
-        <td data-toggle="collapse" data-target={rowID}><CFsListRender list={this.props.row.column_families} /></td>
+        <td data-toggle="collapse" data-target={rowID}><CFsCountListRender list={this.props.row.column_families} /></td>
         <td data-toggle="collapse" data-target={rowID}>
           <div className="progress">
           {repairProgress}
@@ -437,7 +437,7 @@ const repairList = React.createClass({
                               <th>State</th>
                               <th>Cluster</th>
                               <th>Keyspace</th>
-                              <th>CFs</th>
+                              <th>Tables</th>
                               <th>Repaired</th>
                               <th></th>
                           </tr>
@@ -466,7 +466,7 @@ const repairList = React.createClass({
                               <th>State</th>
                               <th>Cluster</th>
                               <th>Keyspace</th>
-                              <th>CFs</th>
+                              <th>Tables</th>
                               <th>Repaired</th>
                               <th></th>
                           </tr>


### PR DESCRIPTION
This allows the automatic blacklisting of TWCS to be calculated just once when the repair run is created.
Previously the TWCS blacklisting was done when reading/displaying repair runs,
  and if jmx latency was high it took minutes to display UI pages listing repair runs.
This improvement also ensures that all repair segment in one repair run repair the same tables.
 Before it was possible for repair segments to differ if table compaction strategies were changed during a repair run.