### PR TITLE
Request remote nodes metrics only if there are several reapers running

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -543,13 +543,19 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
       }
       return nodeDc.equals(localDc)
           ? Optional.empty()
-          : getRemoteNodeMetrics(node, nodeDc);
+          : maybeGetRemoteNodeMetrics(node, nodeDc);
     });
+  }
+
+  private Optional<NodeMetrics> maybeGetRemoteNodeMetrics(String node, String nodeDc) {
+    Preconditions.checkState(context.storage instanceof IDistributedStorage);
+    return ((IDistributedStorage)context.storage).countRunningReapers() == 1
+        ? Optional.empty()
+        : getRemoteNodeMetrics(node, nodeDc);
   }
 
   private Optional<NodeMetrics> getRemoteNodeMetrics(String node, String nodeDc) {
     Preconditions.checkState(DatacenterAvailability.ALL != context.config.getDatacenterAvailability());
-    Preconditions.checkState(context.storage instanceof IDistributedStorage);
     IDistributedStorage storage = ((IDistributedStorage) context.storage);
     Optional<NodeMetrics> result = storage.getNodeMetrics(repairRunner.getRepairRunId(), node);
     if (!result.isPresent()) {

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -1047,6 +1047,7 @@ public final class SegmentRunnerTest {
     context.storage = Mockito.mock(CassandraStorage.class);
     when(((IDistributedStorage) context.storage).getNodeMetrics(any(), any()))
         .thenReturn(Optional.empty());
+    Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
     JmxConnectionFactory jmxConnectionFactory = mock(JmxConnectionFactory.class);
     JmxProxy jmx = mock(JmxProxy.class);
     when(jmxConnectionFactory.connect(any())).thenReturn(jmx);
@@ -1073,6 +1074,9 @@ public final class SegmentRunnerTest {
     Pair<String, Callable<Optional<NodeMetrics>>> result = segmentRunner.getNodeMetrics("node-some", "dc1", "dc2");
     assertFalse(result.getRight().call().isPresent());
     verify(jmxConnectionFactory, times(0)).connect(any());
+    // Verify that we didn't call any method that is used in getRemoteNodeMetrics()
+    verify((CassandraStorage)context.storage, times(0)).storeNodeMetrics(any(), any());
+    verify((CassandraStorage)context.storage, times(0)).getNodeMetrics(any(), any());
   }
 
   @Test


### PR DESCRIPTION
Skips `getRemoteNodeMetrics()` call if there's only one reaper instance running.
Will make LOCAL more versatile and help with integration tests success rate.