### PR TITLE
Fix how streams are tracked

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/Stream.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/Stream.java
@@ -19,6 +19,7 @@ package io.cassandrareaper.core;
 
 import java.util.List;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.collect.ImmutableList;
 
@@ -26,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * This class describes the state of a file exchange between two Cassandra nodes.
  */
+@JsonDeserialize(builder = Stream.Builder.class)
 public final class Stream {
 
   /**
@@ -101,15 +103,16 @@ public final class Stream {
     BOTH
   }
 
+  @JsonDeserialize(builder = TableProgress.Builder.class)
   public static final class TableProgress {
     private final String table;
     private final Long current;
     private final Long total;
 
-    public TableProgress(String table, Long current, Long total) {
-      this.table = table;
-      this.current = current;
-      this.total = total;
+    private TableProgress(TableProgress.Builder builder) {
+      this.table = builder.table;
+      this.current = builder.current;
+      this.total = builder.total;
     }
 
     public String getTable() {
@@ -127,6 +130,35 @@ public final class Stream {
     @Override
     public String toString() {
       return String.format("TableProgress(table=%s,current=%d,total=%d", table, current, total);
+    }
+
+    public static TableProgress.Builder builder() {
+      return new TableProgress.Builder();
+    }
+
+    public static final class Builder {
+      private String table;
+      private Long current;
+      private Long total;
+
+      public TableProgress.Builder withTable(String table) {
+        this.table = table;
+        return this;
+      }
+
+      public TableProgress.Builder withCurrent(Long current) {
+        this.current = current;
+        return this;
+      }
+
+      public TableProgress.Builder withTotal(Long total) {
+        this.total = total;
+        return this;
+      }
+
+      public TableProgress build() {
+        return new TableProgress(this);
+      }
     }
 
   }

--- a/src/server/src/main/java/io/cassandrareaper/core/StreamSession.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/StreamSession.java
@@ -19,6 +19,7 @@ package io.cassandrareaper.core;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.collect.ImmutableMap;
 
@@ -29,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Streaming session is identified by an UUID. A streaming session includes a collection of bi-directional data
  * exchanges between two nodes.
  */
+@JsonDeserialize(builder = StreamSession.Builder.class)
 public final class StreamSession {
 
   /**

--- a/src/server/src/main/java/io/cassandrareaper/jmx/StreamsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/StreamsProxy.java
@@ -17,16 +17,36 @@
 
 package io.cassandrareaper.jmx;
 
+import io.cassandrareaper.core.Node;
+import io.cassandrareaper.core.StreamSession;
+import io.cassandrareaper.service.StreamSessionFactory;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.management.openmbean.CompositeData;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.apache.cassandra.streaming.ProgressInfo;
+import org.apache.cassandra.streaming.SessionInfo;
+import org.apache.cassandra.streaming.StreamState;
+import org.apache.cassandra.streaming.StreamSummary;
+import org.apache.cassandra.streaming.management.StreamStateCompositeData;
+import org.apache.cassandra.streaming.management.StreamSummaryCompositeData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public final class StreamsProxy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StreamsProxy.class);
 
   private final JmxProxyImpl proxy;
 
@@ -39,11 +59,116 @@ public final class StreamsProxy {
     return new StreamsProxy((JmxProxyImpl)proxy);
   }
 
-  public Set<CompositeData> listStreams() {
+  public List<StreamSession> listStreams(Node node) {
+
+    Set<CompositeData> streams = listStreamsInternal();
+
+    return parseCompositeData(streams).stream()
+        .map(streamState -> StreamSessionFactory.fromStreamState(node.getHostname(), streamState))
+        .collect(Collectors.toList());
+  }
+
+  private Set<CompositeData> listStreamsInternal() {
     if (proxy.getStreamManagerMBean().isPresent()) {
       return proxy.getStreamManagerMBean().get().getCurrentStreams();
     } else {
       return ImmutableSet.of();
     }
   }
+
+  private Set<StreamState> parseCompositeData(Set<CompositeData> payload) {
+    Set<StreamState> result = Sets.newHashSet();
+
+    for (CompositeData compositeData : payload) {
+
+      try {
+        // start by trying to parse with classes coming from Reaper's C* dependency
+        StreamState streamState = StreamStateCompositeData.fromCompositeData(compositeData);
+        result.add(streamState);
+      } catch (AssertionError e) {
+        // if that fails, try the older version
+        StreamState olderStreamState = parseStreamStatePre2_1(compositeData);
+        result.add(olderStreamState);
+      }
+    }
+    return result;
+  }
+
+  private StreamState parseStreamStatePre2_1(CompositeData compositeData) {
+    UUID planId = UUID.fromString((String)compositeData.get("planId"));
+    String description = (String) compositeData.get("description");
+
+    CompositeData[] sessionCompositeData = (CompositeData[]) compositeData.get("sessions");
+
+    Set<SessionInfo> sessions = Arrays.stream(sessionCompositeData)
+        .map(this::parseSessionInfoPre2_1)
+        .collect(Collectors.toSet());
+
+    return new StreamState(planId, description, sessions);
+  }
+
+  private SessionInfo parseSessionInfoPre2_1(CompositeData compositeData) {
+    try {
+      // these fields can be directly parsed
+      InetAddress peer = InetAddress.getByName((String)compositeData.get("peer"));
+      InetAddress connecting = InetAddress.getByName((String)compositeData.get("connecting"));
+      org.apache.cassandra.streaming.StreamSession.State state
+          = org.apache.cassandra.streaming.StreamSession.State.valueOf((String)compositeData.get("state"));
+
+      // sending and receiving summaries parsing can be delegated to their composite data classes
+      CompositeData[] receivingSummariesData = (CompositeData[]) compositeData.get("receivingSummaries");
+      Set<StreamSummary> receivingSummaries = Arrays.stream(receivingSummariesData)
+          .map(StreamSummaryCompositeData::fromCompositeData)
+          .collect(Collectors.toSet());
+      CompositeData[] sendingSummariesData = (CompositeData[]) compositeData.get("sendingSummaries");
+      Set<StreamSummary> sendingSummaries = Arrays.stream(sendingSummariesData)
+          .map(StreamSummaryCompositeData::fromCompositeData)
+          .collect(Collectors.toSet());
+
+      // Prior to 2.1, Session does not have session Index in the SessionInfo class
+      int sessionIndex = Integer.MIN_VALUE;
+
+      SessionInfo sessionInfo
+          = new SessionInfo(peer, sessionIndex, connecting, receivingSummaries, sendingSummaries, state);
+
+      // when pulling streams, C* also bundles in the progress of files. it's not possible to add them to SessionInfo
+      // through the constructor, but it's possible via .updateProgress() calls
+
+      CompositeData[] receivingFilesData = (CompositeData[]) compositeData.get("receivingFiles");
+      Arrays.stream(receivingFilesData)
+          .map(this::parseProgressInfoPre2_1)
+          .forEach(sessionInfo::updateProgress);
+
+      CompositeData[] sendingFilesData = (CompositeData[]) compositeData.get("sendingFiles");
+      Arrays.stream(sendingFilesData)
+          .map(this::parseProgressInfoPre2_1)
+          .forEach(sessionInfo::updateProgress);
+
+      return sessionInfo;
+    } catch (UnknownHostException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private ProgressInfo parseProgressInfoPre2_1(CompositeData compositeData) {
+    InetAddress peer = null;
+    try {
+      peer = InetAddress.getByName((String) compositeData.get("peer"));
+    } catch (UnknownHostException e) {
+      LOG.warn("Could not resolve host when parsing ProgressInfo {}", compositeData.toString());
+    }
+
+    Preconditions.checkNotNull(peer);
+
+    String fileName = (String) compositeData.get("fileName");
+    ProgressInfo.Direction direction = ProgressInfo.Direction.valueOf((String) compositeData.get("direction"));
+    long currentBytes = (long) compositeData.get("currentBytes");
+    long totalBytes = (long) compositeData.get("totalBytes");
+
+    // sessionIndex is not present in the ProgressInfo of C* before 2.1
+    int sessionIndex = Integer.MIN_VALUE;
+
+    return new ProgressInfo(peer, sessionIndex, fileName, direction, currentBytes, totalBytes);
+  }
+
 }

--- a/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
@@ -26,6 +26,7 @@ import io.cassandrareaper.core.GenericMetric;
 import io.cassandrareaper.core.JmxStat;
 import io.cassandrareaper.core.MetricsHistogram;
 import io.cassandrareaper.core.Node;
+import io.cassandrareaper.core.StreamSession;
 import io.cassandrareaper.core.ThreadPoolStat;
 import io.cassandrareaper.jmx.ClusterFacade;
 import io.cassandrareaper.storage.IDistributedStorage;
@@ -34,10 +35,8 @@ import io.cassandrareaper.storage.OpType;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import javax.management.JMException;
-import javax.management.openmbean.CompositeData;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -165,7 +164,7 @@ public final class MetricsService {
         "grabAndStoreActiveStreams() can only be called in sidecar");
 
     Node node = Node.builder().withHostname(context.getLocalNodeAddress()).build();
-    Set<CompositeData> activeStreams = ClusterFacade.create(context).listStreamsDirect(node);
+    List<StreamSession> activeStreams = ClusterFacade.create(context).listStreamsDirect(node);
 
     ((IDistributedStorage) context.storage)
         .storeOperations(

--- a/src/server/src/main/java/io/cassandrareaper/service/StreamFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/StreamFactory.java
@@ -95,7 +95,12 @@ public final class StreamFactory {
 
     long currentBytes = progressInfo.currentBytes;
     long totalBytes = progressInfo.totalBytes;
-    return new Stream.TableProgress(ksTable, currentBytes, totalBytes);
+
+    return Stream.TableProgress.builder()
+        .withTable(ksTable)
+        .withCurrent(currentBytes)
+        .withTotal(totalBytes)
+        .build();
   }
 
   private static Stream.TableProgress sumTableProgress(String table,
@@ -109,7 +114,11 @@ public final class StreamFactory {
         .map(Stream.TableProgress::getTotal)
         .mapToLong(Long::longValue)
         .sum();
-    return new Stream.TableProgress(table, sumCurrent, sumTotal);
+    return Stream.TableProgress.builder()
+        .withTable(table)
+        .withCurrent(sumCurrent)
+        .withTotal(sumTotal)
+        .build();
   }
 
   public static Stream testStream(String id,

--- a/src/server/src/main/java/io/cassandrareaper/service/StreamService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/StreamService.java
@@ -24,26 +24,9 @@ import io.cassandrareaper.core.StreamSession;
 import io.cassandrareaper.jmx.ClusterFacade;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
-import javax.management.openmbean.CompositeData;
-
-import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
-import org.apache.cassandra.streaming.ProgressInfo;
-import org.apache.cassandra.streaming.SessionInfo;
-import org.apache.cassandra.streaming.StreamState;
-import org.apache.cassandra.streaming.StreamSummary;
-import org.apache.cassandra.streaming.management.StreamStateCompositeData;
-import org.apache.cassandra.streaming.management.StreamSummaryCompositeData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,111 +60,7 @@ public final class StreamService {
   }
 
   private List<StreamSession> pullStreamInfo(Node node) throws ReaperException, InterruptedException, IOException {
-    Set<CompositeData> streams = clusterFacade.listActiveStreams(node);
-    if (streams.isEmpty()) {
-      return ImmutableList.of();
-    }
-
-    Set<StreamState> streamStates = parse(streams);
-
-    return streamStates.stream()
-        .map(streamState -> StreamSessionFactory.fromStreamState(node.getHostname(), streamState))
-        .collect(Collectors.toList());
-  }
-
-  private Set<StreamState> parse(Set<CompositeData> payload) throws ReaperException {
-    Set<StreamState> result = Sets.newHashSet();
-
-    for (CompositeData compositeData : payload) {
-
-      try {
-        // start by trying to parse with classes coming from Reaper's C* dependency
-        StreamState streamState = StreamStateCompositeData.fromCompositeData(compositeData);
-        result.add(streamState);
-      } catch (AssertionError e) {
-        // if that fails, try the older version
-        StreamState olderStreamState = parseStreamStatePre2_1(compositeData);
-        result.add(olderStreamState);
-      }
-    }
-    return result;
-  }
-
-  private StreamState parseStreamStatePre2_1(CompositeData compositeData) {
-    UUID planId = UUID.fromString((String)compositeData.get("planId"));
-    String description = (String) compositeData.get("description");
-
-    CompositeData[] sessionCompositeData = (CompositeData[]) compositeData.get("sessions");
-
-    Set<SessionInfo> sessions = Arrays.stream(sessionCompositeData)
-        .map(this::parseSessionInfoPre2_1)
-        .collect(Collectors.toSet());
-
-    return new StreamState(planId, description, sessions);
-  }
-
-  private SessionInfo parseSessionInfoPre2_1(CompositeData compositeData) {
-    try {
-      // these fields can be directly parsed
-      InetAddress peer = InetAddress.getByName((String)compositeData.get("peer"));
-      InetAddress connecting = InetAddress.getByName((String)compositeData.get("connecting"));
-      org.apache.cassandra.streaming.StreamSession.State state
-          = org.apache.cassandra.streaming.StreamSession.State.valueOf((String)compositeData.get("state"));
-
-      // sending and receiving summaries parsing can be delegated to their composite data classes
-      CompositeData[] receivingSummariesData = (CompositeData[]) compositeData.get("receivingSummaries");
-      Set<StreamSummary> receivingSummaries = Arrays.stream(receivingSummariesData)
-          .map(StreamSummaryCompositeData::fromCompositeData)
-          .collect(Collectors.toSet());
-      CompositeData[] sendingSummariesData = (CompositeData[]) compositeData.get("sendingSummaries");
-      Set<StreamSummary> sendingSummaries = Arrays.stream(sendingSummariesData)
-          .map(StreamSummaryCompositeData::fromCompositeData)
-          .collect(Collectors.toSet());
-
-      // Prior to 2.1, Session does not have session Index in the SessionInfo class
-      int sessionIndex = Integer.MIN_VALUE;
-
-      SessionInfo sessionInfo
-          = new SessionInfo(peer, sessionIndex, connecting, receivingSummaries, sendingSummaries, state);
-
-      // when pulling streams, C* also bundles in the progress of files. it's not possible to add them to SessionInfo
-      // through the constructor, but it's possible via .updateProgress() calls
-
-      CompositeData[] receivingFilesData = (CompositeData[]) compositeData.get("receivingFiles");
-      Arrays.stream(receivingFilesData)
-          .map(this::parseProgressInfoPre2_1)
-          .forEach(sessionInfo::updateProgress);
-
-      CompositeData[] sendingFilesData = (CompositeData[]) compositeData.get("sendingFiles");
-      Arrays.stream(sendingFilesData)
-          .map(this::parseProgressInfoPre2_1)
-          .forEach(sessionInfo::updateProgress);
-
-      return sessionInfo;
-    } catch (UnknownHostException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
-  private ProgressInfo parseProgressInfoPre2_1(CompositeData compositeData) {
-    InetAddress peer = null;
-    try {
-      peer = InetAddress.getByName((String) compositeData.get("peer"));
-    } catch (UnknownHostException e) {
-      LOG.warn("Could not resolve host when parsing ProgressInfo {}", compositeData.toString());
-    }
-
-    Preconditions.checkNotNull(peer);
-
-    String fileName = (String) compositeData.get("fileName");
-    ProgressInfo.Direction direction = ProgressInfo.Direction.valueOf((String) compositeData.get("direction"));
-    long currentBytes = (long) compositeData.get("currentBytes");
-    long totalBytes = (long) compositeData.get("totalBytes");
-
-    // sessionIndex is not present in the ProgressInfo of C* before 2.1
-    int sessionIndex = Integer.MIN_VALUE;
-
-    return new ProgressInfo(peer, sessionIndex, fileName, direction, currentBytes, totalBytes);
+    return clusterFacade.listActiveStreams(node);
   }
 
 }

--- a/src/server/src/test/java/io/cassandrareaper/jmx/ClusterFacadeTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/ClusterFacadeTest.java
@@ -21,13 +21,20 @@ import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperApplicationConfiguration;
 import io.cassandrareaper.ReaperApplicationConfiguration.DatacenterAvailability;
 import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.StreamSession;
 
+import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -95,5 +102,14 @@ public class ClusterFacadeTest {
     assertFalse(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc2", "127.0.0.2"));
     // Should be accessible, same DC
     assertTrue(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc1", "127.0.0.2"));
+  }
+
+  @Test
+  public void parseStreamSessionJsonTest() throws IOException {
+    URL url = Resources.getResource("metric-samples/stream-session.json");
+    String data = Resources.toString(url, Charsets.UTF_8);
+    List<StreamSession> list = ClusterFacade.parseStreamSessionJson(data);
+
+    assertEquals("6b9d35b0-bab6-11e9-8e34-4d2f1172e8bc", list.get(0).getPlanId());
   }
 }

--- a/src/server/src/test/resources/metric-samples/stream-session.json
+++ b/src/server/src/test/resources/metric-samples/stream-session.json
@@ -1,0 +1,28 @@
+[
+  {
+    "planId": "6b9d35b0-bab6-11e9-8e34-4d2f1172e8bc",
+    "streams": {
+      "127.0.0.2-OUT-127.0.0.1": {
+        "id": "127.0.0.2-OUT-127.0.0.1",
+        "host": "127.0.0.2",
+        "peer": "127.0.0.1",
+        "direction": "OUT",
+        "sizeToSend": 0,
+        "sizeToReceive": 241622030,
+        "sizeSent": 0,
+        "sizeReceived": 10448702,
+        "progressSent": [],
+        "progressReceived": [
+          {
+            "table": "tlp_stress.sensor_data",
+            "current": 10448702,
+            "total": 72648575
+          }
+        ],
+        "lastUpdated": 1565362831063,
+        "completed": false,
+        "success": true
+      }
+    }
+  }
+]


### PR DESCRIPTION
This patch changes how streams are tracked.

The first major change is what get's stored into the `metric` table. Previously, we were putting `Set<CompositeData>` in there. That was not correct because it caused no actual information being stored in the DB. Now we put `List<StreamSession>`.

The second major change has to do with how these stream metrics were read back from the DB. The deserialisation was failing because the target classes didn't have constructors/builders available for Jackson. So I've added the annotations allowing Jackson deserialise the classes properly.

While I was at it, I also moved a whole bunch of parsing code from StreamService to StreamProxy. This way it mirrors how CompactionService and CompactionProxy are built.
