### PR TITLE
Show pending compactions in /compactions + show them in UI. Fixes #877

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/CompactionStats.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/CompactionStats.java
@@ -1,0 +1,68 @@
+/* * Copyright 2018-2018 The Last Pickle Ltd
+ *
+ *
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = CompactionStats.Builder.class)
+public final class CompactionStats {
+  private Integer pendingCompactions;
+  private List<Compaction> activeCompactions;
+
+  private CompactionStats(Builder builder) {
+    this.pendingCompactions = builder.pendingCompactions;
+    this.activeCompactions = builder.activeCompactions;
+  }
+
+  public Integer getPendingCompactions() {
+    return pendingCompactions;
+  }
+
+  public List<Compaction> getActiveCompactions() {
+    return activeCompactions;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
+  public static final class Builder {
+    private Integer pendingCompactions;
+    private List<Compaction> activeCompactions;
+
+    private Builder() {}
+
+    public Builder withPendingCompactions(Integer pendingCompactions) {
+      this.pendingCompactions = pendingCompactions;
+      return this;
+    }
+
+    public Builder withActiveCompactions(List<Compaction> activeCompactions) {
+      this.activeCompactions = activeCompactions;
+      return this;
+    }
+
+    public CompactionStats build() {
+      return new CompactionStats(this);
+    }
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/jmx/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/CompactionProxy.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.management.JMException;
 import javax.management.MalformedObjectNameException;
 import javax.management.ReflectionException;
 
@@ -93,4 +94,14 @@ public final class CompactionProxy {
     }
     return activeCompactions;
   }
+
+  public Integer getPendingCompactions() {
+    try {
+      return proxy.getPendingCompactions();
+    } catch (JMException e) {
+      LOG.warn("Could not fetch pending compactions from {}", proxy.getHost(), e);
+      return -1;
+    }
+  }
+
 }

--- a/src/server/src/main/java/io/cassandrareaper/service/CompactionService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/CompactionService.java
@@ -19,12 +19,11 @@ package io.cassandrareaper.service;
 
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperException;
-import io.cassandrareaper.core.Compaction;
+import io.cassandrareaper.core.CompactionStats;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.jmx.ClusterFacade;
 
-import java.util.List;
-
+import java.io.IOException;
 import javax.management.JMException;
 
 import org.slf4j.Logger;
@@ -45,10 +44,10 @@ public final class CompactionService {
     return new CompactionService(context);
   }
 
-  public List<Compaction> listActiveCompactions(Node host) throws ReaperException {
+  public CompactionStats listActiveCompactions(Node host) throws ReaperException {
     try {
       return ClusterFacade.create(context).listActiveCompactions(host);
-    } catch (JMException | RuntimeException | InterruptedException e) {
+    } catch (JMException | RuntimeException | InterruptedException | IOException e) {
       LOG.error("Failed listing compactions for host {}", host, e);
       throw new ReaperException(e);
     }

--- a/src/server/src/main/java/io/cassandrareaper/service/Heart.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/Heart.java
@@ -150,7 +150,7 @@ final class Heart implements AutoCloseable {
           if (context.config.getDatacenterAvailability() == DatacenterAvailability.SIDECAR) {
             // In sidecar mode we store metrics in the db on a regular basis
             metricsService.grabAndStoreGenericMetrics();
-            metricsService.grabAndStoreActiveCompactions();
+            metricsService.grabAndStoreCompactionStats();
             metricsService.grabAndStoreActiveStreams();
           }
         } catch (ExecutionException | InterruptedException | RuntimeException

--- a/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
@@ -20,7 +20,7 @@ package io.cassandrareaper.service;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
-import io.cassandrareaper.core.Compaction;
+import io.cassandrareaper.core.CompactionStats;
 import io.cassandrareaper.core.DroppedMessages;
 import io.cassandrareaper.core.GenericMetric;
 import io.cassandrareaper.core.JmxStat;
@@ -149,22 +149,22 @@ public final class MetricsService {
 
   }
 
-  void grabAndStoreActiveCompactions() throws JsonProcessingException, JMException, ReaperException {
+  void grabAndStoreCompactionStats() throws JsonProcessingException, JMException, ReaperException {
     Preconditions.checkState(
         context.config.isInSidecarMode(),
-        "grabAndStoreActiveCompactions() can only be called in sidecar");
+        "grabAndStoreCompactionStats() can only be called in sidecar");
 
     Node node = Node.builder().withHostname(context.getLocalNodeAddress()).build();
-    List<Compaction> activeCompactions = ClusterFacade.create(context).listActiveCompactionsDirect(node);
+    CompactionStats compactionStats = ClusterFacade.create(context).listCompactionStatsDirect(node);
 
     ((IDistributedStorage) context.storage)
         .storeOperations(
             localClusterName,
             OpType.OP_COMPACTION,
             context.getLocalNodeAddress(),
-            objectMapper.writeValueAsString(activeCompactions));
+            objectMapper.writeValueAsString(compactionStats));
 
-    LOG.debug("Grabbing and storing compactions for {}", context.getLocalNodeAddress());
+    LOG.debug("Grabbing and storing compaction stats for {}", context.getLocalNodeAddress());
   }
 
   void grabAndStoreActiveStreams() throws JsonProcessingException, ReaperException {

--- a/src/ui/app/jsx/active-compactions.jsx
+++ b/src/ui/app/jsx/active-compactions.jsx
@@ -28,7 +28,7 @@ const ActiveCompactions = CreateReactClass({
     },
 
     getInitialState() {
-      return {activeCompactions: [], scheduler: {}};
+      return {pendingCompactions: 0, activeCompactions: [], scheduler: {}};
     },
 
     UNSAFE_componentWillMount: function() {
@@ -48,9 +48,13 @@ const ActiveCompactions = CreateReactClass({
         dataType: 'json',
         complete: function(data) {
           try {
-            this.component.setState({activeCompactions: data.responseJSON});
+            this.component.setState({
+                pendingCompactions: data.responseJSON.pendingCompactions,
+                activeCompactions: data.responseJSON.activeCompactions
+            });
           } catch(error) {
-            this.component.setState({activeCompactions: []});
+            this.component.setState({pendingCompactions:-1, activeCompactions: []});
+            console.error('Error occurred while retrieving compaction stats:', error);
           }
         },
         error: function(data) {
@@ -104,8 +108,11 @@ const ActiveCompactions = CreateReactClass({
           </tr>
         )
       ;
+
+      const pendingCompactionsCnt = this.state.pendingCompactions;
   
-      return (<div className="col-lg-12"> 
+      return (<div className="col-lg-12">
+              <div> Pending Tasks: {pendingCompactionsCnt} </div>
               <Table striped bordered condensed hover>
                 {compactionsHeader}
                 <tbody>


### PR DESCRIPTION
Before this changes, we only shown the active compactions, despite pending compactions being a prominent information inside Reaper (used for backoff):
<img width="1468" alt="Screenshot 2020-04-30 at 14 38 26" src="https://user-images.githubusercontent.com/2589903/80942626-eeb7a600-8ded-11ea-9878-6c3e1d41790f.png">

This change takes the pending compactions Reaper uses internally and exposes it in the /compactions endpoint and in the UI.
<img width="743" alt="Screenshot 2020-04-30 at 15 29 57" src="https://user-images.githubusercontent.com/2589903/80942635-f4ad8700-8ded-11ea-88c3-bef623b9ed58.png">
