### PR TITLE
Fix UI datacenter display bug

### DIFF
--- a/src/ui/app/jsx/cluster-list.jsx
+++ b/src/ui/app/jsx/cluster-list.jsx
@@ -124,7 +124,7 @@ const Cluster = React.createClass({
     if(this.state.nodes_status != null) {
         var grouped_datacenters = this.chunkArray(Object.keys(this.state.nodes_status.endpointStates[0].endpoints).sort(), 3);
         datacenters = grouped_datacenters.map(dcGroup => 
-          <div className="row" key="">
+          <div className="row" key={dcGroup[0]}>
             {dcGroup.map(dc => 
                         <Datacenter datacenter={this.state.nodes_status.endpointStates[0].endpoints[dc]} 
                                     datacenterName={dc} 


### PR DESCRIPTION
The UI had a bug where only three datacenters would ever be displayed even if there were more. The browser dev console would display the following warning.
```
Warning: flattenChildren(...): Encountered two children with the same key, ``. Child keys must be unique; when two children share a key, only the first child will be used.
``` 

This change fixes the UI so that more than three datacenters can be display and resolves the warning displayed on the dev console. The rest of the code base was scanned for this issue and it appeared in only one place.

This is the test cluster I used to verify the fix.

```
$ ccm node1 nodetool status reaper_db

Datacenter: datacenter1
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load       Tokens       Owns (effective)  Host ID                               Rack
UN  127.0.0.1  182.14 KiB  16           100.0%            3fd384f1-d269-4da8-a331-c145ecf6c5de  rack1
Datacenter: datacenter2
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load       Tokens       Owns (effective)  Host ID                               Rack
UN  127.0.0.2  169.93 KiB  16           0.0%              8d3b3941-9c9e-4d94-ba6a-ae1e82cceeb2  rack1
Datacenter: datacenter3
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load       Tokens       Owns (effective)  Host ID                               Rack
UN  127.0.0.3  190.38 KiB  16           0.0%              afc13c75-26e3-4bb3-a760-a4048f7bff49  rack1
Datacenter: datacenter4
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load       Tokens       Owns (effective)  Host ID                               Rack
UN  127.0.0.4  158.32 KiB  16           0.0%              cd328be0-e5d7-4e7a-8099-7aa8a4c4b913  rack1
```

UI before the fix:

<img width="1680" alt="Screen Shot 2019-11-15 at 12 33 40 pm" src="https://user-images.githubusercontent.com/14037529/68910067-95f34300-07a4-11ea-8db7-3c8f175f81ce.png">

UI after the fix:

<img width="1678" alt="Screen Shot 2019-11-15 at 12 34 06 pm" src="https://user-images.githubusercontent.com/14037529/68910070-9be92400-07a4-11ea-85a6-5c1b6281c3be.png">

