### PR TITLE
Performance optimisations for `storage.getSegmentsWithStates(id, states…)`

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -155,13 +155,10 @@ public final class RepairManager implements AutoCloseable {
   private void abortAllRunningSegmentsWithNoLeader(Collection<RepairRun> runningRepairRuns) {
     runningRepairRuns
         .forEach((repairRun) -> {
-          Collection<RepairSegment> runningSegments
-              = context.storage.getSegmentsWithState(repairRun.getId(), RepairSegment.State.RUNNING);
-          Collection<RepairSegment> startedSegments
-              = context.storage.getSegmentsWithState(repairRun.getId(), RepairSegment.State.STARTED);
+          Collection<RepairSegment> abortSegments
+              = context.storage.getSegmentsWithStartedOrRunningState(repairRun.getId());
 
-          abortSegmentsWithNoLeader(repairRun, runningSegments);
-          abortSegmentsWithNoLeader(repairRun, startedSegments);
+          abortSegmentsWithNoLeader(repairRun, abortSegments);
         });
   }
 
@@ -191,13 +188,10 @@ public final class RepairManager implements AutoCloseable {
           .filter((pausedRepairRun) -> repairRunners.containsKey(pausedRepairRun.getId()))
           .forEach((pausedRepairRun) -> {
             // Abort all running and started segments for paused repair runs
-            Collection<RepairSegment> runningSegments
-                = context.storage.getSegmentsWithState(pausedRepairRun.getId(), RepairSegment.State.RUNNING);
-            Collection<RepairSegment> startedSegments
-                = context.storage.getSegmentsWithState(pausedRepairRun.getId(), RepairSegment.State.STARTED);
+            Collection<RepairSegment> abortSegments
+                = context.storage.getSegmentsWithStartedOrRunningState(pausedRepairRun.getId());
 
-            abortSegments(runningSegments, pausedRepairRun);
-            abortSegments(startedSegments, pausedRepairRun);
+            abortSegments(abortSegments, pausedRepairRun);
           });
     } finally {
       repairRunnersLock.unlock();

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -157,8 +157,11 @@ public final class RepairManager implements AutoCloseable {
         .forEach((repairRun) -> {
           Collection<RepairSegment> runningSegments
               = context.storage.getSegmentsWithState(repairRun.getId(), RepairSegment.State.RUNNING);
+          Collection<RepairSegment> startedSegments
+              = context.storage.getSegmentsWithState(repairRun.getId(), RepairSegment.State.STARTED);
 
           abortSegmentsWithNoLeader(repairRun, runningSegments);
+          abortSegmentsWithNoLeader(repairRun, startedSegments);
         });
   }
 
@@ -187,11 +190,14 @@ public final class RepairManager implements AutoCloseable {
           .stream()
           .filter((pausedRepairRun) -> repairRunners.containsKey(pausedRepairRun.getId()))
           .forEach((pausedRepairRun) -> {
-            // Abort all running segments for paused repair runs
+            // Abort all running and started segments for paused repair runs
             Collection<RepairSegment> runningSegments
                 = context.storage.getSegmentsWithState(pausedRepairRun.getId(), RepairSegment.State.RUNNING);
+            Collection<RepairSegment> startedSegments
+                = context.storage.getSegmentsWithState(pausedRepairRun.getId(), RepairSegment.State.STARTED);
 
             abortSegments(runningSegments, pausedRepairRun);
+            abortSegments(startedSegments, pausedRepairRun);
           });
     } finally {
       repairRunnersLock.unlock();
@@ -223,7 +229,7 @@ public final class RepairManager implements AutoCloseable {
       repairRunnersLock.lock();
       if (context.storage instanceof IDistributedStorage || !repairRunners.containsKey(repairRun.getId())) {
         // When multiple Reapers are in use, we can get stuck segments when one instance is rebooted
-        // Any segment in RUNNING state but with no leader should be killed
+        // Any segment in RUNNING or STARTED state but with no leader should be killed
         List<UUID> leaders = context.storage instanceof IDistributedStorage
                 ? ((IDistributedStorage) context.storage).getLeaders()
                 : Collections.emptyList();
@@ -276,7 +282,8 @@ public final class RepairManager implements AutoCloseable {
         try {
           // refresh segment once we're inside leader-election
           segment = context.storage.getRepairSegment(repairRun.getId(), segment.getId()).get();
-          if (RepairSegment.State.RUNNING == segment.getState()) {
+          if (RepairSegment.State.RUNNING == segment.getState()
+              || RepairSegment.State.STARTED == segment.getState()) {
             JmxProxy jmxProxy = ClusterFacade.create(context).connect(
                       context.storage.getCluster(repairRun.getClusterName()),
                       Arrays.asList(segment.getCoordinatorHost()));

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -706,8 +706,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
       UUID repairRunId = segment.getRunId();
       // this only checks whether any segments from this repair are running,
       //   so `nodesReadyForNewRepair(..)` should always also be called with this method
-      segments = Sets.newHashSet(context.storage.getSegmentsWithState(repairRunId, RepairSegment.State.RUNNING));
-      segments.addAll(context.storage.getSegmentsWithState(repairRunId, RepairSegment.State.STARTED));
+      segments = context.storage.getSegmentsWithStartedOrRunningState(repairRunId);
     }
 
     for (RepairSegment seg : segments) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -163,6 +163,8 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   @Nullable // null on Cassandra-2 as it's not supported syntax
   private PreparedStatement getRepairSegmentsByRunIdAndStatePrepStmt = null;
   @Nullable // null on Cassandra-2 as it's not supported syntax
+  private PreparedStatement getRepairSegmentsByRunIdWithStartedOrRunningStatePrepStmt = null;
+  @Nullable // null on Cassandra-2 as it's not supported syntax
   private PreparedStatement getRepairSegmentCountByRunIdAndStatePrepStmt = null;
   private PreparedStatement insertRepairSchedulePrepStmt;
   private PreparedStatement getRepairSchedulePrepStmt;
@@ -362,20 +364,22 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     insertRepairSegmentPrepStmt = session
         .prepare(
             "INSERT INTO repair_run"
-                + "(id,segment_id,repair_unit_id,start_token,end_token,segment_state,fail_count, token_ranges)"
-                + " VALUES(?, ?, ?, ?, ?, ?, ?, ?)")
+                + "(id,segment_id,repair_unit_id,start_token,end_token,segment_active,segment_state,"
+                + "fail_count,token_ranges)"
+                + " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)")
         .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM);
     insertRepairSegmentIncrementalPrepStmt = session
         .prepare(
             "INSERT INTO repair_run"
-                + "(id,segment_id,repair_unit_id,start_token,end_token,segment_state,coordinator_host,fail_count)"
-                + " VALUES(?, ?, ?, ?, ?, ?, ?, ?)")
+                + "(id,segment_id,repair_unit_id,start_token,end_token,segment_active,segment_state,"
+                + "coordinator_host,fail_count)"
+                + " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)")
         .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM);
     updateRepairSegmentPrepStmt = session
         .prepare(
             "INSERT INTO repair_run"
-                + "(id,segment_id,segment_state,coordinator_host,segment_start_time,fail_count)"
-                + " VALUES(?, ?, ?, ?, ?, ?)")
+                + "(id,segment_id,segment_active,segment_state,coordinator_host,segment_start_time,fail_count)"
+                + " VALUES(?, ?, ?, ?, ?, ?, ?)")
         .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM);
     insertRepairSegmentEndTimePrepStmt = session
         .prepare("INSERT INTO repair_run(id, segment_id, segment_end_time) VALUES(?, ?, ?)")
@@ -441,6 +445,11 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
             "SELECT id,repair_unit_id,segment_id,start_token,end_token,segment_state,coordinator_host,"
                 + "segment_start_time,segment_end_time,fail_count, token_ranges FROM repair_run "
                 + "WHERE id = ? AND segment_state = ? ALLOW FILTERING");
+        getRepairSegmentsByRunIdWithStartedOrRunningStatePrepStmt = session.prepare(
+            "SELECT id,repair_unit_id,segment_id,start_token,end_token,segment_state,coordinator_host,"
+                + "segment_start_time,segment_end_time,fail_count, token_ranges FROM repair_run "
+                + "WHERE id = ? AND segment_active = true ALLOW FILTERING")
+            .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM);
         getRepairSegmentCountByRunIdAndStatePrepStmt = session.prepare(
             "SELECT count(segment_id) FROM repair_run WHERE id = ? AND segment_state = ? ALLOW FILTERING");
       } catch (InvalidQueryException ex) {
@@ -680,6 +689,10 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
       assert 0 == segment.getFailCount();
       assert (null != segment.getCoordinatorHost()) == isIncremental;
 
+      boolean segmentActive
+          = RepairSegment.State.STARTED == segment.getState()
+              || RepairSegment.State.RUNNING == segment.getState();
+
       if (isIncremental) {
         repairRunBatch.add(
             insertRepairSegmentIncrementalPrepStmt.bind(
@@ -688,6 +701,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
               segment.getRepairUnitId(),
               segment.getStartToken(),
               segment.getEndToken(),
+              segmentActive,
               segment.getState().ordinal(),
               segment.getCoordinatorHost(),
               segment.getFailCount()));
@@ -700,6 +714,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
                   segment.getRepairUnitId(),
                   segment.getStartToken(),
                   segment.getEndToken(),
+                  segmentActive,
                   segment.getState().ordinal(),
                   segment.getFailCount(),
                   objectMapper.writeValueAsString(segment.getTokenRange().getTokenRanges())));
@@ -956,12 +971,17 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
           && getRepairUnit(segment.getRepairUnitId()).getIncrementalRepair())
         : "non-leader trying to update repair segment " + segment.getId() + " of run " + segment.getRunId();
 
+    boolean segmentActive
+        = RepairSegment.State.STARTED == segment.getState()
+            || RepairSegment.State.RUNNING == segment.getState();
+
     BatchStatement updateRepairSegmentBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
 
     updateRepairSegmentBatch.add(
         updateRepairSegmentPrepStmt.bind(
             segment.getRunId(),
             segment.getId(),
+            segmentActive,
             segment.getState().ordinal(),
             segment.getCoordinatorHost(),
             segment.hasStartTime() ? segment.getStartTime().toDate() : null,
@@ -1113,6 +1133,30 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
         segments.add(createRepairSegmentFromRow(segmentRow));
       }
     }
+    return segments;
+  }
+
+  @Override
+  public Collection<RepairSegment> getSegmentsWithStartedOrRunningState(UUID runId) {
+    Collection<RepairSegment> segments = Lists.newArrayList();
+
+    if (getRepairSegmentsByRunIdWithStartedOrRunningStatePrepStmt != null) {
+      Statement statement = getRepairSegmentsByRunIdWithStartedOrRunningStatePrepStmt.bind(runId);
+      for (Row segmentRow : session.execute(statement)) {
+        segments.add(createRepairSegmentFromRow(segmentRow));
+      }
+    } else {
+      Statement statement = getRepairSegmentsByRunIdPrepStmt.bind(runId)
+          .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM);
+      for (Row segmentRow : session.execute(statement)) {
+        int segmentState = segmentRow.getInt("segment_state");
+        if (segmentState == RepairSegment.State.STARTED.ordinal()
+            || segmentState == RepairSegment.State.RUNNING.ordinal()) {
+          segments.add(createRepairSegmentFromRow(segmentRow));
+        }
+      }
+    }
+
     return segments;
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -102,6 +102,8 @@ public interface IStorage {
 
   Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState);
 
+  Collection<RepairSegment> getSegmentsWithStartedOrRunningState(UUID runId);
+
   Collection<RepairParameters> getOngoingRepairsInCluster(String clusterName);
 
   SortedSet<UUID> getRepairRunIdsForCluster(String clusterName);

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -41,6 +41,7 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Preconditions;
@@ -351,6 +352,14 @@ public final class MemoryStorage implements IStorage {
       }
     }
     return segments;
+  }
+
+  @Override
+  public Collection<RepairSegment> getSegmentsWithStartedOrRunningState(UUID runId) {
+    return repairSegmentsByRunId.get(runId).values().stream().filter(
+        (segment) -> (
+            segment.getState() == RepairSegment.State.STARTED
+            || segment.getState() == RepairSegment.State.RUNNING)).collect(Collectors.toList());
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -473,6 +473,14 @@ public class PostgresStorage implements IStorage, IDistributedStorage {
   }
 
   @Override
+  public Collection<RepairSegment> getSegmentsWithStartedOrRunningState(UUID runId) {
+    try (Handle h = jdbi.open()) {
+      return getPostgresStorage(h).getRepairSegmentsForRunWithStates2(
+          UuidUtil.toSequenceId(runId), RepairSegment.State.STARTED, RepairSegment.State.RUNNING);
+    }
+  }
+
+  @Override
   public Collection<RepairParameters> getOngoingRepairsInCluster(String clusterName) {
     try (Handle h = jdbi.open()) {
       return getPostgresStorage(h).getRunningRepairsForCluster(clusterName);

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration024.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration024.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019-2019 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cassandra;
+
+
+import io.cassandrareaper.core.RepairSegment;
+
+import java.util.UUID;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+
+public final class Migration024 {
+
+  private static final String REPAIR_RUN_TABLE = "repair_run";
+
+  private Migration024() {
+  }
+
+  /**
+   * Populate the segment_active column of the repair_run table based on the value
+   * of the segment_state column.
+   */
+  public static void migrate(Session session, String keyspace) {
+    PreparedStatement updateStatement = session.prepare(
+        "UPDATE " + REPAIR_RUN_TABLE + " SET segment_active = true WHERE id = ? AND segment_id = ?")
+        .setConsistencyLevel(ConsistencyLevel.EACH_QUORUM);
+    ResultSet resultSet
+        = session.execute(
+            "SELECT id, segment_id, segment_state FROM " + REPAIR_RUN_TABLE,
+            ConsistencyLevel.QUORUM);
+    for (Row row : resultSet) {
+      UUID runId = row.getUUID("id");
+      UUID segmentId = row.getUUID("segment_id");
+      boolean segmentActive;
+      try {
+        int segmentState = row.getInt("segment_state");
+        segmentActive = segmentState == RepairSegment.State.STARTED.ordinal()
+            || segmentState == RepairSegment.State.RUNNING.ordinal();
+      } catch (NullPointerException e) {
+        // A NPE might happen if the the segment_state column is null for some
+        // reason.
+        continue;
+      }
+      // We do not really care whether segment_active is null or false, so we
+      // only update it if it has to be true.
+      if (segmentActive) {
+        session.execute(updateStatement.bind(runId, segmentId));
+      }
+    }
+  }
+
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -138,6 +138,8 @@ public interface IStoragePostgreSql {
       + " FROM repair_segment WHERE run_id = :runId";
   String SQL_GET_REPAIR_SEGMENTS_FOR_RUN_WITH_STATE = "SELECT " + SQL_REPAIR_SEGMENT_ALL_FIELDS
       + " FROM repair_segment WHERE " + "run_id = :runId AND state = :state";
+  String SQL_GET_REPAIR_SEGMENTS_FOR_RUN_WITH_STATES2 = "SELECT " + SQL_REPAIR_SEGMENT_ALL_FIELDS
+      + " FROM repair_segment WHERE " + "run_id = :runId AND (state = :state1 OR state = :state2)";
   String SQL_GET_RUNNING_REPAIRS_FOR_CLUSTER
       = "SELECT start_token, end_token, token_ranges, keyspace_name, column_families, repair_parallelism, tables "
           + "FROM repair_segment "
@@ -524,6 +526,13 @@ public interface IStoragePostgreSql {
   Collection<RepairSegment> getRepairSegmentsForRunWithState(
       @Bind("runId") long runId,
       @Bind("state") RepairSegment.State state);
+
+  @SqlQuery(SQL_GET_REPAIR_SEGMENTS_FOR_RUN_WITH_STATES2)
+  @Mapper(RepairSegmentMapper.class)
+  Collection<RepairSegment> getRepairSegmentsForRunWithStates2(
+      @Bind("runId") long runId,
+      @Bind("state1") RepairSegment.State state1,
+      @Bind("state2") RepairSegment.State state2);
 
   @SqlQuery(SQL_GET_RUNNING_REPAIRS_FOR_CLUSTER)
   @Mapper(RepairParametersMapper.class)

--- a/src/server/src/main/resources/db/cassandra/024_repair_segment_active.cql
+++ b/src/server/src/main/resources/db/cassandra/024_repair_segment_active.cql
@@ -1,0 +1,18 @@
+--
+--  Copyright 2019-2019 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to provide segment_active column in repair_run table.
+
+ALTER TABLE repair_run ADD segment_active boolean;

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -119,13 +119,13 @@ public final class RepairManagerTest {
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
-    when(context.storage.getSegmentsWithState(any(), any())).thenReturn(Arrays.asList(segment));
+    when(context.storage.getSegmentsWithStartedOrRunningState(any())).thenReturn(Arrays.asList(segment));
     when(((IDistributedStorage) context.storage).getLeaders()).thenReturn(Collections.emptyList());
 
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked is at least one segment, meaning abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(2)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
   }
 
   /**
@@ -196,13 +196,13 @@ public final class RepairManagerTest {
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
-    when(context.storage.getSegmentsWithState(any(), any())).thenReturn(Arrays.asList(segment));
+    when(context.storage.getSegmentsWithStartedOrRunningState(any())).thenReturn(Arrays.asList(segment));
     when(((IDistributedStorage) context.storage).getLeaders()).thenReturn(Arrays.asList(segment.getId()));
 
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked with an empty list, meaning no abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(2)).abortSegments(Mockito.argThat(new EmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new EmptyList()), any());
   }
 
   /**
@@ -344,12 +344,12 @@ public final class RepairManagerTest {
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
-    when(context.storage.getSegmentsWithState(any(), any())).thenReturn(Arrays.asList(segment));
+    when(context.storage.getSegmentsWithStartedOrRunningState(any())).thenReturn(Arrays.asList(segment));
 
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked with an non empty list, meaning abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(2)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -125,7 +125,7 @@ public final class RepairManagerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked is at least one segment, meaning abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(2)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
   }
 
   /**
@@ -202,7 +202,7 @@ public final class RepairManagerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked with an empty list, meaning no abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new EmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(2)).abortSegments(Mockito.argThat(new EmptyList()), any());
   }
 
   /**
@@ -349,7 +349,7 @@ public final class RepairManagerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // Check that abortSegments was invoked with an non empty list, meaning abortion occurs
-    Mockito.verify(context.repairManager, Mockito.times(1)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
+    Mockito.verify(context.repairManager, Mockito.times(2)).abortSegments(Mockito.argThat(new NotEmptyList()), any());
   }
 
   @Test


### PR DESCRIPTION
On startup (or periodically in case of the Cassandra storage), the `RepairManager` aborts segments that do not have a leader or that belong to paused repair runs.

However, this code would only abort segments in the `RUNNING` state. This is a problem because segments might also be left in the `STARTED` state when a Cassandra Reaper instance is restarted. Such segments would block other segments from running (because when checking for busy hosts, `STARTED` segments are treated like `RUNNING` segments), but would never finish or be restarted, thus effectively blocking the repair process.

This PR fixes this problem by treating `RUNNING` and `STARTED` segments in the same way when aborting segments that do not have a leader or that belong to paused repair runs.