### PR TITLE
Self register clusters in sidecar mode since the nodes are collocated with Reaper

### DIFF
--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -44,6 +44,8 @@ rpm: prepare
 
 all: package deb rpm
 
+build-packages: deb rpm
+
 clean:
 	rm -Rf packages/*
 	rm -Rf build/*

--- a/src/packaging/docker-build/Dockerfile
+++ b/src/packaging/docker-build/Dockerfile
@@ -45,8 +45,6 @@ RUN mkdir -p /tmp/src
 COPY src/server /tmp/src/server
 COPY src/ui /tmp/src/ui
 WORKDIR /tmp
-RUN mvn clean package -DskipTests \
-    && mvn clean package  -DskipTests
 WORKDIR ${WORKDIR}
 
 # Add entrypoint script

--- a/src/packaging/docker-build/docker-compose.yml
+++ b/src/packaging/docker-build/docker-compose.yml
@@ -23,3 +23,4 @@ services:
     volumes:
       - ../../..:/usr/src/app/cassandra-reaper
       - ../../packages:/usr/src/app/packages
+      - ~/.m2:/root/.m2

--- a/src/packaging/docker-build/docker-entrypoint.sh
+++ b/src/packaging/docker-build/docker-entrypoint.sh
@@ -23,7 +23,7 @@ set -ex
 cd ${WORKDIR}/cassandra-reaper
 export VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
 cd ${WORKDIR}/cassandra-reaper/src/packaging \
-    && make all \
+    && make build-packages \
     && mv *.deb *.rpm ${WORKDIR}/packages \
     && cp ../server/target/cassandra-*.jar ${WORKDIR}/packages \
     && rm ${WORKDIR}/packages/cassandra*-sources.jar

--- a/src/packaging/docker-build/docker-entrypoint.sh
+++ b/src/packaging/docker-build/docker-entrypoint.sh
@@ -20,6 +20,8 @@ set -ex
 # build web UI
 # build Debian and RPM packages
 # copy built packages into a mounted volume
+cd ${WORKDIR}/cassandra-reaper
+export VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
 cd ${WORKDIR}/cassandra-reaper/src/packaging \
     && make all \
     && mv *.deb *.rpm ${WORKDIR}/packages \

--- a/src/packaging/resource/cassandra-reaper-cassandra-sidecar.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra-sidecar.yaml
@@ -22,16 +22,18 @@ repairIntensity: 0.9
 scheduleDaysBetween: 7
 repairRunThreadCount: 15
 hangingRepairTimeoutMins: 30
-storageType: memory
+storageType: cassandra
 enableCrossOrigin: true
 incrementalRepair: false
 blacklistTwcsTables: true
 enableDynamicSeedList: true
 repairManagerSchedulingIntervalSeconds: 10
+activateQueryLogger: false
 jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
 # purgeRecordsAfterInDays: 30
 # numberOfRunsToKeepPerUnit: 10
+enableConcurrentMigrations: true
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH | SIDECAR
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible
@@ -42,19 +44,8 @@ useAddressTranslator: false
 # If jmx access is restricted to localhost, then configure to SIDECAR.
 #
 # The default is ALL
-datacenterAvailability: ALL
+datacenterAvailability: SIDECAR
 
-
-# any cassandra nodes on 127.0.0.x addresses we presume are ccm nodes
-jmxPorts:
-  127.0.0.1: 7100
-  127.0.0.2: 7200
-  127.0.0.3: 7300
-  127.0.0.4: 7400
-  127.0.0.5: 7500
-  127.0.0.6: 7600
-  127.0.0.7: 7700
-  127.0.0.8: 7800
 
 #jmxAuth:
 #  username: myUsername
@@ -63,6 +54,14 @@ jmxPorts:
 logging:
   level: INFO
   loggers:
+    com.datastax.driver.core.QueryLogger.NORMAL:
+      level: DEBUG
+      additive: false
+      appenders:
+        - type: file
+          currentLogFilename: /var/log/cassandra-reaper/query-logger.log
+          archivedLogFilenamePattern: query-logger-%d.log.gz
+          archivedFileCount: 2
     io.dropwizard: WARN
     org.eclipse.jetty: WARN
   appenders:
@@ -88,6 +87,18 @@ server:
   requestLog:
     appenders: []
 
+cassandra:
+  clusterName: "test"
+  contactPoints: ["127.0.0.1"]
+  keyspace: reaper_db
+  loadBalancingPolicy:
+    type: tokenAware
+    shuffleReplicas: true
+    subPolicy:
+      type: dcAwareRoundRobin
+      localDC:
+      usedHostsPerRemoteDC: 0
+      allowRemoteDCsForLocalConsistencyLevel: false
 autoScheduling:
   enabled: false
   initialDelayPeriod: PT15S

--- a/src/packaging/resource/cassandra-reaper-cassandra-ssl.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra-ssl.yaml
@@ -25,7 +25,7 @@ hangingRepairTimeoutMins: 30
 storageType: cassandra
 enableCrossOrigin: true
 incrementalRepair: false
-blacklistTwcsTables: false
+blacklistTwcsTables: true
 repairManagerSchedulingIntervalSeconds: 10
 activateQueryLogger: false
 jmxConnectionTimeoutInSeconds: 5
@@ -33,12 +33,13 @@ useAddressTranslator: false
 # purgeRecordsAfterInDays: 30
 # numberOfRunsToKeepPerUnit: 10
 
-# datacenterAvailability has three possible values: ALL | LOCAL | EACH
+# datacenterAvailability has three possible values: ALL | LOCAL | EACH | SIDECAR
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible
 # If the reaper has access to all node jmx ports, across all datacenters, then configure to ALL.
 # If jmx access is only available to nodes in the same datacenter as reaper in running in, then configure to LOCAL.
 # If there's a reaper instance running in every datacenter, and it's important that nodes under duress are not involved in repairs,
 #    then configure to EACH.
+# If jmx access is restricted to localhost, then configure to SIDECAR.
 #
 # The default is ALL
 datacenterAvailability: ALL

--- a/src/packaging/resource/cassandra-reaper-cassandra.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra.yaml
@@ -25,7 +25,7 @@ hangingRepairTimeoutMins: 30
 storageType: cassandra
 enableCrossOrigin: true
 incrementalRepair: false
-blacklistTwcsTables: false
+blacklistTwcsTables: true
 enableDynamicSeedList: true
 repairManagerSchedulingIntervalSeconds: 10
 activateQueryLogger: false
@@ -34,12 +34,13 @@ useAddressTranslator: false
 # purgeRecordsAfterInDays: 30
 # numberOfRunsToKeepPerUnit: 10
 
-# datacenterAvailability has three possible values: ALL | LOCAL | EACH
+# datacenterAvailability has three possible values: ALL | LOCAL | EACH | SIDECAR
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible
 # If the reaper has access to all node jmx ports, across all datacenters, then configure to ALL.
 # If jmx access is only available to nodes in the same datacenter as reaper in running in, then configure to LOCAL.
 # If there's a reaper instance running in every datacenter, and it's important that nodes under duress are not involved in repairs,
 #    then configure to EACH.
+# If jmx access is restricted to localhost, then configure to SIDECAR.
 #
 # The default is ALL
 datacenterAvailability: ALL

--- a/src/packaging/resource/cassandra-reaper-h2.yaml
+++ b/src/packaging/resource/cassandra-reaper-h2.yaml
@@ -25,7 +25,7 @@ hangingRepairTimeoutMins: 30
 storageType: h2
 enableCrossOrigin: true
 incrementalRepair: false
-blacklistTwcsTables: false
+blacklistTwcsTables: true
 enableDynamicSeedList: true
 repairManagerSchedulingIntervalSeconds: 10
 jmxConnectionTimeoutInSeconds: 5
@@ -33,12 +33,13 @@ useAddressTranslator: false
 # purgeRecordsAfterInDays: 30
 # numberOfRunsToKeepPerUnit: 10
 
-# datacenterAvailability has three possible values: ALL | LOCAL | EACH
+# datacenterAvailability has three possible values: ALL | LOCAL | EACH | SIDECAR
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible
 # If the reaper has access to all node jmx ports, across all datacenters, then configure to ALL.
 # If jmx access is only available to nodes in the same datacenter as reaper in running in, then configure to LOCAL.
 # If there's a reaper instance running in every datacenter, and it's important that nodes under duress are not involved in repairs,
 #    then configure to EACH.
+# If jmx access is restricted to localhost, then configure to SIDECAR.
 #
 # The default is ALL
 datacenterAvailability: ALL

--- a/src/packaging/resource/cassandra-reaper-postgres.yaml
+++ b/src/packaging/resource/cassandra-reaper-postgres.yaml
@@ -25,7 +25,7 @@ hangingRepairTimeoutMins: 30
 storageType: postgres
 enableCrossOrigin: true
 incrementalRepair: false
-blacklistTwcsTables: false
+blacklistTwcsTables: true
 enableDynamicSeedList: true
 repairManagerSchedulingIntervalSeconds: 10
 jmxConnectionTimeoutInSeconds: 5
@@ -33,12 +33,13 @@ useAddressTranslator: false
 # purgeRecordsAfterInDays: 30
 # numberOfRunsToKeepPerUnit: 10
 
-# datacenterAvailability has three possible values: ALL | LOCAL | EACH
+# datacenterAvailability has three possible values: ALL | LOCAL | EACH | SIDECAR
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible
 # If the reaper has access to all node jmx ports, across all datacenters, then configure to ALL.
 # If jmx access is only available to nodes in the same datacenter as reaper in running in, then configure to LOCAL.
 # If there's a reaper instance running in every datacenter, and it's important that nodes under duress are not involved in repairs,
 #    then configure to EACH.
+# If jmx access is restricted to localhost, then configure to SIDECAR.
 #
 # The default is ALL
 datacenterAvailability: ALL

--- a/src/packaging/resource/cassandra-reaper.yaml
+++ b/src/packaging/resource/cassandra-reaper.yaml
@@ -25,7 +25,7 @@ hangingRepairTimeoutMins: 30
 storageType: memory
 enableCrossOrigin: true
 incrementalRepair: false
-blacklistTwcsTables: false
+blacklistTwcsTables: true
 enableDynamicSeedList: true
 repairManagerSchedulingIntervalSeconds: 10
 activateQueryLogger: false
@@ -34,12 +34,13 @@ useAddressTranslator: false
 # purgeRecordsAfterInDays: 30
 # numberOfRunsToKeepPerUnit: 10
 
-# datacenterAvailability has three possible values: ALL | LOCAL | EACH
+# datacenterAvailability has three possible values: ALL | LOCAL | EACH | SIDECAR
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible
 # If the reaper has access to all node jmx ports, across all datacenters, then configure to ALL.
 # If jmx access is only available to nodes in the same datacenter as reaper in running in, then configure to LOCAL.
 # If there's a reaper instance running in every datacenter, and it's important that nodes under duress are not involved in repairs,
 #    then configure to EACH.
+# If jmx access is restricted to localhost, then configure to SIDECAR.
 #
 # The default is ALL
 datacenterAvailability: ALL

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -150,6 +150,10 @@ public final class ReaperApplicationConfiguration extends Configuration {
   @JsonProperty
   private Optional<String> enforcedLocalDatacenter = Optional.empty();
 
+  @JsonProperty
+  @DefaultValue("false")
+  private Boolean enableConcurrentMigrations;
+
   public int getSegmentCount() {
     return segmentCount == null ? 0 : segmentCount;
   }
@@ -434,7 +438,13 @@ public final class ReaperApplicationConfiguration extends Configuration {
     this.enforcedLocalDatacenter = enforcedLocalDatacenter;
   }
 
+  public boolean getEnableConcurrentMigrations() {
+    return this.enableConcurrentMigrations == null ? false : this.enableConcurrentMigrations;
+  }
 
+  public void setEnableConcurrentMigrations(boolean enableConcurrentMigrations) {
+    this.enableConcurrentMigrations = enableConcurrentMigrations;
+  }
 
   public static final class JmxCredentials {
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -80,18 +80,4 @@ public interface IDistributedStorage {
   void storeOperations(String clusterName, OpType operationType, String host, String operationsJson);
 
   String listOperations(String clusterName, OpType operationType, String host);
-  /*
-  void storeCompactions(String clusterName, String host, List<Compaction> activeCompactions)
-      throws JsonProcessingException;
-
-  List<Compaction> listCompactions(String clusterName, String host)
-      throws JsonProcessingException, IOException;
-
-  void storeStreams(String clusterName, String host, Set<CompositeData> activeStreams)
-      throws JsonProcessingException;
-
-  Set<CompositeData> listStreamingOperations(String clusterName, String host)
-      throws JsonProcessingException, IOException;
-  */
-
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/SchemaMigrationLock.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/SchemaMigrationLock.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019-2019 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cassandra;
+
+import io.cassandrareaper.ReaperApplicationConfiguration;
+
+import java.util.UUID;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.VersionNumber;
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class SchemaMigrationLock implements AutoCloseable {
+
+  private static final UUID SCHEMA_MIGRATION_LOCK_ID = UUIDs.startOf(1);
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaMigrationLock.class);
+  private final Session session;
+  private final boolean locked;
+
+  public SchemaMigrationLock(VersionNumber version, Session session, ReaperApplicationConfiguration config) {
+
+    Preconditions.checkArgument(
+        !config.isInSidecarMode() || config.getEnableConcurrentMigrations(),
+        "Running in sidecar mode and concurrent migrations are not enabled.");
+
+    this.session = session;
+    this.locked = migrationConsensusAvailable(config, version) && lockSchemaMigration();
+  }
+
+  @Override
+  public void close() {
+    if (locked) {
+      unlockSchemaMigration();
+    }
+  }
+
+  private boolean lockSchemaMigration() {
+    while (true) {
+      LOG.debug("Trying to take lead on schema migrations");
+
+      ResultSet lwtResult = session.execute(
+          "INSERT INTO system_distributed.parent_repair_history (parent_id, started_at) VALUES ("
+            + SCHEMA_MIGRATION_LOCK_ID + ", dateOf(now())) IF NOT EXISTS USING TTL 300");
+
+      if (lwtResult.wasApplied()) {
+        LOG.debug("Took lead on schema migrations");
+        return true;
+      }
+
+      LOG.info("Cannot grab the lock on schema migration. Waiting for it to be released...");
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+
+  private synchronized boolean unlockSchemaMigration() {
+    LOG.debug("Trying to take lead on schema migrations");
+
+    ResultSet lwtResult = session.execute(
+        "DELETE FROM system_distributed.parent_repair_history WHERE parent_id = " + SCHEMA_MIGRATION_LOCK_ID
+        + " IF EXISTS");
+
+    if (lwtResult.wasApplied()) {
+      LOG.debug("Released lead on schema migrations");
+      return true;
+    }
+    // Another instance took the lead on the segment
+    LOG.error("Could not release lead on schema migrations");
+    return false;
+  }
+
+  private static boolean migrationConsensusAvailable(ReaperApplicationConfiguration config, VersionNumber version) {
+    return config.getEnableConcurrentMigrations() && VersionNumber.parse("2.2").compareTo(version) <= 0;
+  }
+}

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -17,6 +17,7 @@
 
 package io.cassandrareaper.acceptance;
 
+import io.cassandrareaper.AppContext;
 import io.cassandrareaper.SimpleReaperClient;
 import io.cassandrareaper.core.DroppedMessages;
 import io.cassandrareaper.core.MetricsHistogram;
@@ -227,7 +228,10 @@ public final class BasicSteps {
         String responseData = response.readEntity(String.class);
         Assertions.assertThat(responseData).isNotBlank();
         List<String> clusterNames = SimpleReaperClient.parseClusterNameListJSON(responseData);
-        assertEquals(0, clusterNames.size());
+        if (!((AppContext) runner.runnerInstance.getContext()).config.isInSidecarMode()) {
+          // Sidecar self registers clusters
+          assertEquals(0, clusterNames.size());
+        }
       });
     }
   }
@@ -261,7 +265,8 @@ public final class BasicSteps {
         Assertions.assertThat(responseData).isNotBlank();
         Map<String, Object> cluster = SimpleReaperClient.parseClusterStatusJSON(responseData);
 
-        if (Response.Status.CREATED.getStatusCode() == responseStatus) {
+        if (Response.Status.CREATED.getStatusCode() == responseStatus
+            || ((AppContext) runner.runnerInstance.getContext()).config.isInSidecarMode()) {
           TestContext.TEST_CLUSTER = (String) cluster.get("name");
         }
       });

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/ReaperTestJettyRunner.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/ReaperTestJettyRunner.java
@@ -156,7 +156,7 @@ public final class ReaperTestJettyRunner {
       }
     }
 
-    private Object getContext() {
+    Object getContext() {
       try {
         Method method = supportCls.getMethod("getApplication");
         Object application = method.invoke(support);

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -19,6 +19,7 @@ package io.cassandrareaper.service;
 
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperApplicationConfiguration;
+import io.cassandrareaper.ReaperApplicationConfiguration.DatacenterAvailability;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.Node;
@@ -536,11 +537,13 @@ public final class RepairRunnerTest {
   public void getPossibleParallelRepairsTest() throws Exception {
     Map<List<String>, List<String>> map = RepairRunnerTest.threeNodeCluster();
     Map<String, String> endpointsThreeNodes = RepairRunnerTest.threeNodeClusterEndpoint();
-    assertEquals(1, RepairRunner.getPossibleParallelRepairsCount(map, endpointsThreeNodes));
+    assertEquals(1, RepairRunner.getPossibleParallelRepairsCount(map, endpointsThreeNodes, DatacenterAvailability.ALL));
 
     map = RepairRunnerTest.sixNodeCluster();
     Map<String, String> endpointsSixNodes = RepairRunnerTest.sixNodeClusterEndpoint();
-    assertEquals(2, RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes));
+    assertEquals(2, RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes, DatacenterAvailability.ALL));
+    assertEquals(1,
+        RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes, DatacenterAvailability.SIDECAR));
   }
 
   @Test
@@ -561,7 +564,7 @@ public final class RepairRunnerTest {
     Map<String, String> endpointsSixNodes = RepairRunnerTest.sixNodeClusterEndpoint();
 
     List<RingRange> ranges = RepairRunner.getParallelRanges(
-            RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes),
+            RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes, DatacenterAvailability.ALL),
             Lists.newArrayList(
                 Collections2.transform(segments, segment -> segment.getBaseRange())));
 
@@ -587,7 +590,7 @@ public final class RepairRunnerTest {
             32, tokens, Boolean.FALSE, RepairRunService.buildReplicasToRangeMap(map), "2.2.10");
 
     List<RingRange> ranges = RepairRunner.getParallelRanges(
-            RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes),
+            RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes, DatacenterAvailability.ALL),
             Lists.newArrayList(
                 Collections2.transform(segments, segment -> segment.getBaseRange())));
 

--- a/src/server/src/test/resources/reaper-cassandra-sidecar1-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar1-at.yaml
@@ -29,6 +29,7 @@ datacenterAvailability: SIDECAR
 enforcedLocalNode: 127.0.0.1
 enforcedLocalClusterName: test
 enforcedLocalDatacenter: dc1
+enableConcurrentMigrations: true
 
 logging:
   level: WARN

--- a/src/server/src/test/resources/reaper-cassandra-sidecar2-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar2-at.yaml
@@ -29,6 +29,7 @@ datacenterAvailability: SIDECAR
 enforcedLocalNode: 127.0.0.2
 enforcedLocalClusterName: test
 enforcedLocalDatacenter: dc1
+enableConcurrentMigrations: true
 
 logging:
   level: WARN

--- a/src/server/src/test/resources/reaper-cassandra-sidecar3-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar3-at.yaml
@@ -29,6 +29,7 @@ datacenterAvailability: SIDECAR
 enforcedLocalNode: 127.0.0.3
 enforcedLocalClusterName: test
 enforcedLocalDatacenter: dc2
+enableConcurrentMigrations: true
 
 logging:
   level: WARN

--- a/src/server/src/test/resources/reaper-cassandra-sidecar4-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar4-at.yaml
@@ -29,6 +29,7 @@ datacenterAvailability: SIDECAR
 enforcedLocalNode: 127.0.0.4
 enforcedLocalClusterName: test
 enforcedLocalDatacenter: dc2
+enableConcurrentMigrations: true
 
 logging:
   level: WARN


### PR DESCRIPTION
In order to achieve this, I did the following:

To avoid code duplication, I made public the `addOrUpdateCluster()` method from `ClusterResource` so that it could be invoked upon startup, when initializing the sidecar mode.
Since the instances will now self register the cluster in sidecar mode, it was required to update the integration tests so that they wouldn't check the number of clusters in storage for sidecar, and retrieve the cluster name even if it already existed.
The jetty runners needed to have an additional member that exposes their `datacenterAvailability` to the Cucumber tests.