### PR TITLE
Add the name of metrics in the detail panel of the repairs

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
@@ -109,6 +109,10 @@ public final class RepairRunStatus {
   @JsonProperty("repair_thread_count")
   private int repairThreadCount;
 
+  @JsonProperty("repair_unit_id")
+  private UUID repairUnitId;
+
+
   /**
    * Default public constructor Required for Jackson JSON parsing.
    */
@@ -136,7 +140,8 @@ public final class RepairRunStatus {
       Collection<String> nodes,
       Collection<String> datacenters,
       Collection<String> blacklistedTables,
-      int repairThreadCount) {
+      int repairThreadCount,
+      UUID repairUnitId) {
 
     this.id = runId;
     this.cause = cause;
@@ -194,6 +199,8 @@ public final class RepairRunStatus {
         estimatedTimeOfArrival = new DateTime(now + millisecondsPerSegment * segmentsLeft);
       }
     }
+
+    this.repairUnitId = repairUnitId;
   }
 
   public RepairRunStatus(RepairRun repairRun, RepairUnit repairUnit, int segmentsRepaired) {
@@ -218,7 +225,8 @@ public final class RepairRunStatus {
         repairUnit.getNodes(),
         repairUnit.getDatacenters(),
         repairUnit.getBlacklistedTables(),
-        repairUnit.getRepairThreadCount());
+        repairUnit.getRepairThreadCount(),
+        repairRun.getRepairUnitId());
   }
 
   @JsonProperty("creation_time")
@@ -487,4 +495,13 @@ public final class RepairRunStatus {
   public static String dateTimeToIso8601(@Nullable DateTime dateTime) {
     return null != dateTime ? ISODateTimeFormat.dateTimeNoMillis().print(dateTime) : null;
   }
+
+  public UUID getRepairUnitId() {
+    return repairUnitId;
+  }
+
+  public void setRepairUnitId(UUID repairUnitId) {
+    this.repairUnitId = repairUnitId;
+  }
+
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -497,7 +497,8 @@ public final class MemoryStorage implements IStorage {
               unit.getNodes(),
               unit.getDatacenters(),
               unit.getBlacklistedTables(),
-              unit.getRepairThreadCount()));
+              unit.getRepairThreadCount(),
+              unit.getId()));
     }
     return runStatuses;
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/ClusterMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/ClusterMapper.java
@@ -23,6 +23,7 @@ import io.cassandrareaper.core.ClusterProperties;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.Arrays;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,13 +56,17 @@ public final class ClusterMapper implements ResultSetMapper<Cluster> {
       throw new SQLException(e); // Ugly but the interface won't let us throw anything else...
     }
 
+    LocalDate lastContact
+        = rs.getDate("last_contact") != null
+            ? rs.getDate("last_contact").toLocalDate()
+            : LocalDate.now();
     Cluster.Builder builder = Cluster.builder()
         .withName(rs.getString("name"))
         .withSeedHosts(ImmutableSet.copyOf(seedHosts))
         .withState(null != rs.getString("state")
             ? Cluster.State.valueOf(rs.getString("state"))
             : Cluster.State.UNKNOWN)
-        .withLastContact(rs.getDate("last_contact").toLocalDate())
+        .withLastContact(lastContact)
         .withJmxPort(clusterProperties.getJmxPort());
 
     if (null != rs.getString("partitioner")) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -210,7 +210,7 @@ public interface IStoragePostgreSql {
   // View-specific queries
   //
   String SQL_CLUSTER_RUN_OVERVIEW = "SELECT repair_run.id, repair_unit.cluster_name, keyspace_name, column_families, "
-          + "nodes, datacenters, blacklisted_tables, "
+          + "nodes, datacenters, blacklisted_tables, repair_run.repair_unit_id, "
           + "(SELECT COUNT(case when state = 2 then 1 else null end) "
           + "FROM repair_segment "
           + "WHERE run_id = repair_run.id) AS segments_repaired, "

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
@@ -36,6 +36,7 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
   @Override
   public RepairRunStatus map(int index, ResultSet rs, StatementContext ctx) throws SQLException {
     long runId = rs.getLong("id");
+    long unitId = rs.getLong("repair_unit_id");
     String clusterName = rs.getString("cluster_name");
     String keyspaceName = rs.getString("keyspace_name");
 
@@ -98,6 +99,7 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
         nodes,
         datacenters,
         blacklistedTables,
-        repairThreadCount);
+        repairThreadCount,
+        UuidUtil.fromSequenceId(unitId));
   }
 }

--- a/src/server/src/main/resources/db/h2/V17_0_0__multi_instance.sql
+++ b/src/server/src/main/resources/db/h2/V17_0_0__multi_instance.sql
@@ -1,29 +1,29 @@
 -- H2-compatible version of multi-instance reaper Postgres DDL
 -- CHANGES:
---    "node" TEXT  -->  "node" VARCHAR(255)  because H2 doesn't support index on TEXT
+--    node VARCHAR  -->  node VARCHAR(255)  because H2 doesn't support index on VARCHAR
 
 CREATE TABLE IF NOT EXISTS leader (
   leader_id BIGINT PRIMARY KEY,
   reaper_instance_id BIGINT,
-  reaper_instance_host TEXT,
+  reaper_instance_host VARCHAR,
   last_heartbeat TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS running_reapers (
   reaper_instance_id BIGINT PRIMARY KEY,
-  reaper_instance_host TEXT,
+  reaper_instance_host VARCHAR,
   last_heartbeat TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE IF NOT EXISTS node_metrics_v1 (
-  time_partition          BIGINT,
   run_id                  BIGINT,
-  node                    VARCHAR(255),
-  cluster                 TEXT,
-  datacenter              TEXT,
+  ts                      TIMESTAMP WITH TIME ZONE,
+  node                    VARCHAR,
+  cluster                 VARCHAR,
+  datacenter              VARCHAR,
   requested               BOOLEAN,
   pending_compactions     INT,
   has_repair_running      BOOLEAN,
   active_anticompactions  INT,
-  PRIMARY KEY(run_id, time_partition, node)
+  PRIMARY KEY (run_id, ts, node)
 );

--- a/src/server/src/main/resources/db/h2/V18_0_0__sidecar_mode.sql
+++ b/src/server/src/main/resources/db/h2/V18_0_0__sidecar_mode.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS node_metrics_v2_source_nodes (
+  source_node_id SERIAL UNIQUE,
+  cluster VARCHAR,
+  host VARCHAR,
+  last_updated TIMESTAMP WITH TIME ZONE,
+  PRIMARY KEY (cluster, host)
+);
+
+CREATE TABLE IF NOT EXISTS node_metrics_v2_metric_types (
+  metric_type_id SERIAL UNIQUE,
+  metric_domain VARCHAR,
+  metric_type VARCHAR,
+  metric_scope VARCHAR,
+  metric_name VARCHAR,
+  metric_attribute VARCHAR,
+  PRIMARY KEY (metric_domain, metric_type, metric_scope, metric_name, metric_attribute)
+);
+
+CREATE TABLE IF NOT EXISTS node_metrics_v2 (
+  metric_type_id INT,
+  source_node_id INT,
+  ts TIMESTAMP WITH TIME ZONE,
+  value DOUBLE PRECISION,
+  PRIMARY KEY (metric_type_id, source_node_id, ts)
+);
+
+CREATE TABLE IF NOT EXISTS node_operations (
+    cluster VARCHAR,
+    type VARCHAR,
+    host VARCHAR,
+    ts TIMESTAMP WITH TIME ZONE,
+    data VARCHAR,
+    PRIMARY KEY (cluster, type, host, ts)
+);

--- a/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
@@ -78,7 +78,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // nodes
             Collections.EMPTY_LIST, // datacenters
             Collections.EMPTY_LIST, // blacklist
-            1); // repair thread count
+            1,
+            UUID.randomUUID()); // repair thread count
 
     assertEquals("1 minute 0 seconds", repairStatus.getDuration());
   }
@@ -106,7 +107,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // nodes
             Collections.EMPTY_LIST, // datacenters
             Collections.EMPTY_LIST, // blacklist
-            1); // repair thread count
+            1,
+            UUID.randomUUID()); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }
@@ -134,7 +136,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // nodes
             Collections.EMPTY_LIST, // datacenters
             Collections.EMPTY_LIST, // blacklist
-            1); // repair thread count
+            1,
+            UUID.randomUUID()); // repair thread count
 
     assertEquals("1 minute 50 seconds", repairStatus.getDuration());
   }
@@ -162,7 +165,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // nodes
             Collections.EMPTY_LIST, // datacenters
             Collections.EMPTY_LIST, // blacklist
-            1); // repair thread count
+            1,
+            UUID.randomUUID()); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -156,6 +156,14 @@ const TableRowDetails = React.createClass({
           placeholder="repair intensity" />;
     }
 
+    var metrics = ["io.cassandrareaper.service.RepairRunner.repairProgress", "io.cassandrareaper.service.RepairRunner.segmentsDone",
+                   "io.cassandrareaper.service.RepairRunner.segmentsTotal", "io.cassandrareaper.service.RepairRunner.millisSinceLastRepair"];
+  let cleanupRegex = /[^A-Za-z0-9]/mg
+  let availableMetrics = metrics.map(metric => <div key={metric + this.props.row.repair_unit_id}>
+      {metric + "." 
+        + this.props.row.cluster_name.replace(cleanupRegex, "") + "." 
+        + this.props.row.keyspace_name.replace(cleanupRegex, "") + "." 
+        + this.props.row.repair_unit_id.replace(cleanupRegex, "")}</div>)
     return (
       <tr id={rowID} className="collapse out">
         <td colSpan="7">
@@ -232,6 +240,10 @@ const TableRowDetails = React.createClass({
                 <tr>
                     <td>Creation time</td>
                     <td>{createdAt}</td>
+                </tr>
+                <tr>
+                    <td>Available metrics<br/><i>(can require a full run before appearing)</i></td>
+                    <td>{availableMetrics}</td>
                 </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Metrics in Reaper were previously exposed by repair run. This didn't allow to track repairs across runs, and monitor cyclic repairs on the same keyspace (or set of tables).
Now we provide metrics by repair unit instead, which will allow to associate consecutive repair runs under the same metric.
The Repair unit it (or the metric name) should be provided in the UI to ease up its tracking in monitoring.

Also 2 minor fixes:
- Fixed NPE when `last_contact` is null in postgres/h2
- Fixed the schema in migrations 17&18 for h2, which didn't match the postgres schema