### PR TITLE
WIP – avoid cluster conflicts on ipaddresses

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -145,7 +145,12 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>3.7.1</version>
+            <version>3.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-extras</artifactId>
+            <version>3.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -320,17 +320,12 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
   private void maybeInitializeSidecarMode() throws ReaperException {
     if (context.config.isInSidecarMode()) {
       ClusterFacade clusterFacade = ClusterFacade.create(context);
-      Node host
-          = Node.builder()
-              .withHostname(context.config.getEnforcedLocalNode().orElse("127.0.0.1"))
-              .withClusterName("bogus")
-              .build();
+      Node host = Node.builder().withHostname(context.config.getEnforcedLocalNode().orElse("127.0.0.1")).build();
       try {
-        context.localNodeAddress
-            = context
-                .config
+        context.localNodeAddress = context.config
                 .getEnforcedLocalNode()
                 .orElse(clusterFacade.getLocalEndpoint(host));
+
         LOG.info("Sidecar mode. Local node is : {}", context.localNodeAddress);
       } catch (RuntimeException | InterruptedException | ReaperException e) {
         LOG.error("Failed connecting to the local node in sidecar mode {}", host, e);
@@ -479,8 +474,6 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
           .forEach(cluster -> jmxConnectionsIntializer.on(cluster));
 
       LOG.info("Initialized JMX seed list for all clusters.");
-    } catch (RuntimeException | ReaperException e) {
-      LOG.error("Failed initializing JMX seed list", e);
     }
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -235,7 +235,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
   }
 
   public boolean isEnableCrossOrigin() {
-    return this.enableCrossOrigin != null && ("true").equalsIgnoreCase(this.enableCrossOrigin);
+    return this.enableCrossOrigin != null && "true".equalsIgnoreCase(this.enableCrossOrigin);
   }
 
   public void setStorageType(String storageType) {

--- a/src/server/src/main/java/io/cassandrareaper/core/Node.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/Node.java
@@ -17,33 +17,46 @@
 
 package io.cassandrareaper.core;
 
-import java.util.Collections;
 import java.util.Optional;
+
+import com.google.common.base.Preconditions;
 
 public final class Node {
 
-  private final Cluster cluster;
+  private final Optional<Cluster> cluster;
   private final String hostname;
 
   private Node(Builder builder) {
-    this.cluster = builder.cluster;
+    this.cluster = Optional.ofNullable(builder.cluster);
     this.hostname = builder.hostname;
   }
 
-  public Cluster getCluster() {
-    return cluster;
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public Builder with() {
+    Builder builder = builder().withHostname(hostname);
+    if (cluster.isPresent()) {
+      builder = builder.withCluster(cluster.get());
+    }
+    return builder;
+  }
+
+  public String getClusterName() {
+    return cluster.isPresent() ? cluster.get().getName() : "";
   }
 
   public String getHostname() {
     return hostname;
   }
 
-  public String toString() {
-    return hostname + "@" + cluster.getName();
+  public int getJmxPort() {
+    return cluster.isPresent() ? cluster.get().getJmxPort() : Cluster.DEFAULT_JMX_PORT;
   }
 
-  public static Builder builder() {
-    return new Builder();
+  public String toString() {
+    return hostname + (cluster.isPresent() ? "@" + cluster.get().getName() : "");
   }
 
   public static final class Builder {
@@ -53,21 +66,19 @@ public final class Node {
     private Builder() {}
 
     public Builder withCluster(Cluster cluster) {
+      Preconditions.checkNotNull(cluster);
       this.cluster = cluster;
       return this;
     }
 
-    public Builder withClusterName(String clusterName) {
-      this.cluster = new Cluster(clusterName, Optional.empty(), Collections.emptySet());
-      return this;
-    }
-
     public Builder withHostname(String hostname) {
+      Preconditions.checkNotNull(hostname);
       this.hostname = hostname;
       return this;
     }
 
     public Node build() {
+      Preconditions.checkNotNull(hostname);
       return new Node(this);
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/jmx/ClusterFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/ClusterFacade.java
@@ -230,9 +230,7 @@ public final class ClusterFacade {
   public NodesStatus getNodesStatus(Cluster cluster, Collection<String> endpoints) throws ReaperException {
     JmxProxy jmxProxy = connectAnyNode(cluster, enforceLocalNodeForSidecar(endpoints));
     FailureDetectorProxy proxy = FailureDetectorProxy.create(jmxProxy);
-
-    return new NodesStatus(
-        jmxProxy.getHost(), proxy.getAllEndpointsState(), proxy.getSimpleStates());
+    return new NodesStatus(jmxProxy.getHost(), proxy.getAllEndpointsState(), proxy.getSimpleStates());
   }
 
   /**

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
@@ -86,15 +86,15 @@ public class JmxConnectionFactory {
       host = host + ":" + jmxPorts.get(host);
       LOG.debug("Connecting to {} with specific port", host);
     } else {
-      host = host + ":" + node.getCluster().getProperties().getJmxPort();
+      host = host + ":" + node.getJmxPort();
       LOG.debug("Connecting to {} with custom port", host);
     }
 
     String username = null;
     String password = null;
-    if (getJmxCredentialsForCluster(node.getCluster().getName()).isPresent()) {
-      username = getJmxCredentialsForCluster(node.getCluster().getName()).get().getUsername();
-      password = getJmxCredentialsForCluster(node.getCluster().getName()).get().getPassword();
+    if (getJmxCredentialsForCluster(node.getClusterName()).isPresent()) {
+      username = getJmxCredentialsForCluster(node.getClusterName()).get().getUsername();
+      password = getJmxCredentialsForCluster(node.getClusterName()).get().getPassword();
     }
 
     try {
@@ -119,11 +119,6 @@ public class JmxConnectionFactory {
       }
       throw ex;
     }
-  }
-
-  @VisibleForTesting
-  public JmxProxy connect(Node node) throws ReaperException, InterruptedException {
-    return connectImpl(node);
   }
 
   @VisibleForTesting

--- a/src/server/src/main/java/io/cassandrareaper/jmx/MetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/MetricsProxy.java
@@ -219,7 +219,7 @@ public final class MetricsProxy {
     for (Entry<String, List<JmxStat>> jmxStatEntry:jmxStats.entrySet()) {
       for (JmxStat jmxStat:jmxStatEntry.getValue()) {
         GenericMetric metric = GenericMetric.builder()
-            .withClusterName(node.getCluster().getName())
+            .withClusterName(node.getClusterName())
             .withHost(node.getHostname())
             .withMetricDomain(jmxStat.getDomain())
             .withMetricType(jmxStat.getType())

--- a/src/server/src/main/java/io/cassandrareaper/resources/ClusterResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/ClusterResource.java
@@ -84,9 +84,7 @@ public final class ClusterResource {
   }
 
   @GET
-  public Response getClusterList(@QueryParam("seedHost") Optional<String> seedHost)
-      throws ReaperException {
-
+  public Response getClusterList(@QueryParam("seedHost") Optional<String> seedHost) throws ReaperException {
     LOG.debug("get cluster list called");
     Collection<Cluster> clusters = context.storage.getClusters();
     List<String> clusterNames = new ArrayList<>();
@@ -142,8 +140,7 @@ public final class ClusterResource {
 
   @GET
   @Path("/{cluster_name}/tables")
-  public Response getClusterTables(@PathParam("cluster_name") String clusterName)
-      throws ReaperException {
+  public Response getClusterTables(@PathParam("cluster_name") String clusterName) throws ReaperException {
     Map<String, List<String>> tablesByKeyspace = Maps.newHashMap();
 
     Optional<Cluster> cluster = context.storage.getCluster(clusterName);
@@ -267,14 +264,12 @@ public final class ClusterResource {
     String parsedClusterName = parseClusterNameFromSeedHost(seedHost).orElse("");
 
     try {
-      Cluster cluster
-          = new Cluster(
+      Cluster cluster = new Cluster(
               parsedClusterName,
               Optional.empty(),
               Sets.newHashSet(seedHost),
-              ClusterProperties.builder()
-                  .withJmxPort(jmxPort.orElse(Cluster.DEFAULT_JMX_PORT))
-                  .build());
+              ClusterProperties.builder().withJmxPort(jmxPort.orElse(Cluster.DEFAULT_JMX_PORT)) .build());
+
       clusterName = Optional.of(clusterFacade.getClusterName(cluster, seedHosts));
       partitioner = Optional.of(clusterFacade.getPartitioner(cluster, seedHosts));
       liveNodes = Optional.of(clusterFacade.getLiveNodes(cluster, seedHosts));
@@ -293,9 +288,7 @@ public final class ClusterResource {
             clusterName.get(),
             partitioner,
             seedHosts,
-            ClusterProperties.builder()
-                .withJmxPort(jmxPort.orElse(Cluster.DEFAULT_JMX_PORT))
-                .build())
+            ClusterProperties.builder().withJmxPort(jmxPort.orElse(Cluster.DEFAULT_JMX_PORT)).build())
         : null;
   }
 
@@ -313,9 +306,7 @@ public final class ClusterResource {
       Optional<List<String>> liveNodes = Optional.of(clusterFacade.getLiveNodes(cluster, newSeeds));
       newSeeds = liveNodes.get().stream().collect(Collectors.toSet());
       if (!cluster.getSeedHosts().equals(newSeeds)) {
-        cluster
-            = new Cluster(
-                cluster.getName(), cluster.getPartitioner(), newSeeds, cluster.getProperties());
+        cluster = new Cluster(cluster.getName(), cluster.getPartitioner(), newSeeds, cluster.getProperties());
         context.storage.updateCluster(cluster);
       }
       return cluster;
@@ -370,15 +361,16 @@ public final class ClusterResource {
    *     the seedHost node
    */
   private Callable<Optional<NodesStatus>> getEndpointState(
-      List<String> seeds, String clusterName, Optional<Integer> jmxPort) {
-    final Cluster cluster
-        = new Cluster(
+      List<String> seeds,
+      String clusterName,
+      Optional<Integer> jmxPort) {
+
+    final Cluster cluster = new Cluster(
             clusterName,
             Optional.empty(),
             Sets.newConcurrentHashSet(seeds),
-            ClusterProperties.builder()
-                .withJmxPort(jmxPort.orElse(Cluster.DEFAULT_JMX_PORT))
-                .build());
+            ClusterProperties.builder().withJmxPort(jmxPort.orElse(Cluster.DEFAULT_JMX_PORT)).build());
+
     return () -> {
       try {
         return Optional.of(clusterFacade.getNodesStatus(cluster, seeds));
@@ -404,14 +396,16 @@ public final class ClusterResource {
       List<String> seedHosts = new ArrayList<>(cluster.get().getSeedHosts());
       Collections.shuffle(seedHosts);
       int index = 0;
-      for (String host:seedHosts) {
+      for (String host : seedHosts) {
         if (index >= 3) {
           break;
         }
+
         Callable<Optional<NodesStatus>> endpointStateTask = getEndpointState(
             Arrays.asList(host),
             cluster.get().getName(),
             Optional.ofNullable(cluster.get().getProperties().getJmxPort()));
+
         endpointStateTasks.add(endpointStateTask);
         index++;
       }
@@ -461,7 +455,6 @@ public final class ClusterResource {
         return Optional.of(hosts.get(0).split("@")[1]);
       }
     }
-
     return Optional.empty();
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/NodeStatsResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/NodeStatsResource.java
@@ -74,7 +74,7 @@ public final class NodeStatsResource {
 
     try {
       Node node = Node.builder()
-              .withCluster(context.storage.getCluster(clusterName).get())
+              .withCluster(context.storage.getCluster(clusterName))
               .withHostname(host)
               .build();
 
@@ -99,7 +99,7 @@ public final class NodeStatsResource {
 
     try {
       Node node = Node.builder()
-              .withCluster(context.storage.getCluster(clusterName).get())
+              .withCluster(context.storage.getCluster(clusterName))
               .withHostname(host)
               .build();
 
@@ -124,7 +124,7 @@ public final class NodeStatsResource {
 
     try {
       Node node = Node.builder()
-              .withCluster(context.storage.getCluster(clusterName).get())
+              .withCluster(context.storage.getCluster(clusterName))
               .withHostname(host)
               .build();
 
@@ -148,7 +148,7 @@ public final class NodeStatsResource {
 
     try {
       Node node = Node.builder()
-              .withCluster(context.storage.getCluster(clusterName).get())
+              .withCluster(context.storage.getCluster(clusterName))
               .withHostname(host)
               .build();
 
@@ -174,7 +174,7 @@ public final class NodeStatsResource {
 
     try {
       Node node = Node.builder()
-              .withCluster(context.storage.getCluster(clusterName).get())
+              .withCluster(context.storage.getCluster(clusterName))
               .withHostname(host)
               .build();
 
@@ -201,7 +201,7 @@ public final class NodeStatsResource {
       Preconditions.checkState(clusterName != null && !clusterName.isEmpty(), "Cluster name must be set");
 
       Map<String, List<String>> tokens
-          = ClusterFacade.create(context).getTokensByNode(context.storage.getCluster(clusterName).get());
+          = ClusterFacade.create(context).getTokensByNode(context.storage.getCluster(clusterName));
 
       return Response.ok().entity(tokens.get(host)).build();
     } catch (RuntimeException | ReaperException e) {

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -143,7 +143,12 @@ public final class RepairScheduleResource {
             .build();
       }
 
-      Cluster cluster = context.storage.getCluster(Cluster.toSymbolicName(clusterName.get())).get();
+      Cluster cluster ;
+      try {
+        cluster = context.storage.getCluster(Cluster.toSymbolicName(clusterName.get()));
+      } catch (IllegalArgumentException ex) {
+        return Response.status(Response.Status.NOT_FOUND).entity(ex.getMessage()).build();
+      }
       Set<String> tableNames;
       try {
         tableNames = repairRunService.getTableNamesBasedOnParam(cluster, keyspace.get(), tableNamesParam);

--- a/src/server/src/main/java/io/cassandrareaper/service/AutoSchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/AutoSchedulingManager.java
@@ -69,18 +69,13 @@ public final class AutoSchedulingManager extends TimerTask {
   @Override
   public void run() {
     LOG.debug("Checking cluster keyspaces to identify which ones require repair schedules...");
-    Collection<Cluster> clusters;
-    try {
-      clusters = context.storage.getClusters();
-      for (Cluster cluster : clusters) {
-        try {
-          clusterRepairScheduler.scheduleRepairs(cluster);
-        } catch (ReaperException | RuntimeException e) {
-          LOG.error("Error while scheduling repairs for cluster {}", cluster, e);
-        }
+    Collection<Cluster> clusters = context.storage.getClusters();
+    for (Cluster cluster : clusters) {
+      try {
+        clusterRepairScheduler.scheduleRepairs(cluster);
+      } catch (ReaperException | RuntimeException e) {
+        LOG.error("Error while scheduling repairs for cluster {}", cluster, e);
       }
-    } catch (ReaperException e1) {
-      LOG.error("Error while listing cluster to autoschedule repairs", e1);
     }
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
@@ -72,7 +72,6 @@ public final class MetricsService {
 
       Node host = Node.builder()
             .withHostname(context.config.getEnforcedLocalNode().orElse("127.0.0.1"))
-            .withClusterName("bogus")
             .build();
 
       localClusterName = Cluster.toSymbolicName(clusterFacade.getClusterName(host));
@@ -108,7 +107,7 @@ public final class MetricsService {
     for (Entry<String, List<JmxStat>> jmxStatEntry:jmxStats.entrySet()) {
       for (JmxStat jmxStat:jmxStatEntry.getValue()) {
         GenericMetric metric = GenericMetric.builder()
-            .withClusterName(node.getCluster().getName())
+            .withClusterName(node.getClusterName())
             .withHost(node.getHostname())
             .withMetricDomain(jmxStat.getDomain())
             .withMetricType(jmxStat.getType())
@@ -130,7 +129,7 @@ public final class MetricsService {
         context.config.isInSidecarMode(),
         "grabAndStoreGenericMetrics() can only be called in sidecar");
 
-    Node node = Node.builder().withClusterName(localClusterName).withHostname(context.getLocalNodeAddress()).build();
+    Node node = Node.builder().withHostname(context.getLocalNodeAddress()).build();
 
     List<GenericMetric> metrics
         = convertToGenericMetrics(ClusterFacade.create(context).collectMetrics(node, COLLECTED_METRICS), node);
@@ -147,7 +146,7 @@ public final class MetricsService {
         context.config.isInSidecarMode(),
         "grabAndStoreActiveCompactions() can only be called in sidecar");
 
-    Node node = Node.builder().withClusterName(localClusterName).withHostname(context.getLocalNodeAddress()).build();
+    Node node = Node.builder().withHostname(context.getLocalNodeAddress()).build();
     List<Compaction> activeCompactions = ClusterFacade.create(context).listActiveCompactionsDirect(node);
 
     ((IDistributedStorage) context.storage)
@@ -165,7 +164,7 @@ public final class MetricsService {
         context.config.isInSidecarMode(),
         "grabAndStoreActiveStreams() can only be called in sidecar");
 
-    Node node = Node.builder().withClusterName(localClusterName).withHostname(context.getLocalNodeAddress()).build();
+    Node node = Node.builder().withHostname(context.getLocalNodeAddress()).build();
     Set<CompositeData> activeStreams = ClusterFacade.create(context).listStreamsDirect(node);
 
     ((IDistributedStorage) context.storage)

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -277,10 +277,8 @@ public final class RepairManager implements AutoCloseable {
         segment = context.storage.getRepairSegment(repairRun.getId(), segment.getId()).get();
         if (RepairSegment.State.RUNNING == segment.getState()) {
           try {
-            JmxProxy jmxProxy
-                = ClusterFacade.create(context)
-                    .connectAndAllowSidecar(
-                        context.storage.getCluster(repairRun.getClusterName()).get(),
+            JmxProxy jmxProxy = ClusterFacade.create(context).connect(
+                        context.storage.getCluster(repairRun.getClusterName()),
                         Arrays.asList(segment.getCoordinatorHost()));
 
             SegmentRunner.abort(context, segment, jmxProxy);

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -299,7 +299,7 @@ public final class SchedulingManager extends TimerTask {
   private RepairRun createNewRunForUnit(RepairSchedule schedule, RepairUnit repairUnit) throws ReaperException {
 
     return repairRunService.registerRepairRun(
-        context.storage.getCluster(repairUnit.getClusterName()).get(),
+        context.storage.getCluster(repairUnit.getClusterName()),
         repairUnit,
         Optional.of(getCauseName(schedule)),
         schedule.getOwner(),

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -42,13 +42,13 @@ public interface IStorage {
 
   boolean isStorageConnected();
 
-  Collection<Cluster> getClusters() throws ReaperException;
+  Collection<Cluster> getClusters();
 
-  boolean addCluster(Cluster cluster) throws ReaperException;
+  boolean addCluster(Cluster cluster);
 
-  boolean updateCluster(Cluster newCluster) throws ReaperException;
+  boolean updateCluster(Cluster newCluster);
 
-  Optional<Cluster> getCluster(String clusterName) throws ReaperException;
+  Cluster getCluster(String clusterName);
 
   /**
    * Delete the Cluster instance identified by the given cluster name. Delete succeeds only if there are no repair runs
@@ -57,7 +57,7 @@ public interface IStorage {
    * @param clusterName The name of the Cluster instance to delete.
    * @return The deleted Cluster instance if delete succeeds, with state set to DELETED.
    */
-  Optional<Cluster> deleteCluster(String clusterName);
+  Cluster deleteCluster(String clusterName);
 
   RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments);
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -17,7 +17,6 @@
 
 package io.cassandrareaper.storage;
 
-import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSchedule;
@@ -70,7 +69,7 @@ public interface IStorage {
 
   Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId);
 
-  Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState) throws ReaperException;
+  Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState);
 
   /**
    * Delete the RepairRun instance identified by the given id, and delete also all the related repair segments.

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/ClusterMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/ClusterMapper.java
@@ -24,10 +24,9 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
@@ -56,10 +55,14 @@ public final class ClusterMapper implements ResultSetMapper<Cluster> {
       throw new SQLException(e); // Ugly but the interface won't let us throw anything else...
     }
 
-    return new Cluster(
-        rs.getString("name"),
-        Optional.ofNullable(rs.getString("partitioner")),
-        Sets.newHashSet(seedHosts),
-        clusterProperties);
+    Cluster.Builder builder = Cluster.builder()
+        .withName(rs.getString("name"))
+        .withSeedHosts(ImmutableSet.copyOf(seedHosts))
+        .withJmxPort(clusterProperties.getJmxPort());
+
+    if (null != rs.getString("partitioner")) {
+      builder = builder.withPartitioner(rs.getString("partitioner"));
+    }
+    return builder.build();
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/ClusterMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/ClusterMapper.java
@@ -58,6 +58,10 @@ public final class ClusterMapper implements ResultSetMapper<Cluster> {
     Cluster.Builder builder = Cluster.builder()
         .withName(rs.getString("name"))
         .withSeedHosts(ImmutableSet.copyOf(seedHosts))
+        .withState(null != rs.getString("state")
+            ? Cluster.State.valueOf(rs.getString("state"))
+            : Cluster.State.UNKNOWN)
+        .withLastContact(rs.getDate("last_contact").toLocalDate())
         .withJmxPort(clusterProperties.getJmxPort());
 
     if (null != rs.getString("partitioner")) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -30,6 +30,7 @@ import io.cassandrareaper.service.RepairParameters;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -53,16 +54,15 @@ public interface IStoragePostgreSql {
 
   // Cluster
   //
-  String SQL_CLUSTER_ALL_FIELDS = "name, partitioner, seed_hosts, properties";
+  String SQL_CLUSTER_ALL_FIELDS = "name, partitioner, seed_hosts, properties, state, last_contact";
   String SQL_GET_ALL_CLUSTERS = "SELECT " + SQL_CLUSTER_ALL_FIELDS + " FROM cluster";
   String SQL_GET_CLUSTER = "SELECT " + SQL_CLUSTER_ALL_FIELDS + " FROM cluster WHERE name = :name";
   String SQL_INSERT_CLUSTER
       = "INSERT INTO cluster ("
           + SQL_CLUSTER_ALL_FIELDS
-          + ") VALUES (:name, :partitioner, :seedHosts, :properties)";
+          + ") VALUES (:name, :partitioner, :seedHosts, :properties, :state, :lastContact)";
   String SQL_UPDATE_CLUSTER = "UPDATE cluster SET partitioner = :partitioner, "
-      + "seed_hosts = :seedHosts WHERE name = :name";
-  String SQL_DELETE_CLUSTER = "DELETE FROM cluster WHERE name = :name";
+      + "seed_hosts = :seedHosts, state = :state, last_contact = :lastContact WHERE name = :name";
 
   // RepairRun
   //
@@ -265,15 +265,13 @@ public interface IStoragePostgreSql {
       @Bind("name") String name,
       @Bind("partitioner") String partitioner,
       @Bind("seedHosts") Set<String> seedHosts,
-      @Bind("properties") String properties);
+      @Bind("properties") String properties,
+      @Bind("state") String state,
+      @Bind("last_contact") Date lastContact);
 
   @SqlUpdate(SQL_UPDATE_CLUSTER)
   int updateCluster(
       @BindBean Cluster newCluster);
-
-  @SqlUpdate(SQL_DELETE_CLUSTER)
-  int deleteCluster(
-      @Bind("name") String clusterName);
 
   @SqlQuery(SQL_GET_REPAIR_RUN)
   @Mapper(RepairRunMapper.class)

--- a/src/server/src/main/resources/db/cassandra/021_sidecar_mode.cql
+++ b/src/server/src/main/resources/db/cassandra/021_sidecar_mode.cql
@@ -1,4 +1,18 @@
 --
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
 -- Metrics table for the sidecar mode
 --
 

--- a/src/server/src/main/resources/db/cassandra/022_cluster_states.cql
+++ b/src/server/src/main/resources/db/cassandra/022_cluster_states.cql
@@ -1,0 +1,19 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to store cluster state and last jmx connection time
+
+ALTER TABLE cluster ADD state text;
+ALTER TABLE cluster ADD last_contact date;

--- a/src/server/src/main/resources/db/h2/V15_0_0__cluster_states.sql
+++ b/src/server/src/main/resources/db/h2/V15_0_0__cluster_states.sql
@@ -1,0 +1,22 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to store cluster state and last jmx connection time
+
+ALTER TABLE cluster
+ADD state TEXT;
+
+ALTER TABLE cluster
+ADD last_contact TIMESTAMP;

--- a/src/server/src/main/resources/db/postgres/V15_0_0__cluster_states.sql
+++ b/src/server/src/main/resources/db/postgres/V15_0_0__cluster_states.sql
@@ -1,0 +1,22 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to store cluster state and last jmx connection time
+
+ALTER TABLE "cluster"
+ADD "state" TEXT;
+
+ALTER TABLE "cluster"
+ADD "last_contact" TIMESTAMP;

--- a/src/server/src/test/java/io/cassandrareaper/jmx/JmxConnectionsInitializerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/JmxConnectionsInitializerTest.java
@@ -26,11 +26,9 @@ import io.cassandrareaper.core.Node;
 import io.cassandrareaper.storage.CassandraStorage;
 import io.cassandrareaper.storage.PostgresStorage;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -64,17 +62,16 @@ public class JmxConnectionsInitializerTest {
     context.config.setDatacenterAvailability(DatacenterAvailability.EACH);
     context.storage = mock(CassandraStorage.class);
 
-    Cluster cluster = new Cluster(
-            "test",
-            Optional.of("murmur3partitioner"),
-            new LinkedHashSet<>(Arrays.asList("127.0.0.1", "127.0.0.2")));
+    Cluster cluster = Cluster.builder()
+            .withName("test")
+            .withPartitioner("murmur3partitioner")
+            .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2"))
+            .build();
 
     JmxConnectionsInitializer initializer = JmxConnectionsInitializer.create(context);
     initializer.on(cluster);
 
     assertEquals(2, connectionAttempts.get());
-
-
   }
 
   /*
@@ -102,10 +99,11 @@ public class JmxConnectionsInitializerTest {
     context.config.setDatacenterAvailability(DatacenterAvailability.LOCAL);
     context.storage = mock(CassandraStorage.class);
 
-    Cluster cluster = new Cluster(
-            "test",
-            Optional.of("murmur3partitioner"),
-            new LinkedHashSet<>(Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3")));
+    Cluster cluster = Cluster.builder()
+            .withName("test")
+            .withPartitioner("murmur3partitioner")
+            .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2", "127.0.0.3"))
+            .build();
 
     JmxConnectionsInitializer initializer = JmxConnectionsInitializer.create(context);
     initializer.on(cluster);
@@ -138,10 +136,11 @@ public class JmxConnectionsInitializerTest {
     context.config.setDatacenterAvailability(DatacenterAvailability.ALL);
     context.storage = mock(CassandraStorage.class);
 
-    Cluster cluster = new Cluster(
-            "test",
-            Optional.of("murmur3partitioner"),
-            new LinkedHashSet<>(Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3")));
+    Cluster cluster = Cluster.builder()
+            .withName("test")
+            .withPartitioner("murmur3partitioner")
+            .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2", "127.0.0.3"))
+            .build();
 
     JmxConnectionsInitializer initializer = JmxConnectionsInitializer.create(context);
     initializer.on(cluster);
@@ -174,10 +173,11 @@ public class JmxConnectionsInitializerTest {
     context.config.setDatacenterAvailability(DatacenterAvailability.ALL);
     context.storage = mock(PostgresStorage.class);
 
-    Cluster cluster = new Cluster(
-            "test",
-            Optional.of("murmur3partitioner"),
-            new LinkedHashSet<>(Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3")));
+    Cluster cluster = Cluster.builder()
+            .withName("test")
+            .withPartitioner("murmur3partitioner")
+            .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2", "127.0.0.3"))
+            .build();
 
     JmxConnectionsInitializer initializer = JmxConnectionsInitializer.create(context);
     initializer.on(cluster);

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -49,6 +49,7 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
@@ -118,7 +119,13 @@ public final class RepairRunResourceTest {
         TimeUnit.SECONDS);
 
     context.storage = new MemoryStorage();
-    Cluster cluster = new Cluster(CLUSTER_NAME, Optional.of(PARTITIONER), Sets.newHashSet(SEED_HOST));
+
+    Cluster cluster = Cluster.builder()
+        .withName(CLUSTER_NAME)
+        .withPartitioner(PARTITIONER)
+        .withSeedHosts(ImmutableSet.of(SEED_HOST))
+        .build();
+
     context.storage.addCluster(cluster);
 
     context.config = new ReaperApplicationConfiguration();

--- a/src/server/src/test/java/io/cassandrareaper/service/AutoSchedulingManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/AutoSchedulingManagerTest.java
@@ -24,8 +24,7 @@ import io.cassandrareaper.service.AutoSchedulingManager;
 import io.cassandrareaper.service.ClusterRepairScheduler;
 import io.cassandrareaper.storage.MemoryStorage;
 
-import java.util.Collections;
-
+import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,8 +34,12 @@ import static org.mockito.Mockito.verify;
 
 public final class AutoSchedulingManagerTest {
 
-  private static final Cluster CLUSTER_1 = new Cluster("cluster1", null, Collections.singleton(null));
-  private static final Cluster CLUSTER_2 = new Cluster("cluster2", null, Collections.singleton(null));
+  private static final Cluster CLUSTER_1
+      = Cluster.builder().withName("cluster1").withSeedHosts(ImmutableSet.of("127.0.0.1")).build();
+
+  private static final Cluster CLUSTER_2
+      = Cluster.builder().withName("cluster2").withSeedHosts(ImmutableSet.of("127.0.0.1")).build();
+
   private AppContext context;
   private AutoSchedulingManager repairAutoSchedulingManager;
   private ClusterRepairScheduler clusterRepairScheduler;

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -30,8 +30,8 @@ import io.cassandrareaper.storage.MemoryStorage;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.cassandra.repair.RepairParallelism;
@@ -59,7 +59,12 @@ public final class ClusterRepairSchedulerTest {
 
   @Before
   public void setup() throws ReaperException {
-    cluster = new Cluster(RandomStringUtils.randomAlphabetic(12), null, Collections.singleton("127.0.0.1"));
+
+    cluster = Cluster.builder()
+        .withName(RandomStringUtils.randomAlphabetic(12))
+        .withSeedHosts(ImmutableSet.of("127.0.0.1"))
+        .build();
+
     context = new AppContext();
     context.storage = new MemoryStorage();
 

--- a/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
@@ -31,6 +31,7 @@ import io.cassandrareaper.jmx.JmxProxyTest;
 import io.cassandrareaper.jmx.MetricsProxy;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +63,7 @@ public class MetricsServiceTest {
     cxt.config.setJmxConnectionTimeoutInSeconds(10);
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
     JmxProxy jmx = (JmxProxy) mock(Class.forName("io.cassandrareaper.jmx.JmxProxyImpl"));
-    when(cxt.jmxConnectionFactory.connect(Mockito.any(Node.class))).thenReturn(jmx);
+    when(cxt.jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     MBeanServerConnection serverConn = mock(MBeanServerConnection.class);
     JmxProxyTest.mockGetMBeanServerConnection(jmx, serverConn);
 
@@ -70,7 +71,7 @@ public class MetricsServiceTest {
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToThreadPoolStats(..)
     when(serverConn.queryNames(Mockito.any(ObjectName.class), Mockito.isNull())).thenReturn(Collections.emptySet());
 
-    Node node = Node.builder().withClusterName("test").withHostname("127.0.0.1").build();
+    Node node = Node.builder().withHostname("127.0.0.1").build();
     MetricsService.create(cxt, () -> clusterFacade).getTpStats(node);
     Mockito.verify(clusterFacade, Mockito.times(1)).getTpStats(Mockito.any());
   }
@@ -123,7 +124,7 @@ public class MetricsServiceTest {
 
     Map<String, List<JmxStat>> jmxStats = Maps.newHashMap();
     jmxStats.put("ReadStage", statList);
-    Node node = Node.builder().withClusterName("test").withHostname("127.0.0.1").build();
+    Node node = Node.builder().withHostname("127.0.0.1").build();
     AppContext context = new AppContext();
     List<ThreadPoolStat> threadPoolStats
         = ClusterFacade.create(context).convertToThreadPoolStats(
@@ -149,7 +150,7 @@ public class MetricsServiceTest {
     cxt.config.setJmxConnectionTimeoutInSeconds(10);
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
     JmxProxy jmx = (JmxProxy) mock(Class.forName("io.cassandrareaper.jmx.JmxProxyImpl"));
-    when(cxt.jmxConnectionFactory.connect(Mockito.any(Node.class))).thenReturn(jmx);
+    when(cxt.jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     MBeanServerConnection serverConn = mock(MBeanServerConnection.class);
     JmxProxyTest.mockGetMBeanServerConnection(jmx, serverConn);
 
@@ -157,7 +158,7 @@ public class MetricsServiceTest {
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToDroppedMessages(..)
     when(serverConn.queryNames(Mockito.any(ObjectName.class), Mockito.isNull())).thenReturn(Collections.emptySet());
 
-    Node node = Node.builder().withClusterName("test").withHostname("127.0.0.1").build();
+    Node node = Node.builder().withHostname("127.0.0.1").build();
     MetricsService.create(cxt, () -> clusterFacade).getDroppedMessages(node);
     Mockito.verify(clusterFacade, Mockito.times(1)).getDroppedMessages(Mockito.any());
   }
@@ -209,7 +210,7 @@ public class MetricsServiceTest {
     Map<String, List<JmxStat>> jmxStats = Maps.newHashMap();
     jmxStats.put("READ", statList);
 
-    Node node = Node.builder().withClusterName("test").withHostname("127.0.0.1").build();
+    Node node = Node.builder().withHostname("127.0.0.1").build();
     List<DroppedMessages> droppedMessages
         = clusterFacade.convertToDroppedMessages(
             MetricsProxy.convertToGenericMetrics(jmxStats, node));
@@ -233,7 +234,7 @@ public class MetricsServiceTest {
     cxt.config.setJmxConnectionTimeoutInSeconds(10);
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
     JmxProxy jmx = (JmxProxy) mock(Class.forName("io.cassandrareaper.jmx.JmxProxyImpl"));
-    when(cxt.jmxConnectionFactory.connect(Mockito.any(Node.class))).thenReturn(jmx);
+    when(cxt.jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     MBeanServerConnection serverConn = mock(MBeanServerConnection.class);
     JmxProxyTest.mockGetMBeanServerConnection(jmx, serverConn);
 
@@ -241,7 +242,7 @@ public class MetricsServiceTest {
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToMetricsHistogram(..)
     when(serverConn.queryNames(Mockito.any(ObjectName.class), Mockito.isNull())).thenReturn(Collections.emptySet());
 
-    Node node = Node.builder().withClusterName("test").withHostname("127.0.0.1").build();
+    Node node = Node.builder().withHostname("127.0.0.1").build();
     MetricsService.create(cxt, () -> clusterFacadeMock).getClientRequestLatencies(node);
     Mockito.verify(clusterFacadeMock, Mockito.times(1)).getClientRequestLatencies(Mockito.any());
   }

--- a/src/server/src/test/java/io/cassandrareaper/service/PurgeServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/PurgeServiceTest.java
@@ -28,7 +28,6 @@ import io.cassandrareaper.storage.IStorage;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -62,7 +61,9 @@ public final class PurgeServiceTest {
     // Create storage mock
     context.storage = mock(IStorage.class);
 
-    List<Cluster> clusters = Arrays.asList(new Cluster(CLUSTER_NAME, Optional.empty(), Collections.EMPTY_SET));
+    List<Cluster> clusters
+        = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(Collections.EMPTY_SET).build());
+
     when(context.storage.getClusters()).thenReturn(clusters);
 
     // Add repair runs to the mock
@@ -102,7 +103,9 @@ public final class PurgeServiceTest {
     // Create storage mock
     context.storage = mock(IStorage.class);
 
-    List<Cluster> clusters = Arrays.asList(new Cluster(CLUSTER_NAME, Optional.empty(), Collections.EMPTY_SET));
+    List<Cluster> clusters
+        = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(Collections.EMPTY_SET).build());
+
     when(context.storage.getClusters()).thenReturn(clusters);
 
     // Add repair runs to the mock
@@ -142,7 +145,9 @@ public final class PurgeServiceTest {
     // Create storage mock
     context.storage = mock(IStorage.class);
 
-    List<Cluster> clusters = Arrays.asList(new Cluster(CLUSTER_NAME, Optional.empty(), Collections.EMPTY_SET));
+    List<Cluster> clusters
+        = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(Collections.EMPTY_SET).build());
+
     when(context.storage.getClusters()).thenReturn(clusters);
 
     // Add repair runs to the mock

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -74,7 +74,7 @@ public final class RepairManagerTest {
     // use CassandraStorage so we get both IStorage and IDistributedStorage
     final IStorage storage = mock(CassandraStorage.class);
 
-    storage.addCluster(new Cluster(clusterName, null, Collections.<String>singleton("127.0.0.1")));
+    storage.addCluster(Cluster.builder().withName(clusterName).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
 
     AppContext context = new AppContext();
     context.storage = storage;
@@ -154,7 +154,7 @@ public final class RepairManagerTest {
     // use CassandraStorage so we get both IStorage and IDistributedStorage
     final IStorage storage = mock(CassandraStorage.class);
 
-    storage.addCluster(new Cluster(clusterName, null, Collections.<String>singleton("127.0.0.1")));
+    storage.addCluster(Cluster.builder().withName(clusterName).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
 
     AppContext context = new AppContext();
     context.storage = storage;
@@ -235,7 +235,7 @@ public final class RepairManagerTest {
 
     final IStorage storage = mock(IStorage.class);
 
-    storage.addCluster(new Cluster(clusterName, null, Collections.<String>singleton("127.0.0.1")));
+    storage.addCluster(Cluster.builder().withName(clusterName).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
 
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
@@ -313,7 +313,7 @@ public final class RepairManagerTest {
 
     final IStorage storage = mock(IStorage.class);
 
-    storage.addCluster(new Cluster(clusterName, null, Collections.<String>singleton("127.0.0.1")));
+    storage.addCluster(Cluster.builder().withName(clusterName).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
 
     AppContext context = new AppContext();
     context.storage = storage;
@@ -376,7 +376,9 @@ public final class RepairManagerTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.storage = mock(IStorage.class);
-    context.storage.addCluster(new Cluster(clusterName, null, Collections.<String>singleton("127.0.0.1")));
+
+    context.storage
+        .addCluster(Cluster.builder().withName(clusterName).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
 
     context.repairManager = RepairManager.create(
         context,

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -99,7 +99,9 @@ public final class RepairRunnerTest {
     final double INTENSITY = 0.5f;
     final int REPAIR_THREAD_COUNT = 1;
     final IStorage storage = new MemoryStorage();
-    storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton("127.0.0.1")));
+
+    storage.addCluster(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
+
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
             .clusterName(CLUSTER_NAME)
@@ -199,7 +201,7 @@ public final class RepairRunnerTest {
               return repairNumber;
             });
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any())).thenReturn(Lists.newArrayList(NODES));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
@@ -247,7 +249,7 @@ public final class RepairRunnerTest {
     final double INTENSITY = 0.5f;
     final int REPAIR_THREAD_COUNT = 1;
     final IStorage storage = new MemoryStorage();
-    storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton("127.0.0.1")));
+    storage.addCluster(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -344,7 +346,7 @@ public final class RepairRunnerTest {
               return repairNumber;
             });
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(NODES));
@@ -401,7 +403,7 @@ public final class RepairRunnerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    storage.addCluster(new Cluster(CLUSTER_NAME, null, Collections.<String>singleton("127.0.0.1")));
+    storage.addCluster(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
 
     UUID cf = storage.addRepairUnit(
         RepairUnit.builder()
@@ -456,7 +458,7 @@ public final class RepairRunnerTest {
     }
     JmxProxyTest.mockGetEndpointSnitchInfoMBean(jmx, endpointSnitchInfoMBean);
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(NODES));

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
@@ -22,7 +22,6 @@ import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperApplicationConfiguration;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
-import io.cassandrareaper.core.ClusterProperties;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Table;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
@@ -30,7 +29,6 @@ import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.jmx.JmxProxyTest;
 
 import java.util.Collection;
-import java.util.Optional;
 
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.Sets;
@@ -51,11 +49,12 @@ public final class RepairUnitServiceTest {
   private AppContext context;
   private RepairUnitService service;
 
-  private final Cluster cluster = new Cluster(
-      "reaper",
-      Optional.of("murmur3"),
-      Sets.newHashSet("127.0.0.1"),
-      ClusterProperties.builder().withJmxPort(7199).build());
+  private final Cluster cluster = Cluster.builder()
+      .withName("reaper")
+      .withPartitioner("murmur3")
+      .withSeedHosts(Sets.newHashSet("127.0.0.1"))
+      .withJmxPort(7199)
+      .build();
 
   @Before
   public void setUp() throws Exception {

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -22,7 +22,6 @@ import io.cassandrareaper.ReaperApplicationConfiguration;
 import io.cassandrareaper.ReaperApplicationConfiguration.DatacenterAvailability;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
-import io.cassandrareaper.core.ClusterProperties;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.core.NodeMetrics;
 import io.cassandrareaper.core.RepairRun;
@@ -41,10 +40,8 @@ import io.cassandrareaper.storage.MemoryStorage;
 
 import java.math.BigInteger;
 import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -121,9 +118,12 @@ public final class SegmentRunnerTest {
                         .build(),
                     cf.getId())));
 
-    context.storage.addCluster(
-        new Cluster(cf.getClusterName(), Optional.of("murmur3"), cf.getNodes(),
-            ClusterProperties.builder().withJmxPort(7199).build()));
+    context.storage.addCluster(Cluster.builder()
+        .withName(cf.getClusterName())
+        .withPartitioner("murmur3")
+        .withSeedHosts(cf.getNodes())
+        .withJmxPort(7199)
+        .build());
 
     final UUID runId = run.getId();
     final UUID segmentId = context.storage.getNextFreeSegmentInRange(run.getId(),
@@ -185,7 +185,7 @@ public final class SegmentRunnerTest {
     when(ru.getKeyspaceName()).thenReturn("reaper");
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
@@ -231,8 +231,12 @@ public final class SegmentRunnerTest {
                         .build(),
                     cf.getId())));
 
-    storage.addCluster(new Cluster(cf.getClusterName(), Optional.of("murmur3"), cf.getNodes(),
-            ClusterProperties.builder().withJmxPort(7199).build()));
+    storage.addCluster(Cluster.builder()
+        .withName(cf.getClusterName())
+        .withPartitioner("murmur3")
+        .withSeedHosts(cf.getNodes())
+        .withJmxPort(7199)
+        .build());
 
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
@@ -331,7 +335,7 @@ public final class SegmentRunnerTest {
     when(ru.getKeyspaceName()).thenReturn("reaper");
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
@@ -375,8 +379,12 @@ public final class SegmentRunnerTest {
                         .build(),
                     cf.getId())));
 
-    storage.addCluster(new Cluster(cf.getClusterName(), Optional.of("murmur3"), cf.getNodes(),
-            ClusterProperties.builder().withJmxPort(7199).build()));
+    storage.addCluster(Cluster.builder()
+        .withName(cf.getClusterName())
+        .withPartitioner("murmur3")
+        .withSeedHosts(cf.getNodes())
+        .withJmxPort(7199)
+        .build());
 
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
@@ -465,7 +473,7 @@ public final class SegmentRunnerTest {
     when(ru.getKeyspaceName()).thenReturn("reaper");
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
@@ -510,8 +518,12 @@ public final class SegmentRunnerTest {
                         .build(),
                     cf.getId())));
 
-    storage.addCluster(new Cluster(cf.getClusterName(), Optional.of("murmur3"), cf.getNodes(),
-            ClusterProperties.builder().withJmxPort(7199).build()));
+    storage.addCluster(Cluster.builder()
+        .withName(cf.getClusterName())
+        .withPartitioner("murmur3")
+        .withSeedHosts(cf.getNodes())
+        .withJmxPort(7199)
+        .build());
 
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
@@ -595,7 +607,7 @@ public final class SegmentRunnerTest {
     when(ru.getKeyspaceName()).thenReturn("reaper");
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
@@ -641,8 +653,12 @@ public final class SegmentRunnerTest {
                         .build(),
                     cf.getId())));
 
-    storage.addCluster(new Cluster(cf.getClusterName(), Optional.of("murmur3"), cf.getNodes(),
-            ClusterProperties.builder().withJmxPort(7199).build()));
+    storage.addCluster(Cluster.builder()
+        .withName(cf.getClusterName())
+        .withPartitioner("murmur3")
+        .withSeedHosts(cf.getNodes())
+        .withJmxPort(7199)
+        .build());
 
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
@@ -726,7 +742,7 @@ public final class SegmentRunnerTest {
     when(ru.getKeyspaceName()).thenReturn("reaper");
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
@@ -773,8 +789,12 @@ public final class SegmentRunnerTest {
                         .build(),
                     cf.getId())));
 
-    storage.addCluster(new Cluster(cf.getClusterName(), Optional.of("murmur3"), cf.getNodes(),
-            ClusterProperties.builder().withJmxPort(7199).build()));
+    storage.addCluster(Cluster.builder()
+        .withName(cf.getClusterName())
+        .withPartitioner("murmur3")
+        .withSeedHosts(cf.getNodes())
+        .withJmxPort(7199)
+        .build());
 
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
@@ -858,7 +878,7 @@ public final class SegmentRunnerTest {
     when(ru.getKeyspaceName()).thenReturn("reaper");
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
@@ -906,8 +926,12 @@ public final class SegmentRunnerTest {
                         .build(),
                     cf.getId())));
 
-    storage.addCluster(new Cluster(cf.getClusterName(), Optional.of("murmur3"), cf.getNodes(),
-            ClusterProperties.builder().withJmxPort(7199).build()));
+    storage.addCluster(Cluster.builder()
+        .withName(cf.getClusterName())
+        .withPartitioner("murmur3")
+        .withSeedHosts(cf.getNodes())
+        .withJmxPort(7199)
+        .build());
 
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
@@ -991,7 +1015,7 @@ public final class SegmentRunnerTest {
     when(ru.getKeyspaceName()).thenReturn("reaper");
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
@@ -1050,13 +1074,13 @@ public final class SegmentRunnerTest {
     Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
     JmxConnectionFactory jmxConnectionFactory = mock(JmxConnectionFactory.class);
     JmxProxy jmx = mock(JmxProxy.class);
-    when(jmxConnectionFactory.connect(any())).thenReturn(jmx);
+    when(jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     context.jmxConnectionFactory = jmxConnectionFactory;
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(DatacenterAvailability.LOCAL);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
 
     SegmentRunner segmentRunner = SegmentRunner.create(
             context,
@@ -1073,7 +1097,7 @@ public final class SegmentRunnerTest {
 
     Pair<String, Callable<Optional<NodeMetrics>>> result = segmentRunner.getNodeMetrics("node-some", "dc1", "dc2");
     assertFalse(result.getRight().call().isPresent());
-    verify(jmxConnectionFactory, times(0)).connect(any());
+    verify(jmxConnectionFactory, times(0)).connectAny(any(Collection.class));
     // Verify that we didn't call any method that is used in getRemoteNodeMetrics()
     verify((CassandraStorage)context.storage, times(0)).storeNodeMetrics(any(), any());
     verify((CassandraStorage)context.storage, times(0)).getNodeMetrics(any(), any());
@@ -1085,9 +1109,12 @@ public final class SegmentRunnerTest {
     context.storage = Mockito.mock(CassandraStorage.class);
 
     Mockito.when(((CassandraStorage) context.storage).getCluster(any()))
-        .thenReturn(
-            Optional.of(new Cluster("test", Optional.of("murmur3"), new HashSet<String>(Arrays.asList("test")),
-                ClusterProperties.builder().withJmxPort(7199).build())));
+        .thenReturn(Cluster.builder()
+          .withName("test")
+          .withPartitioner("murmur3")
+          .withSeedHosts(ImmutableSet.of("test"))
+          .withJmxPort(7199)
+          .build());
 
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getClusterName()).thenReturn("test");
@@ -1099,7 +1126,6 @@ public final class SegmentRunnerTest {
     JmxProxyTest.mockGetEndpointSnitchInfoMBean(proxy, endpointSnitchInfoMBeanMock);
 
     JmxConnectionFactory jmxConnectionFactory = mock(JmxConnectionFactory.class);
-    when(jmxConnectionFactory.connect(any())).thenReturn(proxy);
     when(jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(proxy);
     when(jmxConnectionFactory.getAccessibleDatacenters()).thenReturn(Sets.newHashSet("dc1"));
     context.jmxConnectionFactory = jmxConnectionFactory;
@@ -1107,7 +1133,7 @@ public final class SegmentRunnerTest {
     context.config.setDatacenterAvailability(DatacenterAvailability.LOCAL);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connectAndAllowSidecar(any(), any())).thenReturn(proxy);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(proxy);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
 
     SegmentRunner segmentRunner = SegmentRunner.create(

--- a/src/server/src/test/java/io/cassandrareaper/service/StreamServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/StreamServiceTest.java
@@ -69,9 +69,10 @@ public class StreamServiceTest {
     when(cxt.jmxConnectionFactory.connectAny(Mockito.anyList())).thenReturn(proxy);
     ClusterFacade clusterFacadeSpy = Mockito.spy(ClusterFacade.create(cxt));
     Mockito.doReturn("dc1").when(clusterFacadeSpy).getDatacenter(any());
+
     StreamService
         .create(() -> clusterFacadeSpy)
-        .listStreams(Node.builder().withClusterName("test").withHostname("127.0.0.1").build());
+        .listStreams(Node.builder().withHostname("127.0.0.1").build());
 
     verify(streamingManagerMBean, times(1)).getCurrentStreams();
   }
@@ -97,7 +98,6 @@ public class StreamServiceTest {
     AppContext cxt = new AppContext();
     cxt.config = TestRepairConfiguration.defaultConfig();
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
-    when(cxt.jmxConnectionFactory.connect(Mockito.any(Node.class))).thenReturn(proxy);
     when(cxt.jmxConnectionFactory.connectAny(Mockito.anyList())).thenReturn(proxy);
     ClusterFacade clusterFacadeSpy = Mockito.spy(ClusterFacade.create(cxt));
     Mockito.doReturn("dc1").when(clusterFacadeSpy).getDatacenter(any());
@@ -105,7 +105,7 @@ public class StreamServiceTest {
     // do the actual pullStreams() call, which should succeed
     List<StreamSession> result = StreamService
         .create(() -> clusterFacadeSpy)
-        .listStreams(Node.builder().withClusterName("test").withHostname("127.0.0.1").build());
+        .listStreams(Node.builder().withHostname("127.0.0.1").build());
 
     verify(streamingManagerMBean, times(1)).getCurrentStreams();
     assertEquals(1, result.size());
@@ -132,7 +132,6 @@ public class StreamServiceTest {
     AppContext cxt = new AppContext();
     cxt.config = TestRepairConfiguration.defaultConfig();
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
-    when(cxt.jmxConnectionFactory.connect(Mockito.any(Node.class))).thenReturn(proxy);
     when(cxt.jmxConnectionFactory.connectAny(Mockito.anyList())).thenReturn(proxy);
     ClusterFacade clusterFacadeSpy = Mockito.spy(ClusterFacade.create(cxt));
     Mockito.doReturn("dc1").when(clusterFacadeSpy).getDatacenter(any());
@@ -140,7 +139,7 @@ public class StreamServiceTest {
     // do the actual pullStreams() call, which should succeed
     List<StreamSession> result = StreamService
         .create(() -> clusterFacadeSpy)
-        .listStreams(Node.builder().withClusterName("test").withHostname("127.0.0.1").build());
+        .listStreams(Node.builder().withHostname("127.0.0.1").build());
 
     verify(streamingManagerMBean, times(1)).getCurrentStreams();
     assertEquals(1, result.size());
@@ -167,7 +166,6 @@ public class StreamServiceTest {
     AppContext cxt = new AppContext();
     cxt.config = TestRepairConfiguration.defaultConfig();
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
-    when(cxt.jmxConnectionFactory.connect(Mockito.any(Node.class))).thenReturn(proxy);
     when(cxt.jmxConnectionFactory.connectAny(Mockito.anyList())).thenReturn(proxy);
     ClusterFacade clusterFacadeSpy = Mockito.spy(ClusterFacade.create(cxt));
     Mockito.doReturn("dc1").when(clusterFacadeSpy).getDatacenter(any());
@@ -175,7 +173,7 @@ public class StreamServiceTest {
     // do the actual pullStreams() call, which should succeed
     List<StreamSession> result = StreamService
         .create(() -> clusterFacadeSpy)
-        .listStreams(Node.builder().withClusterName("test").withHostname("127.0.0.1").build());
+        .listStreams(Node.builder().withHostname("127.0.0.1").build());
 
     verify(streamingManagerMBean, times(1)).getCurrentStreams();
     assertEquals(1, result.size());
@@ -202,7 +200,6 @@ public class StreamServiceTest {
     AppContext cxt = new AppContext();
     cxt.config = TestRepairConfiguration.defaultConfig();
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
-    when(cxt.jmxConnectionFactory.connect(Mockito.any(Node.class))).thenReturn(proxy);
     when(cxt.jmxConnectionFactory.connectAny(Mockito.anyList())).thenReturn(proxy);
     ClusterFacade clusterFacadeSpy = Mockito.spy(ClusterFacade.create(cxt));
     Mockito.doReturn("dc1").when(clusterFacadeSpy).getDatacenter(any());
@@ -210,7 +207,7 @@ public class StreamServiceTest {
     // do the actual pullStreams() call, which should succeed
     List<StreamSession> result = StreamService
         .create(() -> clusterFacadeSpy)
-        .listStreams(Node.builder().withClusterName("test").withHostname("127.0.0.1").build());
+        .listStreams(Node.builder().withHostname("127.0.0.1").build());
 
     verify(streamingManagerMBean, times(1)).getCurrentStreams();
     assertEquals(1, result.size());


### PR DESCRIPTION
**Add `State` and `Last Contact` fields to the Cluster object**  
  - Introduces cluster states: UNKNOWN, ACTIVE, UNREACHABLE, DELETED
 - The UNKNOWN state is needed as a cluster object is often created on-the-fly to pass through jmx port and credentials as connection information
 - Clusters can only be marked as DELETED if they have no active schedules and no running repairs
 - Clusters are marked ACTIVE (and last_contact) updated on successful jmx requests are made against them
 - Clusters are sorted by state then name
 - DELETED clusters are not listed

**Introduce `Cluster.Builder`**  
  - IStorage no longer returns Optionals against Cluster methods, if the name argument is wrong it throws an IllegalArgumentException instead,
 - Node.withClusterName(..) method and usage removed, as it was never used anywhere,
 - Rationalise ClusterFacade connection methods, simplify connection method names.
 - Remove JmxConnectionFactory.connect(node) method, only tests were using it.


WAS
> Add "&force=true` query parameter to the delete cluster rest endpoint that forcible deletes a cluster (by first deleting all schedules and repairs belonging to it).
> 
> Also add the functionality to detect conflicting clusters (two clusters using seeds of the same ipaddress) and to delete the cluster(s) that no longer exists.
> 
> The significant patch is the first commit.