### PR TITLE
ignore src/packaging/data for apache rat checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
                 <exclude>**/*.txt</exclude>
                 <exclude>src/packaging/debian/compat</exclude>
                 <exclude>src/packaging/debian/changelog</exclude>
+                <exclude>src/packaging/data/**</exclude>
               </excludes>
             </configuration>
             <executions>


### PR DESCRIPTION
docker-compose stores data files in src/packaging/data, and it was causing the rat checks to fail for me when building locally.