### PR TITLE
Batch of upgrades recommended by dependabot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,12 +259,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.16</version>
+                <version>1.18</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -29,7 +29,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <dropwizard.version>1.3.8</dropwizard.version>
+        <dropwizard.version>1.3.14</dropwizard.version>
         <docker.directory>src/main/docker</docker.directory>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>23.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>javax.mail-api</artifactId>
-            <version>1.6.1</version>
+            <version>1.6.2</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.coursera</groupId>
             <artifactId>dropwizard-metrics-datadog</artifactId>
-            <version>1.1.13</version>
+            <version>1.1.14</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.5</version>
+            <version>42.2.6</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>org.cognitor.cassandra</groupId>
             <artifactId>cassandra-migration</artifactId>
-            <version>2.1.2</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>0.4.0</version>
+            <version>0.6.0</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>


### PR DESCRIPTION
Bumps `dropwizard.version` from 1.3.8 to 1.3.14.

Updates `dropwizard-core` from 1.3.8 to 1.3.14
- [Release notes](https://github.com/dropwizard/dropwizard/releases)
- [Changelog](https://github.com/dropwizard/dropwizard/blob/master/RELEASES.md)
- [Commits](https://github.com/dropwizard/dropwizard/compare/v1.3.8...v1.3.14)

Updates `dropwizard-jdbi` from 1.3.8 to 1.3.14
- [Release notes](https://github.com/dropwizard/dropwizard/releases)
- [Changelog](https://github.com/dropwizard/dropwizard/blob/master/RELEASES.md)
- [Commits](https://github.com/dropwizard/dropwizard/compare/v1.3.8...v1.3.14)

Updates `dropwizard-metrics-graphite` from 1.3.8 to 1.3.14
- [Release notes](https://github.com/dropwizard/dropwizard/releases)
- [Changelog](https://github.com/dropwizard/dropwizard/blob/master/RELEASES.md)
- [Commits](https://github.com/dropwizard/dropwizard/compare/v1.3.8...v1.3.14)

Updates `dropwizard-assets` from 1.3.8 to 1.3.14
- [Release notes](https://github.com/dropwizard/dropwizard/releases)
- [Changelog](https://github.com/dropwizard/dropwizard/blob/master/RELEASES.md)
- [Commits](https://github.com/dropwizard/dropwizard/compare/v1.3.8...v1.3.14)

Updates `dropwizard-testing` from 1.3.8 to 1.3.14
- [Release notes](https://github.com/dropwizard/dropwizard/releases)
- [Changelog](https://github.com/dropwizard/dropwizard/blob/master/RELEASES.md)
- [Commits](https://github.com/dropwizard/dropwizard/compare/v1.3.8...v1.3.14)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Bump maven-compiler-plugin from 3.7.0 to 3.8.1

Bumps [maven-compiler-plugin](https://github.com/apache/maven-compiler-plugin) from 3.7.0 to 3.8.1.
- [Release notes](https://github.com/apache/maven-compiler-plugin/releases)
- [Commits](https://github.com/apache/maven-compiler-plugin/compare/maven-compiler-plugin-3.7.0...maven-compiler-plugin-3.8.1)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Bump animal-sniffer-maven-plugin from 1.16 to 1.18

Bumps [animal-sniffer-maven-plugin](https://github.com/mojohaus/animal-sniffer) from 1.16 to 1.18.
- [Release notes](https://github.com/mojohaus/animal-sniffer/releases)
- [Commits](https://github.com/mojohaus/animal-sniffer/compare/animal-sniffer-parent-1.16...animal-sniffer-parent-1.18)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Bump cassandra-migration from 2.1.2 to 2.2.1 in /src/server

Bumps [cassandra-migration](https://github.com/patka/cassandra-migration) from 2.1.2 to 2.2.1.
- [Release notes](https://github.com/patka/cassandra-migration/releases)
- [Changelog](https://github.com/patka/cassandra-migration/blob/master/CHANGELOG.md)
- [Commits](https://github.com/patka/cassandra-migration/compare/v2.1.2...v2.2.1)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Bump postgresql from 42.2.5 to 42.2.6 in /src/server

Bumps [postgresql](https://github.com/pgjdbc/pgjdbc) from 42.2.5 to 42.2.6.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/compare/REL42.2.5...REL42.2.6)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Bump dropwizard-metrics-datadog from 1.1.13 to 1.1.14 in /src/server

Bumps [dropwizard-metrics-datadog](https://github.com/coursera/metrics-datadog) from 1.1.13 to 1.1.14.
- [Release notes](https://github.com/coursera/metrics-datadog/releases)
- [Commits](https://github.com/coursera/metrics-datadog/commits)

Bump simpleclient from 0.4.0 to 0.6.0 in /src/server

Bumps [simpleclient](https://github.com/prometheus/client_java) from 0.4.0 to 0.6.0.
- [Release notes](https://github.com/prometheus/client_java/releases)
- [Commits](https://github.com/prometheus/client_java/compare/parent-0.4.0...parent-0.6.0)

Bump javax.mail-api from 1.6.1 to 1.6.2 in /src/server

Bumps javax.mail-api from 1.6.1 to 1.6.2.

Bump guava from 20.0 to 23.0

Bumps [guava](https://github.com/google/guava) from 20.0 to 23.0.
- [Release notes](https://github.com/google/guava/releases)
- [Commits](https://github.com/google/guava/compare/v20.0...v23.0)

<!---
@huboard:{"order":769.0,"milestone_order":769,"custom_state":""}
-->
