### PR TITLE
Make docker image run as non-root

### DIFF
--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright 2017-2017 Spotify AB
-# Copyright 2017-2018 The Last Pickle Ltd
+# Copyright 2017-2019 The Last Pickle Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,32 +76,39 @@ ADD entrypoint.sh /usr/local/bin/entrypoint.sh
 ADD configure-persistence.sh /usr/local/bin/configure-persistence.sh
 ADD configure-metrics.sh /usr/local/bin/configure-metrics.sh
 ADD configure-webui-authentication.sh /usr/local/bin/configure-webui-authentication.sh
+ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
 
-RUN addgroup -S reaper && \
-    adduser -S reaper reaper && \
-    apk add --no-cache 'su-exec>=0.2' && \
-    mkdir -p /var/lib/cassandra-reaper && \
+# get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper.yml: Interrupted system call` unknown error
+RUN touch /etc/cassandra-reaper.yml
+
+RUN mkdir -p /var/lib/cassandra-reaper && \
     mkdir -p /etc/cassandra-reaper/shiro && \
     mkdir -p /var/log/cassandra-reaper && \
-    chown reaper:reaper \
+    chgrp 0 \
         /etc/cassandra-reaper.yml \
-        /etc/shiro.ini \
+        /usr/local/lib/cassandra-reaper.jar \
+        /usr/local/bin/entrypoint.sh \
+        /usr/local/bin/configure-persistence.sh \
+        /usr/local/bin/configure-webui-authentication.sh \
+        /usr/local/bin/configure-metrics.sh \
+        /etc/shiro.ini && \
+    chgrp -R 0 \
         /var/lib/cassandra-reaper \
-        /var/log/cassandra-reaper \
+        /etc/cassandra-reaper/shiro \
+        /var/log/cassandra-reaper && \
+    chmod 770 \
         /usr/local/bin/entrypoint.sh \
         /usr/local/bin/configure-persistence.sh \
         /usr/local/bin/configure-webui-authentication.sh \
         /usr/local/bin/configure-metrics.sh && \
-    chmod u+x \
-        /usr/local/bin/entrypoint.sh \
-        /usr/local/bin/configure-persistence.sh \
-        /usr/local/bin/configure-webui-authentication.sh \
-        /usr/local/bin/configure-metrics.sh
-
+    chmod 660 \
+        /etc/cassandra-reaper.yml \
+        /etc/shiro.ini
+        
 VOLUME /var/lib/cassandra-reaper
 VOLUME /etc/cassandra-reaper/shiro
 
-ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
+USER 1001
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["cassandra-reaper"]

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -17,16 +17,13 @@
 if [ "$1" = 'cassandra-reaper' ]; then
     set -x
 
-    # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper.yml: Interrupted system call` unknown error
-    touch /etc/cassandra-reaper.yml
-
-    su-exec reaper /usr/local/bin/configure-persistence.sh
-    su-exec reaper /usr/local/bin/configure-webui-authentication.sh
-    su-exec reaper /usr/local/bin/configure-metrics.sh
-    exec su-exec reaper java \
-                    ${JAVA_OPTS} \
-                    -jar /usr/local/lib/cassandra-reaper.jar server \
-                    /etc/cassandra-reaper.yml
+    /usr/local/bin/configure-persistence.sh
+    /usr/local/bin/configure-webui-authentication.sh
+    /usr/local/bin/configure-metrics.sh
+    exec java \
+            ${JAVA_OPTS} \
+            -jar /usr/local/lib/cassandra-reaper.jar server \
+            /etc/cassandra-reaper.yml
 fi
 
 exec "$@"


### PR DESCRIPTION
The goal of this PR is to make the docker image compatible with environments where you cannot run the container as root, which is in any case a good practice. My use case is running cassandra-reaper in OpenShift.

- The dependency of su-exec has been removed. The right permissions are given to the files and folders involved before executing the entrypoint.
- The key point about the permissions rely on the group permissions, since the container user is by default part of the root(0) group. Being in the root group doesn't give you the privileges of the root user.
- The USER 1001 (or other numeric uid) is kind of an artifact needed by OpenShift. OpenShift assings pseudo-random uids and groups to the container users. Example in my case:

/ $ id
uid=1000210000 gid=0(root) groups=1000210000
/ $ ps -ef
PID USER TIME COMMAND
1 10002100 1:24 java -jar /usr/local/lib/cassandra-reaper.jar server /etc/cassandra-reaper.yml

while running the same image in docker vanilla:

/ $ id
uid=1001 gid=0(root)
/ $ ps -ef
PID USER TIME COMMAND
1 1001 0:08 java -jar /usr/local/lib/cassandra-reaper.jar server /etc/cassandra-reaper.yml

The USER field could be a parameter if running as 1001 (or other numeric uid) instead of "reaper" is bothersome.

More information: https://docs.openshift.com/container-platform/3.3/creating_images/guidelines.html

I have built and pushed the image to dockerhub: **mimarpe/reaper-test**
I see is heavier than the normal cassandra-reaper image, perhaps because of the way I've included the cassandra-reaper.jar...

Thanks a lot for making a review.