### PR TITLE
Backport "Follow symlinks when searching for reaper jar" to 2.0

### DIFF
--- a/src/packaging/bin/cassandra-reaper
+++ b/src/packaging/bin/cassandra-reaper
@@ -23,7 +23,7 @@ fi
 
 if [ -z "$CLASS_PATH" ]; then
   echo "Looking for reaper in /usr/local/share/"
-  CLASS_PATH="$(find /usr/local/share -maxdepth 4  -regex '.*/cassandra-reaper-.*[0-9rT]\.jar'):$(find /usr/share -regex '.*/cassandra-reaper-.*[0-9rT]\.jar')"
+  CLASS_PATH="$(find -L /usr/local/share -maxdepth 4 -regex '.*/cassandra-reaper-.*[0-9rT]\.jar'):$(find -L /usr/share -maxdepth 4 -regex '.*/cassandra-reaper-.*[0-9rT]\.jar')"
 fi
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
This PR backports #860 to 2.0:

> A typical setup in Homebrew is that /usr/local/share/cassandra-reaper/ is a symlink to elsewhere which contains the needed jar files.
> 
> `find` does not follow symlinks by default. The `-L` flag must be passed for it to do so.

