### PR TITLE
update docker-compose docs

### DIFF
--- a/src/docs/content/docs/download/docker.md
+++ b/src/docs/content/docs/download/docker.md
@@ -118,6 +118,14 @@ The `nodetool` Docker Compose service can be used to check on the Cassandra node
 docker-compose run nodetool status
 ```
 
+You can alternatively attach directly to the Cassandra container and run `nodetool status` from within it. 
+
+First, find the Cassandra container with `docker ps | grep cassandra`. 
+
+Then attach to the container with `docker exec -it <container-id> /bin/bash`.
+
+Now that you have a bash shell in the container, you can run `nodetool -u reaperUser -pwf /etc/cassandra/jmxremote.password`.
+
 Once the Cassandra node is online and accepting CQL connections, create the required `reaper_db` Cassandra keyspace to allow Reaper to save its cluster and scheduling data.
 
 By default, the `reaper_db` keyspace is created using a replication factor of 1. To change this replication factor, provide the intended replication factor as an optional argument:
@@ -193,7 +201,8 @@ For the **SSL encrypted** environment use:
 docker-compose run nodetool-ssl status
 ```
 
-When adding the Cassandra node to the Reaper UI, the above commands can be used to find the node IP address.
+When adding the Cassandra node to the Reaper UI with the IP address, the above commands can be used to find the node IP address.
+You can also add the Cassandra node to the Reaper UI by hostname. The container's hostname is the docker-compose service name.
 
 A `cqlsh` Docker Compose service is included as well for both the default and SSL encrypted environments to allow the creation of user tables in Cassandra.
 

--- a/src/docs/content/docs/download/docker.md
+++ b/src/docs/content/docs/download/docker.md
@@ -118,11 +118,11 @@ The `nodetool` Docker Compose service can be used to check on the Cassandra node
 docker-compose run nodetool status
 ```
 
-You can alternatively attach directly to the Cassandra container and run `nodetool status` from within it. 
+You can alternatively attach directly to the Cassandra container and run `nodetool status` from within it by running:
 
-First, find the Cassandra container with `docker ps | grep cassandra`. 
-
-Then attach to the container with `docker exec -it <container-id> /bin/bash`.
+```bash
+docker-compose exec cassandra /bin/bash
+```
 
 Now that you have a bash shell in the container, you can run `nodetool -u reaperUser -pwf /etc/cassandra/jmxremote.password`.
 

--- a/src/packaging/docker-compose.yml
+++ b/src/packaging/docker-compose.yml
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '2.1'
+version: '2.3'
 
 services:
   cassandra-common:
     image: cassandra:3.11
     env_file:
       - ./docker-services/cassandra/cassandra.env
-    mem_limit: 4g
-    memswap_limit: 4g
+    mem_limit: 1g
+    memswap_limit: 1g
     mem_swappiness: 0
     ports:
       - "7000:7000"

--- a/src/packaging/docker-services/cassandra/cassandra.env
+++ b/src/packaging/docker-services/cassandra/cassandra.env
@@ -32,3 +32,7 @@ CASSANDRA_ENDPOINT_SNITCH=GossipingPropertyFileSnitch
 # open JMX port for access by Reaper
 # WARNING: this is unsafe in production without proper firewall settings
 LOCAL_JMX=no
+
+# JVM heap settings
+MAX_HEAP_SIZE=512M
+HEAP_NEWSIZE=128M


### PR DESCRIPTION
There are two changes with this PR. First, I have reduced the memory for the `cassandra` service from 4 GB to 1 GB with a 512 MB heap. I think that 4 GB is excessive for some getting started examples. For some local testing I am actually using a total memory of 512 MB with a 256 MB heap. 

This makes things a lot more manageable in terms of resources, particularly if you want to run multiple Cassandra containers. In fact it might be useful to provide another example that sets up multiple nodes. I would be happy to provide that if there is interest. 

The second change in the PR is for the docs. There are two things that I wanted to point out. First, you can attach to the Cassandra container to run `nodetool` instead of starting up another Cassandra container (granted, Cassandra is not started). 

The same could be done for `cqlsh` but I did not update the example(s) yet. I wanted wait and first get feedback. 

Secondly, I wanted to mention that you can add the Cassandra node in the reaper ui by the docker-compose service name. This is more convenient IMO than looking up the IP address.