### PR TITLE
Fix travis deploy

### DIFF
--- a/src/ci/before_deploy.sh
+++ b/src/ci/before_deploy.sh
@@ -20,7 +20,7 @@ mkdir -p src/packages
 
 if [ "${TRAVIS_BRANCH}" = "master" -a ! -d "cassandra-reaper-master" ]
 then
-    VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
+    export VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
     DATE=$(date +"%Y%m%d")
     RELEASEDATE=$(date +"%Y-%m-%d")
     RPM_VERSION=$(echo "${VERSION}" | sed "s/-/_/")
@@ -58,7 +58,7 @@ then
 fi
 if [ "x${TRAVIS_TAG}" != "x" -a ! -d "cassandra-reaper-${TRAVIS_TAG}" ]
 then
-    VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
+    export VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
     RELEASEDATE=$(date +"%Y-%m-%d")
     # Update Bintray descriptor files with appropriate version numbers and release dates
     sed -i "s/VERSION/${VERSION}/g" src/ci/descriptor-rpm.json

--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -13,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Using mvn:
-VERSION := `mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version -f ../../pom.xml | grep -v '\['`
-
-# Using python:
-# VERSION := `python -c "import xml.etree.ElementTree as ET; print(ET.parse(open('pom.xml')).getroot().find('{http://maven.apache.org/POM/4.0.0}version').text)"`
-
 package:
 	mvn -B clean package  -f ../../pom.xml -DskipTests
 


### PR DESCRIPTION
The Makefile couldn't evaluate anymore the maven command to parse the version number.
Fixed by exporting the VERSION var in before_deploy.sh and then use it directly in the Makefile.