### PR TITLE
Handle unreachable clusters

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -492,6 +492,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
           .storage
           .getClusters()
           .parallelStream()
+          .sorted()
           .forEach(cluster -> jmxConnectionsIntializer.on(cluster));
 
       LOG.info("Initialized JMX seed list for all clusters.");

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -117,6 +117,10 @@ public final class ReaperApplicationConfiguration extends Configuration {
   private Integer jmxConnectionTimeoutInSeconds;
 
   @JsonProperty
+  @DefaultValue("7")
+  private Integer clusterTimeoutInDays;
+
+  @JsonProperty
   private DatacenterAvailability datacenterAvailability;
 
   @JsonProperty private AccessControlConfiguration accessControl;
@@ -360,6 +364,15 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   public int getJmxConnectionTimeoutInSeconds() {
     return jmxConnectionTimeoutInSeconds != null ? jmxConnectionTimeoutInSeconds : 20;
+  }
+
+  @JsonProperty
+  public void setClusterTimeoutInDays(int clusterTimeoutInDays) {
+    this.clusterTimeoutInDays = clusterTimeoutInDays;
+  }
+
+  public int getClusterTimeoutInDays() {
+    return clusterTimeoutInDays != null ? clusterTimeoutInDays : 7;
   }
 
   @JsonProperty

--- a/src/server/src/main/java/io/cassandrareaper/core/Cluster.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/Cluster.java
@@ -17,29 +17,42 @@
 
 package io.cassandrareaper.core;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.base.Preconditions;
 
-public final class Cluster {
+public final class Cluster implements Comparable<Cluster> {
+
+  public enum State {
+    UNKNOWN,
+    ACTIVE,
+    UNREACHABLE
+  }
 
   public static final int DEFAULT_JMX_PORT = 7199;
 
   private final String name;
   private final Optional<String> partitioner; // Full name of the partitioner class
   private final Set<String> seedHosts;
+  private final State state;
+  private final LocalDate lastContact;
   private final ClusterProperties properties;
 
   private Cluster(
       String name,
       Optional<String> partitioner,
       Set<String> seedHosts,
+      State state,
+      LocalDate lastContact,
       ClusterProperties properties) {
 
     this.name = toSymbolicName(name);
     this.partitioner = partitioner;
     this.seedHosts = seedHosts;
+    this.state = state;
+    this.lastContact = lastContact;
     this.properties = properties;
   }
 
@@ -51,6 +64,8 @@ public final class Cluster {
     Builder builder = new Builder()
         .withName(name)
         .withSeedHosts(seedHosts)
+        .withState(state)
+        .withLastContact(lastContact)
         .withJmxPort(getJmxPort());
 
     if (partitioner.isPresent()) {
@@ -80,8 +95,23 @@ public final class Cluster {
     return properties.getJmxPort();
   }
 
+  public State getState() {
+    return state;
+  }
+
+  public LocalDate getLastContact() {
+    return lastContact;
+  }
+
   public ClusterProperties getProperties() {
     return properties;
+  }
+
+  @Override
+  public int compareTo(Cluster other) {
+    return this.getState() == other.getState()
+        ? this.getName().compareTo(other.getName())
+        : this.getState().compareTo(other.getState());
   }
 
   public static final class Builder {
@@ -89,6 +119,8 @@ public final class Cluster {
     private String name;
     private String partitioner;
     private Set<String> seedHosts;
+    private State state = State.UNKNOWN;
+    private LocalDate lastContact = LocalDate.MIN;
     private final ClusterProperties.Builder properties = ClusterProperties.builder().withJmxPort(DEFAULT_JMX_PORT);
 
     private Builder() {
@@ -107,7 +139,20 @@ public final class Cluster {
     }
 
     public Builder withSeedHosts(Set<String> seedHosts) {
+      Preconditions.checkArgument(!seedHosts.isEmpty());
       this.seedHosts = seedHosts;
+      return this;
+    }
+
+    public Builder withState(State state) {
+      Preconditions.checkNotNull(state);
+      this.state = state;
+      return this;
+    }
+
+    public Builder withLastContact(LocalDate lastContact) {
+      Preconditions.checkNotNull(lastContact);
+      this.lastContact = lastContact;
       return this;
     }
 
@@ -120,7 +165,7 @@ public final class Cluster {
       Preconditions.checkNotNull(name);
       Preconditions.checkNotNull(seedHosts);
 
-      return new Cluster(name, Optional.ofNullable(partitioner), seedHosts, properties.build());
+      return new Cluster(name, Optional.ofNullable(partitioner), seedHosts, state, lastContact, properties.build());
     }
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
@@ -146,20 +145,6 @@ public class JmxConnectionFactory {
       }
     }
     throw new ReaperException("no host could be reached through JMX");
-  }
-
-  @VisibleForTesting
-  public JmxProxy connectAny(Cluster cluster) throws ReaperException {
-    Set<Node> nodes = cluster
-            .getSeedHosts()
-            .stream()
-            .map(host -> Node.builder().withCluster(cluster).withHostname(host).build())
-            .collect(Collectors.toSet());
-
-    if (nodes == null || nodes.isEmpty()) {
-      throw new ReaperException("no seeds in cluster with name: " + cluster.getName());
-    }
-    return connectAny(nodes);
   }
 
   public final void setJmxAuth(JmxCredentials jmxAuth) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -17,7 +17,6 @@
 
 package io.cassandrareaper.storage;
 
-import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSchedule;
@@ -70,7 +69,7 @@ public interface IStorage {
 
   Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId);
 
-  Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState) throws ReaperException;
+  Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState);
 
   /**
    * Delete the RepairRun instance identified by the given id, and delete also all the related repair segments.

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -89,19 +89,28 @@ public final class MemoryStorage implements IStorage {
 
 
   private boolean addClusterAssertions(Cluster cluster) {
+    Preconditions.checkState(
+        Cluster.State.UNKNOWN != cluster.getState(),
+        "Cluster should not be persisted with UNKNOWN state");
+
     // TODO – unit tests need to also always set the paritioner
     //Preconditions.checkState(cluster.getPartitioner().isPresent(), "Cannot store cluster with no partitioner.");
 
+    // assert we're not overwriting a cluster with the same name but different node list
+    Set<String> previousNodes;
     try {
-      // assert we're not overwriting a cluster with the same name but different node list
-      Set<String> previousNodes = getCluster(cluster.getName()).getSeedHosts();
-      Set<String> addedNodes = cluster.getSeedHosts();
+      previousNodes = getCluster(cluster.getName()).getSeedHosts();
+    } catch (IllegalArgumentException ignore) {
+      // there is no previous cluster with same name
+      previousNodes = cluster.getSeedHosts();
+    }
+    Set<String> addedNodes = cluster.getSeedHosts();
 
-      Preconditions.checkArgument(
-          !Collections.disjoint(previousNodes, addedNodes),
-          "Trying to add/update cluster using an existing name: %s. No nodes overlap between %s and %s",
-          cluster.getName(), StringUtils.join(previousNodes, ','), StringUtils.join(addedNodes, ','));
-    } catch (IllegalArgumentException ignore) { }
+    Preconditions.checkArgument(
+        !Collections.disjoint(previousNodes, addedNodes),
+        "Trying to add/update cluster using an existing name: %s. No nodes overlap between %s and %s",
+        cluster.getName(), StringUtils.join(previousNodes, ','), StringUtils.join(addedNodes, ','));
+
     return true;
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/ClusterMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/ClusterMapper.java
@@ -58,6 +58,10 @@ public final class ClusterMapper implements ResultSetMapper<Cluster> {
     Cluster.Builder builder = Cluster.builder()
         .withName(rs.getString("name"))
         .withSeedHosts(ImmutableSet.copyOf(seedHosts))
+        .withState(null != rs.getString("state")
+            ? Cluster.State.valueOf(rs.getString("state"))
+            : Cluster.State.UNKNOWN)
+        .withLastContact(rs.getDate("last_contact").toLocalDate())
         .withJmxPort(clusterProperties.getJmxPort());
 
     if (null != rs.getString("partitioner")) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -30,6 +30,7 @@ import io.cassandrareaper.service.RepairParameters;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -53,15 +54,15 @@ public interface IStoragePostgreSql {
 
   // Cluster
   //
-  String SQL_CLUSTER_ALL_FIELDS = "name, partitioner, seed_hosts, properties";
+  String SQL_CLUSTER_ALL_FIELDS = "name, partitioner, seed_hosts, properties, state, last_contact";
   String SQL_GET_ALL_CLUSTERS = "SELECT " + SQL_CLUSTER_ALL_FIELDS + " FROM cluster";
   String SQL_GET_CLUSTER = "SELECT " + SQL_CLUSTER_ALL_FIELDS + " FROM cluster WHERE name = :name";
   String SQL_INSERT_CLUSTER
       = "INSERT INTO cluster ("
           + SQL_CLUSTER_ALL_FIELDS
-          + ") VALUES (:name, :partitioner, :seedHosts, :properties)";
+          + ") VALUES (:name, :partitioner, :seedHosts, :properties, :state, :lastContact)";
   String SQL_UPDATE_CLUSTER = "UPDATE cluster SET partitioner = :partitioner, "
-      + "seed_hosts = :seedHosts WHERE name = :name";
+      + "seed_hosts = :seedHosts, state = :state, last_contact = :lastContact WHERE name = :name";
   String SQL_DELETE_CLUSTER = "DELETE FROM cluster WHERE name = :name";
 
   // RepairRun
@@ -265,7 +266,9 @@ public interface IStoragePostgreSql {
       @Bind("name") String name,
       @Bind("partitioner") String partitioner,
       @Bind("seedHosts") Set<String> seedHosts,
-      @Bind("properties") String properties);
+      @Bind("properties") String properties,
+      @Bind("state") String state,
+      @Bind("lastContact") Date lastContact);
 
   @SqlUpdate(SQL_UPDATE_CLUSTER)
   int updateCluster(

--- a/src/server/src/main/resources/db/cassandra/021_sidecar_mode.cql
+++ b/src/server/src/main/resources/db/cassandra/021_sidecar_mode.cql
@@ -1,4 +1,18 @@
 --
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
 -- Metrics table for the sidecar mode
 --
 

--- a/src/server/src/main/resources/db/cassandra/022_cluster_states.cql
+++ b/src/server/src/main/resources/db/cassandra/022_cluster_states.cql
@@ -1,0 +1,19 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to store cluster state and last jmx connection time
+
+ALTER TABLE cluster ADD state text;
+ALTER TABLE cluster ADD last_contact timestamp;

--- a/src/server/src/main/resources/db/h2/V15_0_0__cluster_states.sql
+++ b/src/server/src/main/resources/db/h2/V15_0_0__cluster_states.sql
@@ -1,0 +1,22 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to store cluster state and last jmx connection time
+
+ALTER TABLE cluster
+ADD state TEXT;
+
+ALTER TABLE cluster
+ADD last_contact TIMESTAMP;

--- a/src/server/src/main/resources/db/postgres/V15_0_0__cluster_states.sql
+++ b/src/server/src/main/resources/db/postgres/V15_0_0__cluster_states.sql
@@ -1,0 +1,22 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to store cluster state and last jmx connection time
+
+ALTER TABLE "cluster"
+ADD "state" TEXT;
+
+ALTER TABLE "cluster"
+ADD "last_contact" TIMESTAMP;

--- a/src/server/src/test/java/io/cassandrareaper/core/ClusterTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/core/ClusterTest.java
@@ -17,8 +17,11 @@
 
 package io.cassandrareaper.core;
 
-import io.cassandrareaper.core.Cluster;
 
+import java.time.LocalDate;
+
+import com.google.common.collect.ImmutableSet;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -29,5 +32,170 @@ public final class ClusterTest {
   public void testGetSymbolicName() {
     assertEquals("example2cluster", Cluster.toSymbolicName("Example2 Cluster"));
     assertEquals("example2_cluster", Cluster.toSymbolicName("Example2_Cluster"));
+  }
+
+  @Test
+  public void testCreate_0() {
+    Cluster cluster = Cluster.builder()
+        .withName("test")
+        .withSeedHosts(ImmutableSet.of("127.0.0.1"))
+        .build();
+
+    Assertions.assertThat(cluster.getName()).isEqualTo("test");
+    Assertions.assertThat(cluster.getSeedHosts()).hasSize(1);
+    Assertions.assertThat(cluster.getSeedHosts()).contains("127.0.0.1");
+    Assertions.assertThat(cluster.getPartitioner()).isEmpty();
+    Assertions.assertThat(cluster.getJmxPort()).isEqualTo(Cluster.DEFAULT_JMX_PORT);
+    Assertions.assertThat(cluster.getState()).isEqualTo(Cluster.State.UNKNOWN);
+    Assertions.assertThat(cluster.getLastContact()).isEqualTo(LocalDate.MIN);
+  }
+
+  @Test
+  public void testCreate_1() {
+    Cluster cluster = Cluster.builder()
+        .withName("test")
+        .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2"))
+        .build();
+
+    Assertions.assertThat(cluster.getName()).isEqualTo("test");
+    Assertions.assertThat(cluster.getSeedHosts()).hasSize(2);
+    Assertions.assertThat(cluster.getSeedHosts()).contains("127.0.0.1", "127.0.0.2");
+    Assertions.assertThat(cluster.getPartitioner()).isEmpty();
+    Assertions.assertThat(cluster.getJmxPort()).isEqualTo(Cluster.DEFAULT_JMX_PORT);
+    Assertions.assertThat(cluster.getState()).isEqualTo(Cluster.State.UNKNOWN);
+    Assertions.assertThat(cluster.getLastContact()).isEqualTo(LocalDate.MIN);
+  }
+
+  @Test
+  public void testCreate_2() {
+    Cluster cluster = Cluster.builder()
+        .withName("test")
+        .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2"))
+        .withPartitioner("murmur3")
+        .build();
+
+    Assertions.assertThat(cluster.getName()).isEqualTo("test");
+    Assertions.assertThat(cluster.getSeedHosts()).hasSize(2);
+    Assertions.assertThat(cluster.getSeedHosts()).contains("127.0.0.1", "127.0.0.2");
+    Assertions.assertThat(cluster.getPartitioner()).isPresent();
+    Assertions.assertThat(cluster.getPartitioner().get()).isEqualTo("murmur3");
+    Assertions.assertThat(cluster.getJmxPort()).isEqualTo(Cluster.DEFAULT_JMX_PORT);
+    Assertions.assertThat(cluster.getState()).isEqualTo(Cluster.State.UNKNOWN);
+    Assertions.assertThat(cluster.getLastContact()).isEqualTo(LocalDate.MIN);
+  }
+
+  @Test
+  public void testCreate_3() {
+    Cluster cluster = Cluster.builder()
+        .withName("test")
+        .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2"))
+        .withPartitioner("murmur3")
+        .withJmxPort(9999)
+        .build();
+
+    Assertions.assertThat(cluster.getName()).isEqualTo("test");
+    Assertions.assertThat(cluster.getSeedHosts()).hasSize(2);
+    Assertions.assertThat(cluster.getSeedHosts()).contains("127.0.0.1", "127.0.0.2");
+    Assertions.assertThat(cluster.getPartitioner()).isPresent();
+    Assertions.assertThat(cluster.getPartitioner().get()).isEqualTo("murmur3");
+    Assertions.assertThat(cluster.getJmxPort()).isEqualTo(9999);
+    Assertions.assertThat(cluster.getState()).isEqualTo(Cluster.State.UNKNOWN);
+    Assertions.assertThat(cluster.getLastContact()).isEqualTo(LocalDate.MIN);
+  }
+
+  @Test
+  public void testCreate_4() {
+    Cluster cluster = Cluster.builder()
+        .withName("test")
+        .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2"))
+        .withPartitioner("murmur3")
+        .withJmxPort(9999)
+        .withState(Cluster.State.ACTIVE)
+        .build();
+
+    Assertions.assertThat(cluster.getName()).isEqualTo("test");
+    Assertions.assertThat(cluster.getSeedHosts()).hasSize(2);
+    Assertions.assertThat(cluster.getSeedHosts()).contains("127.0.0.1", "127.0.0.2");
+    Assertions.assertThat(cluster.getPartitioner()).isPresent();
+    Assertions.assertThat(cluster.getPartitioner().get()).isEqualTo("murmur3");
+    Assertions.assertThat(cluster.getJmxPort()).isEqualTo(9999);
+    Assertions.assertThat(cluster.getState()).isEqualTo(Cluster.State.ACTIVE);
+    Assertions.assertThat(cluster.getLastContact()).isEqualTo(LocalDate.MIN);
+  }
+
+  @Test
+  public void testCreate_5() {
+    Cluster cluster = Cluster.builder()
+        .withName("test")
+        .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2"))
+        .withPartitioner("murmur3")
+        .withJmxPort(9999)
+        .withState(Cluster.State.ACTIVE)
+        .withLastContact(LocalDate.now())
+        .build();
+
+    Assertions.assertThat(cluster.getName()).isEqualTo("test");
+    Assertions.assertThat(cluster.getSeedHosts()).hasSize(2);
+    Assertions.assertThat(cluster.getSeedHosts()).contains("127.0.0.1", "127.0.0.2");
+    Assertions.assertThat(cluster.getPartitioner()).isPresent();
+    Assertions.assertThat(cluster.getPartitioner().get()).isEqualTo("murmur3");
+    Assertions.assertThat(cluster.getJmxPort()).isEqualTo(9999);
+    Assertions.assertThat(cluster.getState()).isEqualTo(Cluster.State.ACTIVE);
+    Assertions.assertThat(cluster.getLastContact()).isEqualTo(LocalDate.now());
+  }
+
+  @Test
+  public void testCreate_6() {
+    Cluster cluster = Cluster.builder()
+        .withName("test")
+        .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2"))
+        .withPartitioner("murmur3")
+        .withJmxPort(9999)
+        .withState(Cluster.State.UNREACHABLE)
+        .withLastContact(LocalDate.now().minusDays(1))
+        .build();
+
+    Assertions.assertThat(cluster.getName()).isEqualTo("test");
+    Assertions.assertThat(cluster.getSeedHosts()).hasSize(2);
+    Assertions.assertThat(cluster.getSeedHosts()).contains("127.0.0.1", "127.0.0.2");
+    Assertions.assertThat(cluster.getPartitioner()).isPresent();
+    Assertions.assertThat(cluster.getPartitioner().get()).isEqualTo("murmur3");
+    Assertions.assertThat(cluster.getJmxPort()).isEqualTo(9999);
+    Assertions.assertThat(cluster.getState()).isEqualTo(Cluster.State.UNREACHABLE);
+    Assertions.assertThat(cluster.getLastContact()).isEqualTo(LocalDate.now().minusDays(1));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testCreate_fail_0() {
+    Cluster.builder()
+        .withSeedHosts(ImmutableSet.of("127.0.0.1", "127.0.0.2"))
+        .withPartitioner("murmur3")
+        .withJmxPort(9999)
+        .withState(Cluster.State.UNREACHABLE)
+        .withLastContact(LocalDate.now().minusDays(1))
+        .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testCreate_fail_1() {
+    Cluster.builder()
+        .withName("test")
+        .withPartitioner("murmur3")
+        .withJmxPort(9999)
+        .withState(Cluster.State.UNREACHABLE)
+        .withLastContact(LocalDate.now().minusDays(1))
+        .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreate_fail_2() {
+    Cluster.builder()
+        .withName("test")
+        .withSeedHosts(ImmutableSet.of())
+        .withPartitioner("murmur3")
+        .withJmxPort(9999)
+        .withState(Cluster.State.UNREACHABLE)
+        .withLastContact(LocalDate.now().minusDays(1))
+        .build();
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/jmx/JmxCustomPortTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/JmxCustomPortTest.java
@@ -65,7 +65,9 @@ public final class JmxCustomPortTest {
             .withJmxPort(7188)
             .build();
 
-    context.jmxConnectionFactory.connectAny(cluster);
+    context.jmxConnectionFactory
+        .connectAny(Collections.singleton(Node.builder().withCluster(cluster).withHostname("127.0.0.1").build()));
+
     assertEquals(7188, port.get());
 
     Cluster cluster2 = Cluster.builder()

--- a/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
@@ -522,7 +522,6 @@ public final class ClusterResourceTest {
 
     context.jmxConnectionFactory = mock(JmxConnectionFactory.class);
 
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Cluster.class))).thenReturn(jmxProxy);
     when(context.jmxConnectionFactory.connectAny(Mockito.anyCollection())).thenReturn(jmxProxy);
 
     return new MockObjects(context, uriInfo, jmxProxy);

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -162,12 +162,8 @@ public final class RepairRunResourceTest {
         .thenReturn(1);
 
     context.jmxConnectionFactory = mock(JmxConnectionFactory.class);
+    when(context.jmxConnectionFactory.connectAny(Mockito.anyCollection())).thenReturn(proxy);
 
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-
-    when(context.jmxConnectionFactory.connectAny(Mockito.anyCollection()))
-        .thenReturn(proxy);
     RepairUnit.Builder repairUnitBuilder = RepairUnit.builder()
             .clusterName(CLUSTER_NAME)
             .keyspaceName(KEYSPACE)

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -124,6 +124,7 @@ public final class RepairRunResourceTest {
         .withName(CLUSTER_NAME)
         .withPartitioner(PARTITIONER)
         .withSeedHosts(ImmutableSet.of(SEED_HOST))
+        .withState(Cluster.State.ACTIVE)
         .build();
 
     context.storage.addCluster(cluster);

--- a/src/server/src/test/java/io/cassandrareaper/service/AutoSchedulingManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/AutoSchedulingManagerTest.java
@@ -34,11 +34,17 @@ import static org.mockito.Mockito.verify;
 
 public final class AutoSchedulingManagerTest {
 
-  private static final Cluster CLUSTER_1
-      = Cluster.builder().withName("cluster1").withSeedHosts(ImmutableSet.of("127.0.0.1")).build();
+  private static final Cluster CLUSTER_1 = Cluster.builder()
+      .withName("cluster1")
+      .withSeedHosts(ImmutableSet.of("127.0.0.1"))
+      .withState(Cluster.State.ACTIVE)
+      .build();
 
-  private static final Cluster CLUSTER_2
-      = Cluster.builder().withName("cluster2").withSeedHosts(ImmutableSet.of("127.0.0.1")).build();
+  private static final Cluster CLUSTER_2 = Cluster.builder()
+      .withName("cluster2")
+      .withSeedHosts(ImmutableSet.of("127.0.0.1"))
+      .withState(Cluster.State.ACTIVE)
+      .build();
 
   private AppContext context;
   private AutoSchedulingManager repairAutoSchedulingManager;

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -63,6 +63,7 @@ public final class ClusterRepairSchedulerTest {
     cluster = Cluster.builder()
         .withName(RandomStringUtils.randomAlphabetic(12))
         .withSeedHosts(ImmutableSet.of("127.0.0.1"))
+        .withState(Cluster.State.ACTIVE)
         .build();
 
     context = new AppContext();

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -80,7 +80,6 @@ public final class ClusterRepairSchedulerTest {
     clusterRepairAuto = new ClusterRepairScheduler(context);
     jmxProxy = mock(JmxProxy.class);
 
-    when(context.jmxConnectionFactory.connectAny(cluster)).thenReturn(jmxProxy);
     when(context.jmxConnectionFactory.connectAny(Mockito.anyCollection())).thenReturn(jmxProxy);
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/service/PurgeServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/PurgeServiceTest.java
@@ -26,7 +26,6 @@ import io.cassandrareaper.core.RepairRun.RunState;
 import io.cassandrareaper.storage.IStorage;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -50,6 +49,7 @@ public final class PurgeServiceTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(PurgeServiceTest.class);
   private static final String CLUSTER_NAME = "test";
+  private static final Set<String> SEEDS = ImmutableSet.of("127.0.0.1");
   private static final Set<String> TABLES = ImmutableSet.of("table1");
 
   @Test
@@ -61,8 +61,7 @@ public final class PurgeServiceTest {
     // Create storage mock
     context.storage = mock(IStorage.class);
 
-    List<Cluster> clusters
-        = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(Collections.EMPTY_SET).build());
+    List<Cluster> clusters = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(SEEDS).build());
 
     when(context.storage.getClusters()).thenReturn(clusters);
 
@@ -103,8 +102,7 @@ public final class PurgeServiceTest {
     // Create storage mock
     context.storage = mock(IStorage.class);
 
-    List<Cluster> clusters
-        = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(Collections.EMPTY_SET).build());
+    List<Cluster> clusters = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(SEEDS).build());
 
     when(context.storage.getClusters()).thenReturn(clusters);
 
@@ -145,8 +143,7 @@ public final class PurgeServiceTest {
     // Create storage mock
     context.storage = mock(IStorage.class);
 
-    List<Cluster> clusters
-        = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(Collections.EMPTY_SET).build());
+    List<Cluster> clusters = Arrays.asList(Cluster.builder().withName(CLUSTER_NAME).withSeedHosts(SEEDS).build());
 
     when(context.storage.getClusters()).thenReturn(clusters);
 

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
@@ -69,11 +69,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairRemoveOneTableTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-        .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
             .thenReturn(Sets.newHashSet(
@@ -96,11 +92,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairDefaultCompactionStrategyTable() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-          .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-          .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
           .thenReturn(Sets.newHashSet(
@@ -123,11 +115,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairRemoveOneTableWithTwcsTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-        .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
             .thenReturn(Sets.newHashSet(
@@ -149,11 +137,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairRemoveTwoTablesTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-        .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
             .thenReturn(Sets.newHashSet(
@@ -176,11 +160,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairRemoveTwoTablesOneWithTwcsTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-        .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
             .thenReturn(Sets.newHashSet(
@@ -203,11 +183,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairRemoveOneTableFromListTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-        .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
             .thenReturn(Sets.newHashSet(
@@ -231,11 +207,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairRemoveOneTableFromListOneWithTwcsTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-        .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
             .thenReturn(Sets.newHashSet(
@@ -259,11 +231,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairRemoveAllFailingTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-        .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
             .thenReturn(Sets.newHashSet(
@@ -286,11 +254,7 @@ public final class RepairUnitServiceTest {
   public void getTablesToRepairRemoveAllFromListFailingTest() throws ReaperException {
     JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
-
-    when(context.jmxConnectionFactory.connectAny(cluster))
-        .thenReturn(proxy);
-    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class)))
-        .thenReturn(proxy);
+    when(context.jmxConnectionFactory.connectAny(Mockito.any(Collection.class))).thenReturn(proxy);
 
     when(proxy.getTablesForKeyspace(Mockito.anyString()))
         .thenReturn(Sets.newHashSet(

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -123,6 +123,7 @@ public final class SegmentRunnerTest {
         .withPartitioner("murmur3")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
+        .withState(Cluster.State.ACTIVE)
         .build());
 
     final UUID runId = run.getId();
@@ -236,6 +237,7 @@ public final class SegmentRunnerTest {
         .withPartitioner("murmur3")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
+        .withState(Cluster.State.ACTIVE)
         .build());
 
     final UUID runId = run.getId();
@@ -384,6 +386,7 @@ public final class SegmentRunnerTest {
         .withPartitioner("murmur3")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
+        .withState(Cluster.State.ACTIVE)
         .build());
 
     final UUID runId = run.getId();
@@ -523,6 +526,7 @@ public final class SegmentRunnerTest {
         .withPartitioner("murmur3")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
+        .withState(Cluster.State.ACTIVE)
         .build());
 
     final UUID runId = run.getId();
@@ -658,6 +662,7 @@ public final class SegmentRunnerTest {
         .withPartitioner("murmur3")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
+        .withState(Cluster.State.ACTIVE)
         .build());
 
     final UUID runId = run.getId();
@@ -794,6 +799,7 @@ public final class SegmentRunnerTest {
         .withPartitioner("murmur3")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
+        .withState(Cluster.State.ACTIVE)
         .build());
 
     final UUID runId = run.getId();
@@ -931,6 +937,7 @@ public final class SegmentRunnerTest {
         .withPartitioner("murmur3")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
+        .withState(Cluster.State.ACTIVE)
         .build());
 
     final UUID runId = run.getId();

--- a/src/server/src/test/java/io/cassandrareaper/service/SnapshotServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SnapshotServiceTest.java
@@ -151,7 +151,6 @@ public final class SnapshotServiceTest {
     cxt.config = TestRepairConfiguration.defaultConfig();
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
     when(cxt.jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(proxy);
-    when(cxt.jmxConnectionFactory.connectAny(Mockito.any(Cluster.class))).thenReturn(proxy);
     ClusterFacade clusterFacadeSpy = Mockito.spy(ClusterFacade.create(cxt));
     Mockito.doReturn(Arrays.asList("127.0.0.1", "127.0.0.2")).when(clusterFacadeSpy).getLiveNodes(any());
     Mockito.doReturn(Arrays.asList("127.0.0.1", "127.0.0.2"))
@@ -186,7 +185,6 @@ public final class SnapshotServiceTest {
     cxt.config = TestRepairConfiguration.defaultConfig();
     cxt.jmxConnectionFactory = mock(JmxConnectionFactory.class);
     when(cxt.jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(proxy);
-    when(cxt.jmxConnectionFactory.connectAny(Mockito.any(Cluster.class))).thenReturn(proxy);
     ClusterFacade clusterFacadeSpy = Mockito.spy(ClusterFacade.create(cxt));
     Mockito.doReturn(Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3")).when(clusterFacadeSpy).getLiveNodes(any());
     Mockito.doReturn(Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3"))


### PR DESCRIPTION
 Add three states to clusters: `UNKNOWN`, `UNREACHABLE`, and `ACTIVE`; along with a day-timestamp of when the last successful jmx connection was made.

`UNKNOWN` is only used when the `Cluster` object is created on-the-fly to pass through jmx connection details. It is never a state that is persisted in the storage backend.

`ACTIVE` is the default state. It indicates there have been successful jmx connections made against the cluster in the past seven days.

`UNREACHABLE` is the state a cluster is transitioned to when it has not had any successful jmx connections over the past 7 days. This period is configurable via the (undocumented) `ReaperApplicationConfiguration.clusterTimeoutInDays` yaml option.


---
Left to do
- [x] unit tests