### PR TITLE
Display a maximum of three datacenters per row in the UI

### DIFF
--- a/src/ui/app/jsx/cluster-list.jsx
+++ b/src/ui/app/jsx/cluster-list.jsx
@@ -213,7 +213,7 @@ const Datacenter = React.createClass({
       marginLeft: "0",
       paddingLeft: "0",
       paddingRight: "1px",
-      width: (((dcSize/this.props.totalLoad)*100)) + "%"
+      width: Math.max(33,((dcSize/this.props.totalLoad)*100)) + "%"
     };
 
     let badgeStyle = {


### PR DESCRIPTION
(More than three DCs per row messes up the table and becomes unreadable.)