### PR TITLE
Fixed CSS / bootstrap layout issues for cluster-list page

### DIFF
--- a/src/ui/app/jsx/cluster-list.jsx
+++ b/src/ui/app/jsx/cluster-list.jsx
@@ -142,25 +142,26 @@ const Cluster = React.createClass({
       <div className="panel panel-default" style={clusterDisplayStyle}>
         <div className="panel-body">
           <div className="row">
-            <div className="col-lg-2">
+            <div className="col-lg-auto">
               <div className="row">
+                <button
+                  type="button"
+                  className="pull-right cluster-info-button btn btn-md glyphicon glyphicon-info-sign"
+                  data-toggle="modal"
+                  data-target="#clusterInfoModal">
+                </button>
                 <div className="col-lg-8">
                   <a href={'repair.html?currentCluster=' + this.props.name}><h4>{this.props.name}</h4></a>
-                </div>
-                <div className="col-lg-1">
-                  <button
-                    type="button"
-                    className="cluster-info-button btn btn-lg glyphicon glyphicon-info-sign"
-                    data-toggle="modal"
-                    data-target="#clusterInfoModal">
-                  </button>
                 </div>
               </div>
               <div className="font-bold">Total load: <span className="badge">{humanFileSize(totalLoad,1024)}</span></div>
               <div className="font-bold">Running repairs: {runningRepairsBadge}</div>
               <button type="button" className="forget-cluster-button btn btn-xs btn-danger" onClick={this._onDelete}>Forget cluster</button>
             </div>
-            <div className="col-lg-10">
+        &nbsp;
+          </div>
+          <div className="row">
+            <div className="col-lg-auto">
               <div className="row" style={rowDivStyle}>
                 {datacenters}
               </div>
@@ -213,7 +214,7 @@ const Datacenter = React.createClass({
       marginLeft: "0",
       paddingLeft: "0",
       paddingRight: "1px",
-      width: Math.max(33,((dcSize/this.props.totalLoad)*100)) + "%"
+      width: Math.max(100,((dcSize/this.props.totalLoad)*100)) + "%"
     };
 
     let badgeStyle = {


### PR DESCRIPTION
- Set layout to be row based for clusters with many DC's / racks in each DC
- Adjusted the cluster JMX info bar to float to the right
    (couldn't figure out how to have it float left :\)
- Could not test against multiple cluster layout, but simulated it in UI only

# Previous Layout:
![2019-08-25_00-54](https://user-images.githubusercontent.com/749515/63647253-33256a80-c6d3-11e9-804b-0116d89cf100.png)

# Fixed Layout
![2019-08-25_00-55](https://user-images.githubusercontent.com/749515/63647259-41738680-c6d3-11e9-9e19-b57c851722fd.png)
