### PR TITLE
Add "force" flag to cluster delete REST endpoint

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -124,11 +124,13 @@ public final class MemoryStorage implements IStorage {
 
   @Override
   public Cluster deleteCluster(String clusterName) {
-    assert getRepairSchedulesForCluster(clusterName).isEmpty()
-        : StringUtils.join(getRepairSchedulesForCluster(clusterName));
+    getRepairSchedulesForCluster(clusterName).forEach(schedule -> deleteRepairSchedule(schedule.getId()));
+    getRepairRunIdsForCluster(clusterName).forEach(runId -> deleteRepairRun(runId));
 
-    assert getRepairRunsForCluster(clusterName, Optional.of(Integer.MAX_VALUE)).isEmpty()
-        : StringUtils.join(getRepairRunsForCluster(clusterName, Optional.of(Integer.MAX_VALUE)));
+    getEventSubscriptions(clusterName)
+        .stream()
+        .filter(subscription -> subscription.getId().isPresent())
+        .forEach(subscription -> deleteEventSubscription(subscription.getId().get()));
 
     repairUnits.values().stream()
         .filter((unit) -> unit.getClusterName().equals(clusterName))

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/access_control.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/access_control.feature
@@ -14,8 +14,10 @@
 
 Feature: Access Control
 
+  Background:
+    Given cluster seed host "127.0.0.1" points to cluster with name "test"
+
   Scenario Outline: Request to protected resource is redirected to login page when accessed without login
-    Given that we are going to use "127.0.0.1@test" as cluster seed host
     When a <path> <request> is made
     Then the response was redirected to the login page
     Examples:
@@ -24,7 +26,6 @@ Feature: Access Control
       | GET    | /webui/index.html    |
 
   Scenario Outline: Request to public resource is allowed without login
-    Given that we are going to use "127.0.0.1@test" as cluster seed host
     When a <path> <request> is made
     Then a "OK" response is returned
     Examples:
@@ -32,7 +33,6 @@ Feature: Access Control
       | GET    | /webui/login.html    |
 
   Scenario Outline: Request to ping resource is allowed but not healthy
-    Given that we are going to use "127.0.0.1@test" as cluster seed host
     When a <path> <request> is made
     Then a "NOT_ACCEPTABLE" response is returned
     Examples:
@@ -40,7 +40,6 @@ Feature: Access Control
       | GET    | /ping                |
 
   Scenario Outline: Request to protected resource without login returns forbidden
-    Given that we are going to use "127.0.0.1@test" as cluster seed host
     When a <path> <request> is made
     Then a "FORBIDDEN" response is returned
     Examples:

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -36,6 +36,27 @@ Feature: Using Reaper
   ${cucumber.upgrade-versions}
 
   @sidecar
+  Scenario Outline: Force deleting a cluster
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new daily "full" repair schedule is added for "test" and keyspace "test_keyspace"
+    Then reaper has a cluster called "test" in storage
+    And reaper has 1 scheduled repairs for cluster called "test"
+    When reaper is upgraded to latest
+    Then reaper has a cluster called "test" in storage
+    And reaper has 1 scheduled repairs for cluster called "test"
+    When deleting cluster called "test" fails
+    Then reaper has a cluster called "test" in storage
+    And reaper has 1 scheduled repairs for cluster called "test"
+    When the last added cluster is force deleted
+    And reaper has 0 scheduled repairs for cluster called "test"
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
   Scenario Outline: Create a cluster and a scheduled repair run and delete them
     Given that reaper <version> is running
     And cluster seed host "127.0.0.2" points to cluster with name "test"
@@ -51,7 +72,7 @@ Feature: Using Reaper
     Then reaper has 1 scheduled repairs for the last added cluster
     When reaper is upgraded to latest
     Then reaper has 1 scheduled repairs for the last added cluster
-    And deleting the last added cluster fails
+    And deleting cluster called "test" fails
     When the last added schedule is deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
@@ -112,14 +133,14 @@ Feature: Using Reaper
     And reaper has 0 scheduled repairs for the last added cluster
     When a new daily repair schedule is added for the last added cluster and keyspace "booya" with next repair immediately
     Then reaper has 1 scheduled repairs for the last added cluster
-    And deleting the last added cluster fails
+    And deleting cluster called "test" fails
     When we wait for a scheduled repair run has started for cluster "test"
     And we wait for at least 1 segments to be repaired
     Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
     Then reseting one segment sets its state to not started
     And all added repair runs are deleted for the last added cluster
-    And deleting the last added cluster fails
+    And deleting cluster called "test" fails
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
@@ -137,7 +158,7 @@ Feature: Using Reaper
     And the last added repair has twcs table "booya_twcs" in the blacklist
     When reaper is upgraded to latest
     And the last added repair has table "booya2" in the blacklist
-    And deleting the last added cluster fails
+    And deleting cluster called "test" fails
     And the last added repair is activated
     And we wait for at least 1 segments to be repaired
     Then reaper has 1 started or done repairs for the last added cluster
@@ -158,7 +179,7 @@ Feature: Using Reaper
     And the last added repair has twcs table "booya_twcs" in the blacklist
     When reaper is upgraded to latest
     And the last added repair has twcs table "booya_twcs" in the blacklist
-    And deleting the last added cluster fails
+    And deleting cluster called "test" fails
     And the last added repair is activated
     And we wait for at least 1 segments to be repaired
     Then reaper has 1 started or done repairs for the last added cluster
@@ -178,7 +199,7 @@ Feature: Using Reaper
     Then reaper has the last added cluster in storage
     And reaper has 0 repairs for the last added cluster
     When a new incremental repair is added for the last added cluster and keyspace "booya"
-    And deleting the last added cluster fails
+    And deleting cluster called "test" fails
     And the last added repair is activated
     And we wait for at least 1 segments to be repaired
     Then reaper has 1 started or done repairs for the last added cluster


### PR DESCRIPTION
Add "force" flag to cluster delete REST endpoint, allowing registered clusters with schedules and repairs runs to be forcibly deleted.

Forcibly deleting a cluster entails first deleting those schedules, repair runs, and repair units belonging to the cluster, before also deleting the cluster.