### PR TITLE
Avoid aborting repair segments too early

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -396,21 +396,17 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
       final long startTime = System.currentTimeMillis();
       final long maxTime = startTime + timeoutMillis;
       final long waitTime = Math.min(timeoutMillis, 60000);
-      long lastLoopTime = startTime;
 
       while (System.currentTimeMillis() < maxTime) {
-        condition.await(waitTime, TimeUnit.MILLISECONDS);
+        boolean isDoneOrFailed = condition.await(waitTime, TimeUnit.MILLISECONDS);
 
-        boolean isDoneOrTimedOut = lastLoopTime + 60_000 > System.currentTimeMillis();
-
-        isDoneOrTimedOut |= RepairSegment.State.DONE == context.storage
+        isDoneOrFailed |= RepairSegment.State.DONE == context.storage
             .getRepairSegment(segment.getRunId(), segmentId).get().getState();
 
-        if (isDoneOrTimedOut) {
+        if (isDoneOrFailed) {
           break;
         }
         renewLead();
-        lastLoopTime = System.currentTimeMillis();
       }
     } catch (InterruptedException e) {
       LOG.warn("Repair command {} on segment {} interrupted", this.repairNo, segmentId, e);


### PR DESCRIPTION
There was a bug which would sometimes cause repair segments to be aborted before the timeout was reached, resulting in the repair process to get stuck.

We experienced this problem with Cassandra Reaper 2.0.2 (and older versions) running on Ubuntu 18.04 LTS with OpenJDK 1.8.0.131.

The problem was in `SegmentRunner.processTriggeredSegment`. Inside the loop, the code would check whether at least 60 seconds have passed since the last iteration. However, with the version of the JRE specified above, `condition.await(…)` would often return a bit early (e.g. after 59997 ms instead of 60000 ms). In this case, the segment would be aborted even though the repair was still running.

This PR fixes this problem by checking the return value of `condition.await(…)` instead of checking the time that has passed since the last iteration. `condition.await(…)` returns `true` if and only if `condition.signalAll()` has been called. This means that the loop will now only be quit if the repair has finished (state `DONE`) or the repair function has returned for some other reason. The timeout is still handled correctly by the loop condition.

I have deployed Cassandra Reaper 2.0.2 with the patch applied on one of our clusters and it seems to reliably resolve the problem for us.

BTW: I believe this PR might fix the issue reported as #376.