### PR TITLE
Added support for custom address translation 

### DIFF
--- a/docs/docs/backends/cassandra/index.html
+++ b/docs/docs/backends/cassandra/index.html
@@ -371,6 +371,24 @@ cassandra:
 
 <p>Schema initialization and migration will be done automatically upon startup.</p>
 
+<p>Sometimes it’s not possible for Cassandra nodes to broadcast addresses that will work for each and every client; for instance, they might broadcast private IPs because most clients are in the same network, but a particular client could be on another network and go through a router. For such cases, you can configure a custom address translator that will perform additional address translation based on configured mapping.</p>
+
+<pre><code class="language-yaml">storageType: cassandra
+cassandra:
+  clusterName: &quot;test&quot;
+  contactPoints: ["node1.cassandra.reaper.io", "node2.cassandra.reaper.io"]
+  keyspace: reaper_db
+  jmxAddressTranslator:
+    type: multiIpPerNode
+    ipTranslations:
+      - from: "10.10.10.111"
+        to: "node1.cassandra.reaper.io"
+      - from: "10.10.10.112"
+        to: "node2.cassandra.reaper.io"
+</code></pre>
+
+<p>When running multi region clusters in AWS, set type to <code>ec2MultiRegion</code> in order to use the EC2MultiRegionAddressTranslator from the Datastax Java Driver.</p>
+
                         </div>
 
                     </div>

--- a/docs/docs/configuration/reaper_specific/index.html
+++ b/docs/docs/configuration/reaper_specific/index.html
@@ -721,6 +721,24 @@ blocking in cause some thread is waiting for I/O, like calling a Cassandra clust
 
 <p><br/></p>
 
+<h3 id="jmxAddressTranslator"><code>jmxAddressTranslator</code></h3>
+
+<p><em><strong>Since 2.1.0</strong></em>
+Sometimes it’s not possible for Cassandra nodes to broadcast addresses that will work for each and every client; for instance, they might broadcast private IPs because most clients are in the same network, but a particular client could be on another network and go through a router. For such cases, you can configure a custom address translator that will perform additional address translation based on configured mapping.</p>
+
+<pre><code>jmxAddressTranslator:
+  type: multiIpPerNode
+  ipTranslations:
+    - from: "10.10.10.111"
+      to: "node1.cassandra.reaper.io"
+    - from: "10.10.10.112"
+      to: "node2.cassandra.reaper.io"
+</code></pre>
+
+<p>When running multi region clusters in AWS, set type to <code>ec2MultiRegion</code> in order to use the EC2MultiRegionAddressTranslator from the Datastax Java Driver. This will allow translating the public address that the nodes broadcast to the private IP address that is used to expose JMX.</p>
+
+<p><br/></p>
+
 <h3 id="accesscontrol"><code>accessControl</code></h3>
 
 <p>Settings to activate and configure authentication for the web UI.

--- a/src/docs/content/docs/backends/cassandra.md
+++ b/src/docs/content/docs/backends/cassandra.md
@@ -54,3 +54,22 @@ When operating Reaper in a production environment, it is recommended that:
 * The `NetworkTopologyStrategy` should be used for the replication strategy of the keyspace. This is because `LOCAL_*` requests will fail if the `SimpleNetworkingStrategy` is used in an environment where there is more than one data center defined.
 
 Schema initialization and migration will be done automatically upon startup.
+
+Sometimes it’s not possible for Cassandra nodes to broadcast addresses that will work for each and every client; for instance, they might broadcast private IPs because most clients are in the same network, but a particular client could be on another network and go through a router. For such cases, you can configure a custom address translator that will perform additional address translation based on configured mapping.
+
+```yaml
+storageType: cassandra
+cassandra:
+  clusterName: "test"
+  contactPoints: ["node1.cassandra.reaper.io", "node2.cassandra.reaper.io"]
+  keyspace: reaper_db
+  jmxAddressTranslator:
+    type: multiIpPerNode
+    ipTranslations:
+      - from: "10.10.10.111"
+        to: "node1.cassandra.reaper.io"
+      - from: "10.10.10.112"
+        to: "node2.cassandra.reaper.io"
+```
+
+When running multi region clusters in AWS, set type to `ec2MultiRegion` in order to use the EC2MultiRegionAddressTranslator from the Datastax Java Driver. 

--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -411,6 +411,26 @@ When running multi region clusters in AWS, turn this setting to `true` in order 
 
 <br/>
 
+### `jmxAddressTranslator`
+
+_**Since 2.1.0**_
+
+Sometimes it’s not possible for Cassandra nodes to broadcast addresses that will work for each and every client; for instance, they might broadcast private IPs because most clients are in the same network, but a particular client could be on another network and go through a router. For such cases, you can configure a custom address translator that will perform additional address translation based on configured mapping.
+
+```yaml
+jmxAddressTranslator:
+  type: multiIpPerNode
+  ipTranslations:
+    - from: "10.10.10.111"
+      to: "node1.cassandra.reaper.io"
+    - from: "10.10.10.112"
+      to: "node2.cassandra.reaper.io"
+```
+
+When running multi region clusters in AWS, set type to `ec2MultiRegion` in order to use the EC2MultiRegionAddressTranslator from the Datastax Java Driver. This will allow translating the public address that the nodes broadcast to the private IP address that is used to expose JMX.
+
+<br/>
+
 ### `accessControl`
 
 Settings to activate and configure authentication for the web UI.

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -61,6 +61,7 @@ import javax.servlet.FilterRegistration;
 import com.codahale.metrics.InstrumentedScheduledExecutorService;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.datastax.driver.core.policies.AddressTranslator;
 import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.annotations.VisibleForTesting;
@@ -322,6 +323,10 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
       }
       if (config.useAddressTranslator()) {
         context.jmxConnectionFactory.setAddressTranslator(new EC2MultiRegionAddressTranslator());
+      }
+      if (config.getJmxAddressTranslator().isPresent()) {
+        AddressTranslator addressTranslator = config.getJmxAddressTranslator().get().build();
+        context.jmxConnectionFactory.setAddressTranslator(addressTranslator);
       }
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
+import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;
@@ -40,6 +41,7 @@ import org.apache.cassandra.repair.RepairParallelism;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.secnod.dropwizard.shiro.ShiroConfiguration;
 import systems.composable.dropwizard.cassandra.CassandraFactory;
+import systems.composable.dropwizard.cassandra.network.AddressTranslatorFactory;
 
 public final class ReaperApplicationConfiguration extends Configuration {
 
@@ -79,6 +81,9 @@ public final class ReaperApplicationConfiguration extends Configuration {
   @JsonProperty
   @DefaultValue("false")
   private Boolean useAddressTranslator;
+
+  @Valid
+  private Optional<AddressTranslatorFactory> jmxAddressTranslator = Optional.empty();
 
   @JsonProperty
   @NotNull
@@ -475,6 +480,16 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   public void setHttpClientConfiguration(HttpClientConfiguration httpClient) {
     this.httpClient = httpClient;
+  }
+
+  @JsonProperty
+  public Optional<AddressTranslatorFactory> getJmxAddressTranslator() {
+    return jmxAddressTranslator;
+  }
+
+  @JsonProperty
+  public void setJmxAddressTranslator(Optional<AddressTranslatorFactory> jmxAddressTranslator) {
+    this.jmxAddressTranslator = jmxAddressTranslator;
   }
 
   @Nullable

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxConnectionFactory.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
+import com.datastax.driver.core.policies.AddressTranslator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -55,7 +55,7 @@ public class JmxConnectionFactory {
   private Map<String, Integer> jmxPorts;
   private JmxCredentials jmxAuth;
   private Map<String, JmxCredentials> jmxCredentials;
-  private EC2MultiRegionAddressTranslator addressTranslator;
+  private AddressTranslator addressTranslator;
   private final Set<String> accessibleDatacenters = Sets.newHashSet();
 
   public JmxConnectionFactory(AppContext context, Cryptograph cryptograph) {
@@ -158,7 +158,7 @@ public class JmxConnectionFactory {
     this.jmxPorts = jmxPorts;
   }
 
-  public final void setAddressTranslator(EC2MultiRegionAddressTranslator addressTranslator) {
+  public final void setAddressTranslator(AddressTranslator addressTranslator) {
     this.addressTranslator = addressTranslator;
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/JmxProxyImpl.java
@@ -68,7 +68,7 @@ import javax.validation.constraints.NotNull;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.datastax.driver.core.VersionNumber;
-import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
+import com.datastax.driver.core.policies.AddressTranslator;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
@@ -150,12 +150,12 @@ final class JmxProxyImpl implements JmxProxy {
   }
 
   /**
-   * @see #connect(String, int, Optional, EC2MultiRegionAddressTranslator, int, MetricRegistry, Cryptograph)
+   * @see #connect(String, int, Optional, AddressTranslator, int, MetricRegistry, Cryptograph)
    */
   static JmxProxy connect(
       String host,
       Optional<JmxCredentials> jmxCredentials,
-      final EC2MultiRegionAddressTranslator addressTranslator,
+      final AddressTranslator addressTranslator,
       int connectionTimeout,
       MetricRegistry metricRegistry,
       Cryptograph cryptograph)
@@ -190,7 +190,7 @@ final class JmxProxyImpl implements JmxProxy {
       String originalHost,
       int port,
       Optional<JmxCredentials> jmxCredentials,
-      final EC2MultiRegionAddressTranslator addressTranslator,
+      final AddressTranslator addressTranslator,
       int connectionTimeout,
       MetricRegistry metricRegistry,
       Cryptograph cryptograph) throws ReaperException, InterruptedException {

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MultiIpPerNodeAddressTranslator.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MultiIpPerNodeAddressTranslator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019-2019 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cassandra;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.policies.AddressTranslator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maps broadcast addresses (as advertised by the cassandra cluster) to effective addresses using a hard-coded mapping
+ */
+public final class MultiIpPerNodeAddressTranslator implements AddressTranslator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MultiIpPerNodeAddressTranslator.class);
+  private Map<String, String> addressTranslation = new HashMap<>();
+
+  public MultiIpPerNodeAddressTranslator(
+      final List<MultiIpPerNodeAddressTranslatorFactory.AddressTranslation> translations) {
+    if (!translations.isEmpty()) {
+      addressTranslation = new HashMap<>(translations.size());
+      translations.forEach(i -> addressTranslation.put(i.getFrom(), i.getTo()));
+      if (translations.size() != addressTranslation.size()) {
+        throw new IllegalArgumentException("Invalid mapping specified - some mappings are defined multiple times");
+      }
+      LOGGER.info("Initialised cassandra address translator {}", addressTranslation);
+    }
+  }
+
+  @Override
+  public void init(Cluster cluster) {
+    // nothing to do
+  }
+
+  @Override
+  public InetSocketAddress translate(final InetSocketAddress broadcastAddress) {
+    final String from = broadcastAddress.getAddress().getHostAddress();
+    final String to = addressTranslation.get(from);
+    if (to != null) {
+      final InetSocketAddress result = new InetSocketAddress(to, broadcastAddress.getPort());
+      LOGGER.debug("Performed cassandra address translation from {} to {}", from, result);
+      return result;
+    } else {
+      return broadcastAddress;
+    }
+  }
+
+  @Override
+  public void close() {
+    //do nothing
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MultiIpPerNodeAddressTranslatorFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MultiIpPerNodeAddressTranslatorFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019-2019 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cassandra;
+
+import java.util.List;
+
+import com.datastax.driver.core.policies.AddressTranslator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.hibernate.validator.constraints.NotEmpty;
+import systems.composable.dropwizard.cassandra.network.AddressTranslatorFactory;
+
+/**
+ * A factory for configuring and building custom {@link com.datastax.driver.core.policies.AddressTranslator} instance.
+ */
+@JsonTypeName("multiIpPerNode")
+public class MultiIpPerNodeAddressTranslatorFactory implements AddressTranslatorFactory {
+  @JsonProperty("ipTranslations")
+  private List<AddressTranslation> addressTranslations;
+
+  public List<AddressTranslation> getAddressTranslations() {
+    return addressTranslations;
+  }
+
+  public void setAddressTranslations(List<AddressTranslation> addressTranslations) {
+    this.addressTranslations = addressTranslations;
+  }
+
+  @Override
+  public AddressTranslator build() {
+    return new MultiIpPerNodeAddressTranslator(addressTranslations);
+  }
+
+  public static class AddressTranslation {
+    /**
+     * An IP address as returned by {@link java.net.InetAddress#getHostAddress()}. This IP address will be tranlated to
+     * the "to" hostname.
+     */
+    @NotEmpty
+    @JsonProperty
+    private String from;
+    /**
+     * An IP address or hostname to translate to.
+     */
+    @JsonProperty
+    private String to;
+
+    public String getFrom() {
+      return from;
+    }
+
+    public AddressTranslation setFrom(final String from) {
+      this.from = from;
+      return this;
+    }
+
+    public String getTo() {
+      return to;
+    }
+
+    public AddressTranslation setTo(final String to) {
+      this.to = to;
+      return this;
+    }
+  }
+}

--- a/src/server/src/main/resources/META-INF/services/systems.composable.dropwizard.cassandra.network.AddressTranslatorFactory
+++ b/src/server/src/main/resources/META-INF/services/systems.composable.dropwizard.cassandra.network.AddressTranslatorFactory
@@ -1,0 +1,2 @@
+io.cassandrareaper.storage.cassandra.MultiIpPerNodeAddressTranslatorFactory
+systems.composable.dropwizard.cassandra.network.EC2MultiRegionAddressTranslatorFactory

--- a/src/server/src/test/java/io/cassandrareaper/storage/MultiIpPerNodeAddressTranslatorFactoryTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/storage/MultiIpPerNodeAddressTranslatorFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019-2019 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage;
+
+import io.cassandrareaper.storage.cassandra.MultiIpPerNodeAddressTranslator;
+import io.cassandrareaper.storage.cassandra.MultiIpPerNodeAddressTranslatorFactory;
+import io.cassandrareaper.storage.cassandra.MultiIpPerNodeAddressTranslatorFactory.AddressTranslation;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class MultiIpPerNodeAddressTranslatorFactoryTest {
+
+  @Test
+  public void isDiscoverable() {
+    assertTrue("problem with discovering custom factory",
+        new DiscoverableSubtypeResolver().getDiscoveredSubtypes()
+        .contains(MultiIpPerNodeAddressTranslatorFactory.class));
+  }
+
+  @Test
+  public void shouldReturnSameAddressWhenNoEntryFound() {
+    MultiIpPerNodeAddressTranslatorFactory factory = new MultiIpPerNodeAddressTranslatorFactory();
+    List<AddressTranslation> addressTranslations = new ArrayList<>();
+    factory.setAddressTranslations(addressTranslations);
+    MultiIpPerNodeAddressTranslator translator = (MultiIpPerNodeAddressTranslator) factory.build();
+
+    InetSocketAddress address = new InetSocketAddress("123.2.23.109", 9042);
+    assertThat(translator.translate(address)).isEqualTo(address);
+  }
+
+  @Test
+  public void shouldReturnNewAddressWhenMatchFound() {
+    List<AddressTranslation> addressTranslations = new ArrayList<>();
+    AddressTranslation addressTranslation = new AddressTranslation();
+    addressTranslation.setFrom("1.1.1.1");
+    addressTranslation.setTo("2.2.2.2");
+    addressTranslations.add(addressTranslation);
+    MultiIpPerNodeAddressTranslatorFactory factory = new MultiIpPerNodeAddressTranslatorFactory();
+    factory.setAddressTranslations(addressTranslations);
+    MultiIpPerNodeAddressTranslator translator = (MultiIpPerNodeAddressTranslator) factory.build();
+
+    InetSocketAddress expectedAddress = new InetSocketAddress("2.2.2.2", 9042);
+    InetSocketAddress address = new InetSocketAddress("1.1.1.1", 9042);
+    assertThat(translator.translate(address)).isEqualTo(expectedAddress);
+  }
+}


### PR DESCRIPTION
Provide a possibility to configure simple address translator for Cassandra storage connection and and for JMX connection.
Sometimes it’s not possible for Cassandra nodes to broadcast addresses that will work for each and every client; for instance, they might broadcast private IPs because most clients are in the same network, but a particular client could be on another network and go through a router. For such cases, you can configure a custom address translator that will perform additional address translation based on configured mapping.

See Issue 832 for details (https://github.com/thelastpickle/cassandra-reaper/issues/832)