### PR TITLE
[UI] Fix color & text wrapping in progress bars. Fixes #874

### DIFF
--- a/src/ui/app/bootstrap-theme.css
+++ b/src/ui/app/bootstrap-theme.css
@@ -357,9 +357,8 @@ body {
   background-color: var(--body-bg) !important;
 }
 
-.progress-bar {
-  color: var(--text-color) !important;
-  background-color: var(--body-bg) !important;
+.progress {
+  white-space: nowrap;
 }
 
 .select__control {

--- a/src/ui/app/bootstrap.css
+++ b/src/ui/app/bootstrap.css
@@ -217,7 +217,7 @@ html {
   --navbar-inverse-toggle-icon-bar-bg: #ebebeb;
   --navbar-inverse-toggle-border-color: transparent;
   --nav-link-padding: 10px 15px;
-  --nav-link-hover-bg: #2b3e50; 
+  --nav-link-hover-bg: #2b3e50;
   --nav-disabled-link-color: #4e5d6c;
   --nav-disabled-link-hover-color: #4e5d6c;
   --nav-tabs-border-color: transparent;

--- a/src/ui/app/jsx/stream.jsx
+++ b/src/ui/app/jsx/stream.jsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import Select from 'react-select';
 import ProgressBar from 'react-bootstrap/lib/ProgressBar';
 import Table from 'react-bootstrap/lib/Table';
-import {DeleteStatusMessageMixin, humanFileSize, getUrlPrefix, toast} from "jsx/mixin";
+import {DeleteStatusMessageMixin, CFsCountListRender, humanFileSize, getUrlPrefix, toast} from "jsx/mixin";
 
 const Stream = CreateReactClass({
     propTypes: {
@@ -32,28 +32,10 @@ const Stream = CreateReactClass({
         return {communicating: false, collapsed: true};
     },
 
-    _tableList: function(tables) {
-        const selectValues = tables.reduce((sum, item) => sum.concat({value: item, label: item}), [])
-        return (
-            <Select
-                name="tableList"
-                classNamePrefix="select"
-                value={selectValues}
-                isMulti
-                isClearable={false}
-                isDisabled={true}
-                components={{
-                  DropdownIndicator: () => null,
-                  IndicatorSeparator: () => null
-                }}
-            />
-        );
-    },
-
     render: function() {
 
         const stream = this.props.stream;
-        const isActive = stream.completed ? false : true;
+        const isActive = stream.completed ? false : (stream.success ? true : false);
         const style = stream.success ? (stream.completed ? "success" : "info") : "danger";
         const state = stream.success ? (stream.completed ? "Done" : "Streaming") : "Error";
 
@@ -73,8 +55,6 @@ const Stream = CreateReactClass({
             var directionText = "To: ";
         };
 
-        const tableList = this._tableList(tables)
-
         const peerWidth = {
             width: "10%"
         }
@@ -92,7 +72,7 @@ const Stream = CreateReactClass({
             <tr>
                 <td style={peerWidth}> <strong>{directionText} </strong> {stream.peer} </td>
                 <td style={planWidth}> <strong>PlanId: </strong> {this.props.planId} </td>
-                <td style={tableWidth}> <strong>Tables: </strong> {tableList} </td>
+                <td style={tableWidth}> <CFsCountListRender list={tables} /> </td>
                 <td style={barWidth}> <ProgressBar now={progress} active={isActive} label={label} bsStyle={style} key={stream.id} /> </td>
             </tr>
         );


### PR DESCRIPTION
The bulk of the change is in removing the progress bar color overrides. The other part is explicitly controlling the wrapping in progress bars so it overflows the actual element.

Before:
<img width="827" alt="Screenshot 2020-04-30 at 11 39 27" src="https://user-images.githubusercontent.com/2589903/80944820-10fff280-8df3-11ea-864b-817148d89d1b.png">
Sadly, I lost the shot of the text in progress bars being cut.

After:
<img width="1473" alt="Screenshot 2020-05-04 at 12 18 45" src="https://user-images.githubusercontent.com/2589903/80951952-8246a200-8e01-11ea-84ff-23bd016cef53.png">
^ This shows the info about which tables are repaired now works and is consistent with table listings in repair details.
<img width="738" alt="Screenshot 2020-04-30 at 14 12 20" src="https://user-images.githubusercontent.com/2589903/80944872-312fb180-8df3-11ea-8514-0e8d7ef945bc.png">
^ Progress bars have correct colours and the text is shown even if the bar is not full enough.
<img width="421" alt="Screenshot 2020-04-30 at 14 07 05" src="https://user-images.githubusercontent.com/2589903/80944885-35f46580-8df3-11ea-8ead-bb335056d172.png">
^ The same applies for the repair progress now.
<img width="419" alt="Screenshot 2020-04-30 at 14 07 41" src="https://user-images.githubusercontent.com/2589903/80944895-3db40a00-8df3-11ea-8c48-2f8446e3916a.png">
^ The bar colour in cluster list is fixed too.
