### PR TITLE
fix for issue 810

### DIFF
--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -79,9 +79,6 @@ ADD configure-metrics.sh /usr/local/bin/configure-metrics.sh
 ADD configure-webui-authentication.sh /usr/local/bin/configure-webui-authentication.sh
 ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
 
-# get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper.yml: Interrupted system call` unknown error
-RUN touch /etc/cassandra-reaper.yml
-
 RUN mkdir -p /var/lib/cassandra-reaper && \
     mkdir -p /etc/cassandra-reaper/shiro && \
     mkdir -p /var/log/cassandra-reaper && \

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -17,6 +17,9 @@
 if [ "$1" = 'cassandra-reaper' ]; then
     set -x
 
+    # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper.yml: Interrupted system call` unknown error
+    touch /etc/cassandra-reaper.yml
+
     /usr/local/bin/configure-persistence.sh
     /usr/local/bin/configure-webui-authentication.sh
     /usr/local/bin/configure-metrics.sh


### PR DESCRIPTION
It looks like #783 caused a regression which was reported in #810. 

I spent some time testing and I am still not sure I understand what exactly is going on but adding back the `touch` in `entrypoint.sh` does seem to fix the issue.

Aside from the regression, running as a non-root user is a good practice and definitely a change worth trying to maintain.