### PR TITLE
Limit the number of queries sent to C* backend

### DIFF
--- a/.github/scripts/configure-ccm.sh
+++ b/.github/scripts/configure-ccm.sh
@@ -50,8 +50,6 @@ case "${TEST_TYPE}" in
         mkdir -p ~/.local
         cp ./.github/files/jmxremote.password ~/.local/jmxremote.password
         chmod 400 ~/.local/jmxremote.password
-        sudo chmod 777 /usr/lib/jvm/zulu-8-azure-amd64/jre/lib/management/jmxremote.access
-        echo "cassandra     readwrite" >> /usr/lib/jvm/zulu-8-azure-amd64/jre/lib/management/jmxremote.access
         sudo chmod 777 /opt/hostedtoolcache/jdk/8.0.192/x64/jre/lib/management/jmxremote.access
         echo "cassandra     readwrite" >> /opt/hostedtoolcache/jdk/8.0.192/x64/jre/lib/management/jmxremote.access
         if [[ ! -z $ELASSANDRA_VERSION ]]; then

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -614,10 +614,11 @@ public final class RepairRunResource {
   @GET
   @Path("/cluster/{cluster_name}")
   public Response getRepairRunsForCluster(
-      @PathParam("cluster_name") String clusterName) {
+      @PathParam("cluster_name") String clusterName,
+      @QueryParam("limit") Optional<Integer> limit) {
 
     LOG.debug("get repair run for cluster called with: cluster_name = {}", clusterName);
-    final Collection<RepairRun> repairRuns = context.storage.getRepairRunsForCluster(clusterName, Optional.empty());
+    final Collection<RepairRun> repairRuns = context.storage.getRepairRunsForCluster(clusterName, limit);
     final Collection<RepairRunStatus> repairRunViews = new ArrayList<>();
     for (final RepairRun repairRun : repairRuns) {
       repairRunViews.add(getRepairRunStatus(repairRun));
@@ -656,7 +657,8 @@ public final class RepairRunResource {
   public Response listRepairRuns(
       @QueryParam("state") Optional<String> state,
       @QueryParam("cluster_name") Optional<String> cluster,
-      @QueryParam("keyspace_name") Optional<String> keyspace) {
+      @QueryParam("keyspace_name") Optional<String> keyspace,
+      @QueryParam("limit") Optional<Integer> limit) {
 
     try {
       final Set desiredStates = splitStateParam(state);
@@ -670,7 +672,7 @@ public final class RepairRunResource {
 
       List<RepairRunStatus> runStatuses = Lists.newArrayList();
       for (final Cluster clstr : clusters) {
-        Collection<RepairRun> runs = context.storage.getRepairRunsForCluster(clstr.getName(), Optional.empty());
+        Collection<RepairRun> runs = context.storage.getRepairRunsForCluster(clstr.getName(), limit);
 
         runStatuses.addAll(
             (List<RepairRunStatus>) getRunStatuses(runs, desiredStates)

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -342,7 +343,7 @@ public final class RepairManager implements AutoCloseable {
 
   public RepairRun updateRepairRunIntensity(RepairRun repairRun, Double intensity) throws ReaperException {
     RepairRun updatedRun = repairRun.with().intensity(intensity).build(repairRun.getId());
-    if (!context.storage.updateRepairRun(updatedRun)) {
+    if (!context.storage.updateRepairRun(updatedRun, Optional.of(false))) {
       throw new ReaperException("failed updating repair run " + updatedRun.getId());
     }
     return updatedRun;

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -613,7 +613,9 @@ final class RepairRunner implements Runnable {
             "Will not update lastEvent of run that has already terminated. The message was: " + "\"{}\"",
             newEvent);
       } else {
-        context.storage.updateRepairRun(repairRun.get().with().lastEvent(newEvent).build(repairRunId));
+        context.storage.updateRepairRun(
+            repairRun.get().with().lastEvent(newEvent).build(repairRunId),
+            Optional.of(false));
         LOG.info(newEvent);
       }
     }
@@ -644,7 +646,7 @@ final class RepairRunner implements Runnable {
           .tables(RepairUnitService.create(context).getTablesToRepair(cluster, repairUnit))
           .build(repairRun.getId());
 
-      context.storage.updateRepairRun(newRepairRun);
+      context.storage.updateRepairRun(newRepairRun, Optional.of(false));
       return newRepairRun;
     }
     return repairRun;

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -61,6 +61,8 @@ public interface IStorage {
 
   RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments);
 
+  boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState);
+
   boolean updateRepairRun(RepairRun repairRun);
 
   Optional<RepairRun> getRepairRun(UUID id);
@@ -104,7 +106,7 @@ public interface IStorage {
 
   Collection<RepairParameters> getOngoingRepairsInCluster(String clusterName);
 
-  SortedSet<UUID> getRepairRunIdsForCluster(String clusterName);
+  SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit);
 
   int getSegmentAmountForRepairRun(UUID runId);
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -125,7 +125,7 @@ public final class MemoryStorage implements IStorage {
   @Override
   public Cluster deleteCluster(String clusterName) {
     getRepairSchedulesForCluster(clusterName).forEach(schedule -> deleteRepairSchedule(schedule.getId()));
-    getRepairRunIdsForCluster(clusterName).forEach(runId -> deleteRepairRun(runId));
+    getRepairRunIdsForCluster(clusterName, Optional.empty()).forEach(runId -> deleteRepairRun(runId));
 
     getEventSubscriptions(clusterName)
         .stream()
@@ -153,6 +153,11 @@ public final class MemoryStorage implements IStorage {
 
   @Override
   public boolean updateRepairRun(RepairRun repairRun) {
+    return updateRepairRun(repairRun, Optional.of(true));
+  }
+
+  @Override
+  public boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState) {
     if (!getRepairRun(repairRun.getId()).isPresent()) {
       return false;
     } else {
@@ -368,7 +373,7 @@ public final class MemoryStorage implements IStorage {
   }
 
   @Override
-  public SortedSet<UUID> getRepairRunIdsForCluster(String clusterName) {
+  public SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit) {
     SortedSet<UUID> repairRunIds = Sets.newTreeSet((u0, u1) -> (int)(u0.timestamp() - u1.timestamp()));
     for (RepairRun repairRun : repairRuns.values()) {
       if (repairRun.getClusterName().equalsIgnoreCase(clusterName)) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -144,7 +144,7 @@ public class PostgresStorage implements IStorage, IDistributedStorage {
   @Override
   public Cluster deleteCluster(String clusterName) {
     getRepairSchedulesForCluster(clusterName).forEach(schedule -> deleteRepairSchedule(schedule.getId()));
-    getRepairRunIdsForCluster(clusterName).forEach(runId -> deleteRepairRun(runId));
+    getRepairRunIdsForCluster(clusterName, Optional.empty()).forEach(runId -> deleteRepairRun(runId));
 
     getEventSubscriptions(clusterName)
         .stream()
@@ -345,6 +345,11 @@ public class PostgresStorage implements IStorage, IDistributedStorage {
 
   @Override
   public boolean updateRepairRun(RepairRun repairRun) {
+    return updateRepairRun(repairRun, Optional.of(true));
+  }
+
+  @Override
+  public boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState) {
     boolean result = false;
     try (Handle h = jdbi.open()) {
       int rowsAdded = getPostgresStorage(h).updateRepairRun(repairRun);
@@ -480,7 +485,7 @@ public class PostgresStorage implements IStorage, IDistributedStorage {
   }
 
   @Override
-  public SortedSet<UUID> getRepairRunIdsForCluster(String clusterName) {
+  public SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit) {
     SortedSet<UUID> result = Sets.newTreeSet(Collections.reverseOrder());
     try (Handle h = jdbi.open()) {
       for (Long l : getPostgresStorage(h).getRepairRunIdsForCluster(clusterName)) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration025.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration025.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019-2019 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cassandra;
+
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Migration025 {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Migration025.class);
+  private static final String V1_TABLE = "repair_run_by_cluster";
+  private static final String V2_TABLE = "repair_run_by_cluster_v2";
+  private static PreparedStatement v2_insert;
+
+  private Migration025() {
+  }
+
+  /**
+   * Switch to v2 of repair_run_by_cluster
+   */
+  public static void migrate(Session session, String keyspace) {
+
+    try {
+      if (session.getCluster().getMetadata().getKeyspace(keyspace).getTable(V1_TABLE) != null) {
+        v2_insert = session.prepare(
+            "INSERT INTO " + V2_TABLE + "(cluster_name, id, repair_run_state) values (?, ?, ?)");
+        LOG.info("Converting {} table...", V1_TABLE);
+        ResultSet results = session.execute("SELECT * FROM " + V1_TABLE);
+        for (Row row:results) {
+          String state = session.execute("SELECT distinct state from repair_run where id = " + row.getUUID("id")).one()
+              .getString("state");
+          session.execute(v2_insert.bind(row.getString("cluster_name"), row.getUUID("id"), state));
+        }
+        session.execute("DROP TABLE " + V1_TABLE);
+      }
+    } catch (RuntimeException e) {
+      LOG.error("Failed transferring rows to " + V2_TABLE, e);
+    }
+  }
+
+}

--- a/src/server/src/main/resources/db/cassandra/025_lighten_load_repair_run_scans.cql
+++ b/src/server/src/main/resources/db/cassandra/025_lighten_load_repair_run_scans.cql
@@ -1,0 +1,27 @@
+--
+--  Copyright 2020 The Last Pickle Ltd
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to handle diagnostic event subscriptions
+
+CREATE TABLE IF NOT EXISTS repair_run_by_cluster_v2 (
+    cluster_name text,
+    id timeuuid,
+    repair_run_state text,
+    PRIMARY KEY (cluster_name, id)
+) WITH CLUSTERING ORDER BY (id DESC)
+    AND bloom_filter_fp_chance = 0.1
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000;

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -238,8 +238,8 @@ public final class RepairRunResourceTest {
 
     assertEquals(1, context.storage.getClusters().size());
     assertEquals(1, context.storage.getRepairRunsForCluster(clustername, Optional.of(2)).size());
-    assertEquals(1, context.storage.getRepairRunIdsForCluster(clustername).size());
-    UUID runId = context.storage.getRepairRunIdsForCluster(clustername).iterator().next();
+    assertEquals(1, context.storage.getRepairRunIdsForCluster(clustername, Optional.empty()).size());
+    UUID runId = context.storage.getRepairRunIdsForCluster(clustername, Optional.empty()).iterator().next();
     RepairRun run = context.storage.getRepairRun(runId).get();
     final RepairUnit unit = context.storage.getRepairUnit(run.getRepairUnitId());
     assertEquals(RepairRun.RunState.NOT_STARTED, run.getRunState());

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -397,14 +397,14 @@ public final class RepairManagerTest {
             .tables(TABLES)
             .build(UUIDs.timeBased());
 
-    when(context.storage.updateRepairRun(any())).thenReturn(true);
+    when(context.storage.updateRepairRun(any(), any())).thenReturn(true);
 
     intensity = 0.1;
     RepairRun updated = context.repairManager.updateRepairRunIntensity(run, intensity);
 
     Assertions.assertThat(updated.getId()).isEqualTo(run.getId());
     Assertions.assertThat(updated.getIntensity()).isEqualTo(intensity);
-    Mockito.verify(context.storage, Mockito.times(1)).updateRepairRun(any());
+    Mockito.verify(context.storage, Mockito.times(1)).updateRepairRun(any(), any());
   }
 
   private static class NotEmptyList implements ArgumentMatcher<Collection<RepairSegment>> {

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -324,7 +324,8 @@ const repairList = CreateReactClass({
   },
 
   _handleTimer: function() {
-     this.props.repairRunSubject.onNext({ clusterName: this.state.currentCluster });
+      numberOfElementsToDisplay: 10,
+     this.props.repairRunSubject.onNext({ clusterName: this.state.currentCluster, limit: this.state.numberOfElementsToDisplay });
   },
 
   updateWindowDimensions: function() {


### PR DESCRIPTION
Reaper checks the running and paused repair runs every 10 to 30 seconds to perform maintenance operations.
When the repair history starts growing, Reaper will scan them all to look for running/paused repairs because the repair_run_by_cluster table doesn't contain the repair run state.
This commit adds this column, which allows to filter runs early in the process instead of scanning them all in the repair_run table.
With hundreds or thousands of repair runs in history, this can end up adding a lot of unnecessary load on the Cassandra backend.