### PR TITLE
Refine cassandra reaper launcher

### DIFF
--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -29,6 +29,7 @@ prepare:
 	mkdir -p build/lib/systemd/system/
 	cp resource/cassandra-reaper.yaml build/etc/cassandra-reaper/
 	cp resource/cassandra-reaper*.yaml build/etc/cassandra-reaper/configs
+	cp resource/cassandra-reaper-ssl.properties build/etc/cassandra-reaper/configs
 	cp ../server/target/cassandra-reaper-$(VERSION).jar build/usr/share/cassandra-reaper/
 	cp bin/* build/usr/local/bin/
 	cp etc/bash_completion.d/spreaper build/etc/bash_completion.d/

--- a/src/packaging/bin/cassandra-reaper
+++ b/src/packaging/bin/cassandra-reaper
@@ -14,7 +14,23 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-REAPER_JAR=$(find . -maxdepth 4 -regex '.*/cassandra-reaper-.*[0-9rT]\.jar')
+set -e
+
+find_reaper_jar() {
+    local target_path
+    target_path="$1"
+
+    find -L "$target_path" \
+        -maxdepth 4 \
+        -regex '.*/cassandra-reaper-.*[0-9rT]\.jar' || true
+}
+
+# Do not search from '/' as it prints many permission errors (even for
+# root user), notably for '/proc', '/run', etc.
+# Also it can potentially take a huge amount of time.
+if [ "$(pwd -P)" != "/" ]; then
+    REAPER_JAR=$(find_reaper_jar ".")
+fi
 
 if [ $REAPER_JAR ]; then
     echo "Using reaper in target"
@@ -22,18 +38,27 @@ if [ $REAPER_JAR ]; then
 fi
 
 if [ -z "$CLASS_PATH" ]; then
-  echo "Looking for reaper in /usr/local/share/"
-  CLASS_PATH="$(find -L /usr/local/share -maxdepth 4 -regex '.*/cassandra-reaper-.*[0-9rT]\.jar'):$(find -L /usr/share -maxdepth 4 -regex '.*/cassandra-reaper-.*[0-9rT]\.jar')"
+    echo "Looking for reaper under /usr"
+    CLASS_PATH=""
+    CLASS_PATH+=:$(find_reaper_jar "/usr/local/share")
+    CLASS_PATH+=:$(find_reaper_jar "/usr/share")
 fi
 
 if [ $# -eq 0 ]; then
-    if [ -e /usr/local/etc/cassandra-reaper/cassandra-reaper.yaml ]; then
-        CONFIG_PATH="/usr/local/etc/cassandra-reaper/cassandra-reaper.yaml"
-    else
+    CONFIG_PATH="/usr/local/etc/cassandra-reaper/cassandra-reaper.yaml"
+    if [ ! -e "$CONFIG_PATH" ]; then
         CONFIG_PATH="/etc/cassandra-reaper/cassandra-reaper.yaml"
     fi
 else
     CONFIG_PATH="$@"
+fi
+
+SSL_CONFIG_PATH="/etc/cassandra-reaper/cassandra-reaper-ssl.properties"
+if [ -r "$SSL_CONFIG_PATH" ]; then
+    echo "Loading SSL configuration from $SSL_CONFIG_PATH"
+    # The `sed` expression below removes empty lines and comments
+    # (i.e. lines starting with '#' character).
+    mapfile -t JVM_OPTS <<< "$(cat "$SSL_CONFIG_PATH" | sed '/^\(#.*\)*$/d')"
 fi
 
 # Use JAVA_HOME if set, otherwise look for java in PATH
@@ -59,10 +84,12 @@ fi
 
 
 JVM_OPTS=(
-    # it is safe and performant to disable assertions in production environments (ie replace `-ea` with `-da`)
+    # it is safe and performant to disable assertions in production
+    # environments (ie replace `-ea` with `-da`)
     -ea
     -Xms2G
     -Xmx2G
+    ${JVM_OPTS[@]}
     # Prefer binding to IPv4 network intefaces (when net.ipv6.bindv6only=1). See
     # http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6342561 (short version:
     # comment out this entry to enable IPv6 support).

--- a/src/packaging/resource/cassandra-reaper-ssl.properties
+++ b/src/packaging/resource/cassandra-reaper-ssl.properties
@@ -1,0 +1,20 @@
+# Cassandra Reaper SSL Configuration Example.
+#
+# * Replace keyStore/trustStore parameter values with the real paths to
+#   your credentials files.
+# * Replace keyStorePassword/trustStorePassword parameter values with the
+#   real passwords protecting your files.
+#
+# In case some parameters are not applicable to your SSL configuration,
+# just comment out the respective lines.
+#
+# After filling in the real values, always make sure the resulting file
+# has appropriate permissions set.
+
+-Djavax.net.ssl.keyStore=/path/to/keystore.jks
+-Djavax.net.ssl.keyStorePassword=keystore_password
+
+-Djavax.net.ssl.trustStore=/path/to/truststore.jks
+-Djavax.net.ssl.trustStorePassword=truststore_password
+
+-Dssl.enable=true


### PR DESCRIPTION
This work refines the cassandra-reaper [launcher](https://github.com/thelastpickle/cassandra-reaper/blob/master/src/packaging/bin/cassandra-reaper) in several ways. It so happened that most of the changes are refactoring, though my main goal was the last commit, which adds SSL/TLS support.

I have implemented this support a while ago, internally at the company I work for, so the implementation itself has been tested up to production level. It was only due to a lack of time the change had not been submitted upstream until now. To be honest, I had to update the internal implementation because of some incompatible upstream changes, but this time I have decided not to postpone the submission.

Please review by commits reading *full* commit messages. This way it will be much easier to follow the changes.
