### PR TITLE
Add repair unit id to cluster status

### DIFF
--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -333,6 +333,11 @@ def _arguments_for_login(parser):
     """Arguments needed to login"""
     parser.add_argument("username", help="Username to login with")
 
+def _arguments_for_delete_cluster(parser):
+    """Arguments needed for deleting a cluster"""
+    parser.add_argument("cluster_name", help="Name of the cluster to delete")
+    parser.add_argument("--force", action="store_true", help="Force deletion of the cluster")
+
 def _parse_arguments(command, description, usage=None, extra_arguments=None):
     """Generic argument parsing done by every command"""
     parser = argparse.ArgumentParser(description=description, usage=usage)
@@ -371,6 +376,7 @@ Usage: spreaper [<global_args>] <command> [<command_args>]
     status-repair   Show status of a repair run.
     status-schedule Show status of a repair schedule.
     add-cluster     Register a cluster.
+    delete-cluster  Delete a cluster.
     repair          Create a repair run, optionally starting it. You need to register
                     a cluster into Reaper (add-cluster) before calling repair.
     schedule        Create a repair schedule, choosing the first activation time and days
@@ -683,6 +689,16 @@ class ReaperCLI(object):
         cluster_data = reaper.post("cluster", seedHost=args.seed_host, jmxPort=args.jmx_port)
         printq("# Registration succeeded:")
         print json.dumps(json.loads(cluster_data), indent=2, sort_keys=True)
+
+    def delete_cluster(self):
+        reaper, args = ReaperCLI.prepare_reaper(
+            "delete-cluster",
+            "Delete a cluster.",
+            extra_arguments=_arguments_for_delete_cluster
+        )
+        printq("# Removing Cassandra cluster {0} from Reaper".format(args.cluster_name))
+        result = reaper.delete("cluster/{0}?force={1}".format(args.cluster_name, args.force))
+        printq("# Removal succeeded")
 
     def repair(self):
         reaper, args = ReaperCLI.prepare_reaper(

--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -524,7 +524,7 @@ class ReaperCLI(object):
         printq("# Listing repair runs")
         endpoint = 'repair_run'
         if args.state is not None:
-            endpoint = '{0}?{1}'.format(endpoint, urllib.urlencode({'state': args.state, 'cluster': args.cluster, 'keyspace': args.keyspace}))
+            endpoint = '{0}?{1}'.format(endpoint, urllib.urlencode({'state': args.state, 'cluster_name': args.cluster, 'keyspace_name': args.keyspace}))
         repair_runs = json.loads(reaper.get(endpoint))
         printq("# Found {0} repair runs".format(len(repair_runs)))
         print json.dumps(repair_runs, indent=2, sort_keys=True)

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
@@ -88,6 +88,9 @@ public final class RepairScheduleStatus {
   @JsonProperty("repair_thread_count")
   private int repairThreadCount;
 
+  @JsonProperty("repair_unit_id")
+  private UUID repairUnitId;
+
   /**
    * Default public constructor Required for Jackson JSON parsing.
    */
@@ -113,7 +116,8 @@ public final class RepairScheduleStatus {
       Collection<String> datacenters,
       Collection<String> blacklistedTables,
       int segmentCountPerNode,
-      int repairThreadCount) {
+      int repairThreadCount,
+      UUID repairUnitId) {
 
     this.id = id;
     this.owner = owner;
@@ -134,6 +138,8 @@ public final class RepairScheduleStatus {
     this.blacklistedTables = blacklistedTables;
     this.segmentCountPerNode = segmentCountPerNode;
     this.repairThreadCount = repairThreadCount;
+    this.repairUnitId = repairUnitId;
+
   }
 
   public RepairScheduleStatus(RepairSchedule repairSchedule, RepairUnit repairUnit) {
@@ -156,7 +162,8 @@ public final class RepairScheduleStatus {
         repairUnit.getDatacenters(),
         repairUnit.getBlacklistedTables(),
         repairSchedule.getSegmentCountPerNode(),
-        repairUnit.getRepairThreadCount());
+        repairUnit.getRepairThreadCount(),
+        repairUnit.getId());
   }
 
   public UUID getId() {
@@ -354,5 +361,12 @@ public final class RepairScheduleStatus {
     this.repairThreadCount = repairThreadCount;
   }
 
+  @JsonProperty("repair_unit_id")
+  public UUID getRepairUnitId() {
+    return repairUnitId;
+  }
 
+  public void setRepairUnitId(UUID repairUnitId) {
+    this.repairUnitId = repairUnitId;
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -228,7 +228,7 @@ public interface IStoragePostgreSql {
       = "SELECT repair_schedule.id, owner, cluster_name, keyspace_name, column_families, state, "
           + "creation_time, next_activation, pause_time, intensity, segment_count, "
           + "repair_parallelism, days_between, incremental_repair, nodes, "
-          + "datacenters, blacklisted_tables, segment_count_per_node, repair_thread_count "
+          + "datacenters, blacklisted_tables, segment_count_per_node, repair_thread_count, repair_unit_id "
           + "FROM repair_schedule "
           + "JOIN repair_unit ON repair_unit_id = repair_unit.id "
           + "WHERE cluster_name = :clusterName";

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -66,7 +66,8 @@ public final class RepairScheduleStatusMapper implements ResultSetMapper<RepairS
                 ? new String[] {}
                 : getStringArray(rs.getArray("blacklisted_tables").getArray())),
         rs.getInt("segment_count_per_node"),
-        rs.getInt("repair_thread_count"));
+        rs.getInt("repair_thread_count"),
+        UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")));
   }
 
   private String[] getStringArray(Object array) {


### PR DESCRIPTION
Also adds a lost commit on allowing to use `force` in cluster deletion and a small fix on the spreaper `list_runs()` command which didn't use the right names for query params.