### PR TITLE
Allow JMXMP connection to Cassandra/Elassandra

### DIFF
--- a/docs/docs/configuration/docker_vars/index.html
+++ b/docs/docs/configuration/docker_vars/index.html
@@ -545,6 +545,31 @@
 <td><a href="/docs/configuration/reaper_specific/#useaddresstranslator">useAddressTranslator</a></td>
 <td>false</td>
 </tr>
+
+<tr>
+<td><code class="codeLarge">REAPER_CASS_ADDRESS_TRANSLATOR_TYPE</code></td>
+<td><a href="/docs/configuration/reaper_specific/#addressTranslator">addressTranslator</a></td>
+<td>false</td>
+</tr>
+
+<tr>
+<td><code class="codeLarge">JMX_ADDRESS_TRANSLATOR_TYPE</code></td>
+<td><a href="/docs/configuration/reaper_specific/#jmxAddresstranslator">jmxAddressTranslator</a></td>
+<td>false</td>
+</tr>
+
+<tr>
+<td><code class="codeLarge">REAPER_JMXMP_ENABLED</code></td>
+<td><a href="/docs/configuration/reaper_specific/#jmxmp">jmxmp.enabled</a></td>
+<td>false</td>
+</tr>
+
+<tr>
+<td><code class="codeLarge">REAPER_JMXMP_SSL</code></td>
+<td><a href="/docs/configuration/reaper_specific/#jmxmp">jmxmp.ssl</a></td>
+<td>false</td>
+</tr>
+
 </tbody>
 </table>
 

--- a/docs/docs/configuration/reaper_specific/index.html
+++ b/docs/docs/configuration/reaper_specific/index.html
@@ -531,6 +531,19 @@ The cluster name must match the one defined in the cassandra.yaml file (in the e
 <p>Adding a new cluster with specific credentials requires to add the seed node in the following format : <code>host@cluster</code>
 To match the example above, it could be something like : <code>10.0.10.5@clusterProduction1</code></p>
 
+<h3 id="jmxmp"><code>JMXMP</code></h3>
+
+<p>Type: <em>Object</em></p>
+
+<p>Optional usage of JMX over JMXMP (instead of RMI). This allow to port-forward JMX connections over a single TCP port. Because JMXMP is vulerable to a Java deserialization attack (not fixed by Oracle), access to JMX MUST be restricted and secured with TLS encryption and SASL authentication.</p>
+
+<pre><code>jmxmp:
+    enabled: true
+    ssl: true
+</code></pre>
+
+<p><br/></p>
+
 <h3 id="jmxconnectiontimeoutinseconds"><code>jmxConnectionTimeoutInSeconds</code></h3>
 
 <p>Type: <em>Integer</em></p>
@@ -731,6 +744,20 @@ blocking in cause some thread is waiting for I/O, like calling a Cassandra clust
 <p>Default: <em>false</em></p>
 
 <p>When running multi region clusters in AWS, turn this setting to <code>true</code> in order to use the EC2MultiRegionAddressTranslator from the Datastax Java Driver. This will allow translating the public address that the nodes broadcast to the private IP address that is used to expose JMX.</p>
+
+<p><br/></p>
+
+<h3 id="addressTranslator"><code>addressTranslator</code></h3>
+
+<p>Type: <em>Object</em></p>
+
+<p>Default: <em></em></p>
+
+<p>Defines the type of address translator, usually the EC2MultiRegionAddressTranslator from the Datastax Java Driver. This will allow translating the public address that the nodes broadcast to the private IP address that is used to expose JMX.</p>
+
+<pre><code>addressTranslator:
+    type: EC2MultiRegionAddressTranslator
+</code></pre>
 
 <p><br/></p>
 

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -235,7 +235,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+		<!-- https://mvnrepository.com/artifact/org.glassfish.main.external/jmxremote_optional-repackaged -->
+        <!-- Used to connect to Cassandra through JMXMP protocol-->
+        <dependency>
+            <groupId>org.glassfish.main.external</groupId>
+            <artifactId>jmxremote_optional-repackaged</artifactId>
+            <version>5.0</version>
+        </dependency>
         <!--test scope -->
 
         <dependency>

--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -69,6 +69,8 @@ ENV REAPER_SEGMENT_COUNT=200 \
     REAPER_AUTH_USER="" \
     REAPER_AUTH_PASSWORD="" \
     REAPER_SHIRO_INI="" \
+    REAPER_JMXMP_ENABLED="false" \
+    REAPER_JMXMP_SSL="false" \
     JAVA_OPTS=""
 
 ADD cassandra-reaper.yml /etc/cassandra-reaper.yml

--- a/src/server/src/main/docker/cassandra-reaper.yml
+++ b/src/server/src/main/docker/cassandra-reaper.yml
@@ -54,6 +54,10 @@ jmxAuth:
   username: ${REAPER_JMX_AUTH_USERNAME}
   password: ${REAPER_JMX_AUTH_PASSWORD}
 
+jmxmp:
+  enabled: ${REAPER_JMXMP_ENABLED}
+  ssl: ${REAPER_JMXMP_SSL}
+
 logging:
   level: ${REAPER_LOGGING_ROOT_LEVEL}
   loggers: ${REAPER_LOGGING_LOGGERS}

--- a/src/server/src/main/docker/configure-persistence.sh
+++ b/src/server/src/main/docker/configure-persistence.sh
@@ -14,6 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Add specific jmxAddressTranslator
+if [ ! -z "${JMX_ADDRESS_TRANSLATOR_TYPE}" ]; then
+cat <<EOT >> /etc/cassandra-reaper.yml
+jmxAddressTranslator:
+  type: ${JMX_ADDRESS_TRANSLATOR_TYPE}
+EOT
+fi
+
 case ${REAPER_STORAGE_TYPE} in
     "cassandra")
 

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -25,7 +25,7 @@ if [ "$1" = 'cassandra-reaper' ]; then
     /usr/local/bin/configure-metrics.sh
     exec java \
             ${JAVA_OPTS} \
-            -jar /usr/local/lib/cassandra-reaper.jar server \
+            -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication server \
             /etc/cassandra-reaper.yml
 fi
 

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -330,6 +330,13 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
       }
     }
 
+    if (config.getJmxmp() != null) {
+      if (config.getJmxmp().isEnabled()) {
+        LOG.info("JMXMP enabled");
+      }
+      context.jmxConnectionFactory.setJmxmp(config.getJmxmp());
+    }
+
     JmxCredentials jmxAuth = config.getJmxAuth();
     if (jmxAuth != null) {
       LOG.debug("using specified JMX credentials for authentication");

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -102,6 +102,9 @@ public final class ReaperApplicationConfiguration extends Configuration {
   private Map<String, Integer> jmxPorts;
 
   @JsonProperty
+  private Jmxmp jmxmp = new Jmxmp();
+
+  @JsonProperty
   private Map<String, JmxCredentials> jmxCredentials;
 
   @JsonProperty
@@ -172,6 +175,14 @@ public final class ReaperApplicationConfiguration extends Configuration {
   @JsonProperty
   @Nullable
   private CryptographFactory cryptograph;
+
+  public Jmxmp getJmxmp() {
+    return jmxmp;
+  }
+
+  public void setJmxmp(Jmxmp jmxmp) {
+    this.jmxmp = jmxmp;
+  }
 
   public int getSegmentCount() {
     return segmentCount == null ? 0 : segmentCount;
@@ -642,5 +653,22 @@ public final class ReaperApplicationConfiguration extends Configuration {
     }
 
 
+  }
+
+  public static final class Jmxmp {
+
+    @JsonProperty
+    private Boolean ssl = false;
+
+    @JsonProperty
+    private Boolean enabled = false;
+
+    public Boolean useSsl() {
+      return ssl;
+    }
+
+    public Boolean isEnabled() {
+      return enabled;
+    }
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxAddresses.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxAddresses.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 
 public final class JmxAddresses {
   private static final String JMX_URL = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
+  private static final String JMXMP_URL = "service:jmx:jmxmp://%s:%d/";
 
   private JmxAddresses() {
 
@@ -37,10 +38,15 @@ public final class JmxAddresses {
 
   public static JMXServiceURL getJmxServiceUrl(String host, int port)
         throws MalformedURLException {
+    return getJmxServiceUrl(host, port, false);
+  }
+
+  public static JMXServiceURL getJmxServiceUrl(String host, int port, boolean jmxmp)
+        throws MalformedURLException {
     Preconditions.checkNotNull(host);
     Preconditions.checkArgument(port > 0);
     String effectiveHost = isNumericIPv6Address(host) ? wrapIPv6BracesIfNeed(host) : host;
-    return new JMXServiceURL(String.format(JMX_URL, effectiveHost, port));
+    return new JMXServiceURL(String.format(jmxmp ? JMXMP_URL : JMX_URL, effectiveHost, port));
   }
 
   private static String wrapIPv6BracesIfNeed(String address) {


### PR DESCRIPTION
Hi,

Here is a proposal to provide JMXMP connection for reaper.

We forked reaper to implement this feature because [Elassandra](https://elassandra.readthedocs.io/en/latest/operations.html#jmxmp-support) provides JMXMP support since version 6.2.3.21. Thanks to JMXMP java objects are just serialized over a TCP connection that makes JMX management through a tunnel or a firewall easier.

The strapdata fork of cassandra implements JMXMP at the server side, see : https://github.com/strapdata/cassandra/commit/8b83a7bc9a93bfdd5ff3f382627640c868782414 

Hope you will found this useful.
Regards,
Eric
