### PR TITLE
The setting `enableConcurrentMigrations` should imply that migrations are allowed to be run concurrently

### DIFF
--- a/src/packaging/resource/cassandra-reaper-cassandra-sidecar.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra-sidecar.yaml
@@ -33,7 +33,7 @@ jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
 # purgeRecordsAfterInDays: 30
 # numberOfRunsToKeepPerUnit: 10
-enableConcurrentMigrations: true
+enableConcurrentMigrations: false
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH | SIDECAR
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -156,7 +156,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
   private Optional<String> enforcedLocalDatacenter = Optional.empty();
 
   @JsonProperty
-  @DefaultValue("false")
+  @DefaultValue("true")
   private Boolean enableConcurrentMigrations;
 
   private HttpClientConfiguration httpClient = new HttpClientConfiguration();
@@ -455,7 +455,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
   }
 
   public boolean getEnableConcurrentMigrations() {
-    return this.enableConcurrentMigrations == null ? false : this.enableConcurrentMigrations;
+    return this.enableConcurrentMigrations == null ? true : this.enableConcurrentMigrations;
   }
 
   public void setEnableConcurrentMigrations(boolean enableConcurrentMigrations) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/SchemaMigrationLock.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/SchemaMigrationLock.java
@@ -25,7 +25,6 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.VersionNumber;
 import com.datastax.driver.core.utils.UUIDs;
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,13 +36,11 @@ public final class SchemaMigrationLock implements AutoCloseable {
   private final boolean locked;
 
   public SchemaMigrationLock(VersionNumber version, Session session, ReaperApplicationConfiguration config) {
-
-    Preconditions.checkArgument(
-        !config.isInSidecarMode() || config.getEnableConcurrentMigrations(),
-        "Running in sidecar mode and concurrent migrations are not enabled.");
-
     this.session = session;
-    this.locked = migrationConsensusAvailable(config, version) && lockSchemaMigration();
+
+    this.locked = !config.getEnableConcurrentMigrations()
+        && migrationConsensusAvailable(config, version)
+        && lockSchemaMigration();
   }
 
   @Override
@@ -92,6 +89,6 @@ public final class SchemaMigrationLock implements AutoCloseable {
   }
 
   private static boolean migrationConsensusAvailable(ReaperApplicationConfiguration config, VersionNumber version) {
-    return config.getEnableConcurrentMigrations() && VersionNumber.parse("2.2").compareTo(version) <= 0;
+    return VersionNumber.parse("2.2").compareTo(version) <= 0;
   }
 }

--- a/src/server/src/test/resources/reaper-cassandra-sidecar1-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar1-at.yaml
@@ -29,7 +29,7 @@ datacenterAvailability: SIDECAR
 enforcedLocalNode: 127.0.0.1
 enforcedLocalClusterName: test
 enforcedLocalDatacenter: dc1
-enableConcurrentMigrations: true
+enableConcurrentMigrations: false
 
 logging:
   level: WARN

--- a/src/server/src/test/resources/reaper-cassandra-sidecar2-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar2-at.yaml
@@ -29,7 +29,7 @@ datacenterAvailability: SIDECAR
 enforcedLocalNode: 127.0.0.2
 enforcedLocalClusterName: test
 enforcedLocalDatacenter: dc1
-enableConcurrentMigrations: true
+enableConcurrentMigrations: false
 
 logging:
   level: WARN

--- a/src/server/src/test/resources/reaper-cassandra-sidecar3-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar3-at.yaml
@@ -29,7 +29,7 @@ datacenterAvailability: SIDECAR
 enforcedLocalNode: 127.0.0.3
 enforcedLocalClusterName: test
 enforcedLocalDatacenter: dc2
-enableConcurrentMigrations: true
+enableConcurrentMigrations: false
 
 logging:
   level: WARN

--- a/src/server/src/test/resources/reaper-cassandra-sidecar4-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar4-at.yaml
@@ -29,7 +29,7 @@ datacenterAvailability: SIDECAR
 enforcedLocalNode: 127.0.0.4
 enforcedLocalClusterName: test
 enforcedLocalDatacenter: dc2
-enableConcurrentMigrations: true
+enableConcurrentMigrations: false
 
 logging:
   level: WARN


### PR DESCRIPTION


Currently it's implemented as the opposite: it enables locking on schema migrations, which ensures they run sequentially. Such behaviour should be invoked with the use of `enableConcurrentMigrations=false`.