### PR TITLE
Store replicas in the segments

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -18,6 +18,7 @@
 package io.cassandrareaper.core;
 
 import java.math.BigInteger;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -26,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
 
 @JsonDeserialize(builder = RepairSegment.Builder.class)
@@ -42,6 +44,7 @@ public final class RepairSegment {
   private final String coordinatorHost;
   private final DateTime startTime;
   private final DateTime endTime;
+  private final Map<String, String> replicas;
 
   private RepairSegment(Builder builder, @Nullable UUID id) {
     this.id = id;
@@ -53,6 +56,9 @@ public final class RepairSegment {
     this.coordinatorHost = builder.coordinatorHost;
     this.startTime = builder.startTime;
     this.endTime = builder.endTime;
+    this.replicas = builder.replicas != null
+        ? ImmutableMap.copyOf(builder.replicas)
+        : null;
   }
 
   public static Builder builder(Segment tokenRange, UUID repairUnitId) {
@@ -108,6 +114,10 @@ public final class RepairSegment {
     return endTime;
   }
 
+  public Map<String, String> getReplicas() {
+    return replicas;
+  }
+
   public Builder with() {
     return new Builder(this);
   }
@@ -149,6 +159,7 @@ public final class RepairSegment {
     private String coordinatorHost;
     private DateTime startTime;
     private DateTime endTime;
+    private Map<String, String> replicas;
 
     private Builder() {}
 
@@ -159,6 +170,7 @@ public final class RepairSegment {
       this.tokenRange = tokenRange;
       this.failCount = 0;
       this.state = State.NOT_STARTED;
+      this.replicas = tokenRange.getReplicas();
     }
 
     private Builder(RepairSegment original) {
@@ -171,6 +183,7 @@ public final class RepairSegment {
       coordinatorHost = original.coordinatorHost;
       startTime = original.startTime;
       endTime = original.endTime;
+      replicas = original.replicas;
     }
 
     public Builder withRunId(UUID runId) {
@@ -222,6 +235,11 @@ public final class RepairSegment {
 
     public Builder withId(@Nullable UUID segmentId) {
       this.id = segmentId;
+      return this;
+    }
+
+    public Builder withReplicas(Map<String, String> replicas) {
+      this.replicas = replicas;
       return this;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/core/Segment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/Segment.java
@@ -23,9 +23,11 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.common.collect.ImmutableMap;
 
 @JsonDeserialize(builder = Segment.Builder.class)
 public final class Segment {
@@ -36,6 +38,7 @@ public final class Segment {
 
   RingRange baseRange;
   List<RingRange> tokenRanges;
+  Map<String, String> replicas;
 
   private Segment(Builder builder) {
     this.tokenRanges = builder.tokenRanges;
@@ -43,6 +46,9 @@ public final class Segment {
     if (builder.baseRange != null) {
       this.baseRange = builder.baseRange;
     }
+    this.replicas = builder.replicas != null
+        ? ImmutableMap.copyOf(builder.replicas)
+        : null;
   }
 
   public RingRange getBaseRange() {
@@ -62,6 +68,10 @@ public final class Segment {
     return tokens;
   }
 
+  public Map<String, String> getReplicas() {
+    return this.replicas;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -70,6 +80,7 @@ public final class Segment {
   public static final class Builder {
     private List<RingRange> tokenRanges;
     private RingRange baseRange;
+    private Map<String, String> replicas;
 
     private Builder() {}
 
@@ -85,6 +96,11 @@ public final class Segment {
 
     public Builder withBaseRange(RingRange baseRange) {
       this.baseRange = baseRange;
+      return this;
+    }
+
+    public Builder withReplicas(Map<String, String> replicas) {
+      this.replicas = replicas;
       return this;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -305,7 +305,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
 
             // ~double-checking idiom, only applies to non-incremental and distributed storage
             if (!repairUnit.getIncrementalRepair() && context.storage instanceof IDistributedStorage) {
-              Map<String, String> dcByNode = getDCsByNodeForRepairSegment(coordinator, cluster, segment, keyspace);
+              Map<String, String> dcByNode = segment.getReplicas();
               if (isRepairRunningOnNodes(segment, dcByNode, keyspace, cluster)) {
                 LOG.warn(
                     "Post-lock, cannot run segment {} for repair {} at the moment. Will try again later",
@@ -503,7 +503,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
 
     if (RepairSegment.State.NOT_STARTED == segment.getState()) {
       try {
-        Map<String, String> dcByNode = getDCsByNodeForRepairSegment(coordinator, cluster, segment, keyspace);
+        Map<String, String> dcByNode = segment.getReplicas();
 
         return !isRepairRunningOnNodes(segment, dcByNode, keyspace, cluster)
             && nodesReadyForNewRepair(coordinator, segment, dcByNode, busyHosts);
@@ -745,19 +745,6 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
     return !Collections.disjoint(
         clusterFacade.tokenRangeToEndpoint(cluster, keyspace, segment.getTokenRange()),
         nodes);
-  }
-
-  private Map<String, String> getDCsByNodeForRepairSegment(
-      JmxProxy coordinator,
-      Cluster cluster,
-      RepairSegment segment,
-      String keyspace) {
-
-    // when hosts are coming up or going down, this method can throw an UndeclaredThrowableException
-    Collection<String> nodes = clusterFacade.tokenRangeToEndpoint(cluster, keyspace, segment.getTokenRange());
-    Map<String, String> dcByNode = Maps.newHashMap();
-    nodes.forEach(node -> dcByNode.put(node, EndpointSnitchInfoProxy.create(coordinator).getDataCenter(node)));
-    return dcByNode;
   }
 
   private void storeNodeMetrics(NodeMetrics metrics) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/JsonParseUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/JsonParseUtils.java
@@ -20,7 +20,9 @@ package io.cassandrareaper.storage;
 import io.cassandrareaper.service.RingRange;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -36,7 +38,10 @@ public final class JsonParseUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonParseUtils.class);
 
-  private static final ObjectReader READER = new ObjectMapper().readerFor(new TypeReference<List<RingRange>>() {});
+  private static final ObjectReader LIST_READER
+      = new ObjectMapper().readerFor(new TypeReference<List<RingRange>>() {});
+  private static final ObjectReader MAP_READER
+      = new ObjectMapper().readerFor(new TypeReference<Map<String, String>>() {});
   private static final ObjectWriter WRITER = new ObjectMapper().writer();
 
   private JsonParseUtils() {
@@ -45,7 +50,7 @@ public final class JsonParseUtils {
 
   public static List<RingRange> parseRingRangeList(Optional<String> json) {
     try {
-      return json.isPresent() ? READER.readValue(json.get()) : Lists.newArrayList();
+      return json.isPresent() ? LIST_READER.readValue(json.get()) : Lists.newArrayList();
     } catch (IOException e) {
       LOG.error("error parsing json", e);
       throw new IllegalArgumentException(e);
@@ -55,6 +60,23 @@ public final class JsonParseUtils {
   public static String writeTokenRangesTxt(List<RingRange> tokenRanges) {
     try {
       return WRITER.writeValueAsString(tokenRanges);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  public static Map<String, String> parseReplicas(Optional<String> json) {
+    try {
+      return json.isPresent() ? MAP_READER.readValue(json.get()) : Collections.emptyMap();
+    } catch (IOException e) {
+      LOG.error("error parsing json", e);
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  public static String writeReplicas(Map<String, String> replicas) {
+    try {
+      return WRITER.writeValueAsString(replicas);
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException(e);
     }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -122,13 +122,13 @@ public interface IStoragePostgreSql {
   //
   String SQL_REPAIR_SEGMENT_ALL_FIELDS_NO_ID
       = "repair_unit_id, run_id, start_token, end_token, state, coordinator_host, start_time, "
-          + "end_time, fail_count, token_ranges";
+          + "end_time, fail_count, token_ranges, replicas";
   String SQL_REPAIR_SEGMENT_ALL_FIELDS = "repair_segment.id, " + SQL_REPAIR_SEGMENT_ALL_FIELDS_NO_ID;
   String SQL_INSERT_REPAIR_SEGMENT = "INSERT INTO repair_segment ("
           + SQL_REPAIR_SEGMENT_ALL_FIELDS_NO_ID
           + ") VALUES "
           + "(:repairUnitId, :runId, :startToken, :endToken, :state, :coordinatorHost, :startTime, "
-          + ":endTime, :failCount, :tokenRangesTxt)";
+          + ":endTime, :failCount, :tokenRangesTxt, :replicasTxt)";
   String SQL_UPDATE_REPAIR_SEGMENT = "UPDATE repair_segment SET repair_unit_id = :repairUnitId, run_id = :runId, "
           + "start_token = :startToken, end_token = :endToken, state = :state, "
           + "coordinator_host = :coordinatorHost, start_time = :startTime, end_time = :endTime, "
@@ -139,7 +139,8 @@ public interface IStoragePostgreSql {
   String SQL_GET_REPAIR_SEGMENTS_FOR_RUN_WITH_STATE = "SELECT " + SQL_REPAIR_SEGMENT_ALL_FIELDS
       + " FROM repair_segment WHERE " + "run_id = :runId AND state = :state";
   String SQL_GET_RUNNING_REPAIRS_FOR_CLUSTER
-      = "SELECT start_token, end_token, token_ranges, keyspace_name, column_families, repair_parallelism, tables "
+      = "SELECT start_token, end_token, token_ranges, keyspace_name, column_families, "
+          + "repair_parallelism, tables, replicas "
           + "FROM repair_segment "
           + "JOIN repair_run ON run_id = repair_run.id "
           + "JOIN repair_unit ON repair_run.repair_unit_id = repair_unit.id "

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/PostgresRepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/PostgresRepairSegment.java
@@ -38,6 +38,7 @@ public class PostgresRepairSegment {
   private final DateTime startTime;
   private final DateTime endTime;
   private final String tokenRangesTxt;
+  private final String replicasTxt;
 
   public PostgresRepairSegment(RepairSegment original) {
     runId = original.getRunId();
@@ -50,6 +51,7 @@ public class PostgresRepairSegment {
     startTime = original.getStartTime();
     endTime = original.getEndTime();
     tokenRangesTxt = JsonParseUtils.writeTokenRangesTxt(original.getTokenRange().getTokenRanges());
+    replicasTxt = JsonParseUtils.writeReplicas(original.getReplicas());
   }
 
   public UUID getId() {
@@ -98,5 +100,9 @@ public class PostgresRepairSegment {
 
   public BigInteger getEndToken() {
     return tokenRange.getBaseRange().getEnd();
+  }
+
+  public String getReplicasTxt() {
+    return replicasTxt;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairSegmentMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairSegmentMapper.java
@@ -37,17 +37,25 @@ public final class RepairSegmentMapper implements ResultSetMapper<RepairSegment>
         = new RingRange(rs.getBigDecimal("start_token").toBigInteger(), rs.getBigDecimal("end_token").toBigInteger());
 
     RepairSegment.Builder builder = RepairSegment.builder(
-                Segment.builder().withTokenRange(range).build(),
-                UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")))
-            .withRunId(UuidUtil.fromSequenceId(rs.getLong("run_id")))
-            .withState(RepairSegment.State.values()[rs.getInt("state")])
-            .withFailCount(rs.getInt("fail_count"))
-            .withTokenRange(
-                Segment.builder()
-                    .withTokenRanges(
-                        JsonParseUtils.parseRingRangeList(
-                            Optional.ofNullable(rs.getString("token_ranges"))))
-                    .build());
+        Segment.builder()
+            .withTokenRange(range)
+            .withReplicas(JsonParseUtils.parseReplicas(
+                Optional.ofNullable(rs.getString("replicas")))).build(),
+        UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")))
+        .withRunId(UuidUtil.fromSequenceId(rs.getLong("run_id")))
+        .withState(RepairSegment.State.values()[rs.getInt("state")])
+        .withFailCount(rs.getInt("fail_count"))
+        .withReplicas(JsonParseUtils.parseReplicas(
+            Optional.ofNullable(rs.getString("replicas"))))
+        .withTokenRange(
+            Segment.builder()
+                .withTokenRanges(
+                    JsonParseUtils.parseRingRangeList(
+                        Optional.ofNullable(rs.getString("token_ranges"))))
+                .withReplicas(JsonParseUtils.parseReplicas(
+                    Optional.ofNullable(rs.getString("replicas"))))
+                .build());
+
 
     if (null != rs.getString("coordinator_host")) {
       builder = builder.withCoordinatorHost(rs.getString("coordinator_host"));

--- a/src/server/src/main/resources/db/cassandra/026_concurrent_repairs.cql
+++ b/src/server/src/main/resources/db/cassandra/026_concurrent_repairs.cql
@@ -1,0 +1,18 @@
+--
+--  Copyright 2020-2020 Datastax inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Upgrade to handle diagnostic event subscriptions
+
+ALTER TABLE repair_run ADD replicas frozen<map<text, text>>;

--- a/src/server/src/main/resources/db/h2/V19_0_0__list_replicas_segment.sql
+++ b/src/server/src/main/resources/db/h2/V19_0_0__list_replicas_segment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repair_segment
+ADD replicas VARCHAR;

--- a/src/server/src/main/resources/db/postgres/V19_0_0__list_replicas_segment.sql
+++ b/src/server/src/main/resources/db/postgres/V19_0_0__list_replicas_segment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "repair_segment"
+ADD "replicas" TEXT;

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -27,6 +27,7 @@ import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Table;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
+import io.cassandrareaper.jmx.JmxProxyTest;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.RepairRunnerTest;
@@ -34,6 +35,7 @@ import io.cassandrareaper.storage.MemoryStorage;
 
 import java.math.BigInteger;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +54,7 @@ import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -138,7 +141,7 @@ public final class RepairRunResourceTest {
     uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(SAMPLE_URI));
 
-    proxy = mock(JmxProxy.class);
+    proxy = JmxProxyTest.mockJmxProxyImpl();
     when(proxy.getClusterName()).thenReturn(clustername);
     when(proxy.getCassandraVersion()).thenReturn("3.11.4");
     when(proxy.getPartitioner()).thenReturn(PARTITIONER);
@@ -162,6 +165,15 @@ public final class RepairRunResourceTest {
             any(),
             any(Integer.class)))
         .thenReturn(1);
+
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    JmxProxyTest.mockGetEndpointSnitchInfoMBean(proxy, endpointSnitchInfoMBean);
 
     context.jmxConnectionFactory = mock(JmxConnectionFactory.class);
     when(context.jmxConnectionFactory.connectAny(Mockito.anyCollection())).thenReturn(proxy);

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -60,7 +60,6 @@ import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.progress.ProgressEventType;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.assertj.core.util.Maps;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.junit.Before;
@@ -89,6 +88,9 @@ public final class RepairRunnerTest {
             .withSeedHosts(ImmutableSet.of("127.0.0.1"))
             .withState(Cluster.State.ACTIVE)
             .build();
+  private Map<String, String> replicas = ImmutableMap.of(
+      "127.0.0.1", "dc1"
+  );
 
   @Before
   public void setUp() throws Exception {
@@ -109,7 +111,6 @@ public final class RepairRunnerTest {
     final IStorage storage = new MemoryStorage();
 
     storage.addCluster(cluster);
-
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
             .clusterName(cluster.getName())
@@ -121,6 +122,7 @@ public final class RepairRunnerTest {
             .blacklistedTables(BLACKLISTED_TABLES)
             .repairThreadCount(REPAIR_THREAD_COUNT));
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
+
     RepairRun run = storage.addRepairRun(
             RepairRun.builder(cluster.getName(), cf.getId())
                 .intensity(INTENSITY)
@@ -129,7 +131,10 @@ public final class RepairRunnerTest {
                 .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
-                    Segment.builder().withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100"))).build(),
+                    Segment.builder()
+                           .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                           .withReplicas(replicas)
+                           .build(),
                     cf.getId())));
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
@@ -277,7 +282,10 @@ public final class RepairRunnerTest {
                 .tables(TABLES),
             Collections.singleton(
                 RepairSegment.builder(
-                    Segment.builder().withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100"))).build(),
+                    Segment.builder()
+                           .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                           .withReplicas(replicas)
+                           .build(),
                     cf.getId())));
     final UUID RUN_ID = run.getId();
     final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
@@ -397,7 +405,9 @@ public final class RepairRunnerTest {
     final Set<String> CF_NAMES = Sets.newHashSet("reaper");
     final boolean INCREMENTAL_REPAIR = false;
     final Set<String> NODES = Sets.newHashSet("127.0.0.1");
-    final Map<String, String> NODES_MAP = Maps.newHashMap("node1", "127.0.0.1");
+    final Map<String, String> NODES_MAP = ImmutableMap.of(
+        "127.0.0.1", "dc1"
+        );
     final Set<String> DATACENTERS = Collections.emptySet();
     final Set<String> BLACKLISTED_TABLES = Collections.emptySet();
     final long TIME_RUN = 41L;
@@ -411,9 +421,7 @@ public final class RepairRunnerTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-
     storage.addCluster(cluster);
-
     UUID cf = storage.addRepairUnit(
         RepairUnit.builder()
             .clusterName(cluster.getName())
@@ -438,6 +446,7 @@ public final class RepairRunnerTest {
                 RepairSegment.builder(
                         Segment.builder()
                             .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                            .withReplicas(replicas)
                             .build(),
                         cf)
                     .withState(RepairSegment.State.RUNNING)
@@ -446,6 +455,7 @@ public final class RepairRunnerTest {
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
+                        .withReplicas(replicas)
                         .build(),
                     cf)));
 
@@ -696,6 +706,158 @@ public final class RepairRunnerTest {
     List<String> endPoints = Lists.newArrayList(hosts);
     map.put(range, endPoints);
     return map;
+  }
+
+  @Test
+  public void testFailRepairAfterTopologyChange() throws InterruptedException, ReaperException {
+    final String KS_NAME = "reaper";
+    final Set<String> CF_NAMES = Sets.newHashSet("reaper");
+    final boolean INCREMENTAL_REPAIR = false;
+    final Set<String> NODES = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
+    final List<String> NODES_AFTER_TOPOLOGY_CHANGE = Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.4");
+    final Map<String, String> NODES_MAP = ImmutableMap.of(
+        "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1"
+        );
+    final Set<String> DATACENTERS = Collections.emptySet();
+    final Set<String> BLACKLISTED_TABLES = Collections.emptySet();
+    final long TIME_RUN = 41L;
+    final double INTENSITY = 0.5f;
+    final int REPAIR_THREAD_COUNT = 1;
+    final List<BigInteger> TOKENS = Lists.newArrayList(
+        BigInteger.valueOf(0L),
+        BigInteger.valueOf(100L),
+        BigInteger.valueOf(200L));
+    final IStorage storage = new MemoryStorage();
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = new ReaperApplicationConfiguration();
+    storage.addCluster(cluster);
+    UUID cf = storage.addRepairUnit(
+        RepairUnit.builder()
+            .clusterName(cluster.getName())
+            .keyspaceName(KS_NAME)
+            .columnFamilies(CF_NAMES)
+            .incrementalRepair(INCREMENTAL_REPAIR)
+            .nodes(NODES)
+            .datacenters(DATACENTERS)
+            .blacklistedTables(BLACKLISTED_TABLES)
+            .repairThreadCount(REPAIR_THREAD_COUNT))
+        .getId();
+    DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder(cluster.getName(), cf)
+                .intensity(INTENSITY)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL)
+                .tables(TABLES),
+            Lists.newArrayList(
+                RepairSegment.builder(
+                        Segment.builder()
+                            .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                            .withReplicas(NODES_MAP)
+                            .build(),
+                        cf)
+                    .withState(RepairSegment.State.RUNNING)
+                    .withStartTime(DateTime.now())
+                    .withCoordinatorHost("reaper"),
+                RepairSegment.builder(
+                    Segment.builder()
+                        .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
+                        .withReplicas(NODES_MAP)
+                        .build(),
+                    cf)));
+
+    final UUID RUN_ID = run.getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
+    assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(), RepairSegment.State.NOT_STARTED);
+    final JmxProxy jmx = JmxProxyTest.mockJmxProxyImpl();
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(jmx.getEndpointToHostId()).thenReturn(NODES_MAP);
+    when(jmx.getTokens()).thenReturn(TOKENS);
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    JmxProxyTest.mockGetEndpointSnitchInfoMBean(jmx, endpointSnitchInfoMBean);
+    ClusterFacade clusterFacade = mock(ClusterFacade.class);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
+    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
+        .thenReturn(Lists.newArrayList(NODES));
+    when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
+        .thenReturn((Map)ImmutableMap.of(
+            Lists.newArrayList("0", "100"), Lists.newArrayList(NODES),
+            Lists.newArrayList("100", "200"), Lists.newArrayList(NODES)));
+    when(clusterFacade.getEndpointToHostId(any())).thenReturn(NODES_MAP);
+    context.repairManager = RepairManager.create(
+        context,
+        clusterFacade,
+        Executors.newScheduledThreadPool(10),
+        500,
+        TimeUnit.MILLISECONDS,
+        1,
+        TimeUnit.MILLISECONDS);
+    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+
+    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+        .then(
+            (invocation) -> {
+              final int repairNumber = repairNumberCounter.getAndIncrement();
+
+              new Thread() {
+                @Override
+                public void run() {
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.STARTED),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.FINISHED),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                }
+              }.start();
+              return repairNumber;
+            });
+    context.jmxConnectionFactory = new JmxConnectionFactory(context, new NoopCrypotograph()) {
+          @Override
+          protected JmxProxy connectImpl(Node host) throws ReaperException {
+            return jmx;
+          }
+        };
+    ClusterFacade clusterProxy = ClusterFacade.create(context);
+    ClusterFacade clusterProxySpy = Mockito.spy(clusterProxy);
+    Mockito.doReturn(NODES_AFTER_TOPOLOGY_CHANGE).when(clusterProxySpy).tokenRangeToEndpoint(any(), any(), any());
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRun(RUN_ID).get().getRunState());
+    storage.updateRepairRun(
+        run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(RUN_ID));
+    // We'll now change the list of replicas for any segment, making the stored ones obsolete
+    when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
+      .thenReturn(Lists.newArrayList(NODES_AFTER_TOPOLOGY_CHANGE));
+    context.repairManager.resumeRunningRepairRuns();
+    // The repair should now fail as the list of replicas for the segments are different from storage
+    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+      return RepairRun.RunState.ERROR == storage.getRepairRun(RUN_ID).get().getRunState();
+    });
+    assertEquals(RepairRun.RunState.ERROR, storage.getRepairRun(RUN_ID).get().getRunState());
   }
 
 }

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -43,6 +43,7 @@ import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -55,6 +56,7 @@ import java.util.concurrent.Future;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import jersey.repackaged.com.google.common.collect.Maps;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.progress.ProgressEventType;
@@ -106,6 +108,8 @@ public final class SegmentRunnerTest {
                 .nodes(Sets.newHashSet("127.0.0.1"))
                 .repairThreadCount(1));
 
+    Map<String, String> replicas = Maps.newHashMap();
+    replicas.put("127.0.0.1", "dc1");
     RepairRun run = context.storage.addRepairRun(
             RepairRun.builder("reaper", cf.getId())
                 .intensity(0.5)
@@ -116,12 +120,13 @@ public final class SegmentRunnerTest {
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .withReplicas(replicas)
                         .build(),
                     cf.getId())));
 
     context.storage.addCluster(Cluster.builder()
         .withName(cf.getClusterName())
-        .withPartitioner("murmur3")
+        .withPartitioner("Murmur3Partitioner")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
         .withState(Cluster.State.ACTIVE)
@@ -220,6 +225,8 @@ public final class SegmentRunnerTest {
                 .nodes(Sets.newHashSet("127.0.0.1"))
                 .repairThreadCount(1));
 
+    Map<String, String> replicas = Maps.newHashMap();
+    replicas.put("127.0.0.1", "dc1");
     RepairRun run = storage.addRepairRun(
             RepairRun.builder("reaper", cf.getId())
                 .intensity(0.5)
@@ -230,12 +237,13 @@ public final class SegmentRunnerTest {
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .withReplicas(replicas)
                         .build(),
                     cf.getId())));
 
     storage.addCluster(Cluster.builder()
         .withName(cf.getClusterName())
-        .withPartitioner("murmur3")
+        .withPartitioner("Murmur3Partitioner")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
         .withState(Cluster.State.ACTIVE)
@@ -369,6 +377,8 @@ public final class SegmentRunnerTest {
                 .nodes(Sets.newHashSet("127.0.0.1"))
                 .repairThreadCount(1));
 
+    Map<String, String> replicas = Maps.newHashMap();
+    replicas.put("127.0.0.1", "dc1");
     RepairRun run = storage.addRepairRun(
             RepairRun.builder("reaper", cf.getId())
                 .intensity(0.5)
@@ -379,12 +389,13 @@ public final class SegmentRunnerTest {
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .withReplicas(replicas)
                         .build(),
                     cf.getId())));
 
     storage.addCluster(Cluster.builder()
         .withName(cf.getClusterName())
-        .withPartitioner("murmur3")
+        .withPartitioner("Murmur3Partitioner")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
         .withState(Cluster.State.ACTIVE)
@@ -509,6 +520,8 @@ public final class SegmentRunnerTest {
                 .nodes(Sets.newHashSet("127.0.0.1"))
                 .repairThreadCount(1));
 
+    Map<String, String> replicas = Maps.newHashMap();
+    replicas.put("127.0.0.1", "dc1");
     RepairRun run = storage.addRepairRun(
             RepairRun.builder("reaper", cf.getId())
                 .intensity(0.5)
@@ -519,12 +532,13 @@ public final class SegmentRunnerTest {
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .withReplicas(replicas)
                         .build(),
                     cf.getId())));
 
     storage.addCluster(Cluster.builder()
         .withName(cf.getClusterName())
-        .withPartitioner("murmur3")
+        .withPartitioner("Murmur3Partitioner")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
         .withState(Cluster.State.ACTIVE)
@@ -645,6 +659,8 @@ public final class SegmentRunnerTest {
                 .nodes(Sets.newHashSet("127.0.0.1"))
                 .repairThreadCount(1));
 
+    Map<String, String> replicas = Maps.newHashMap();
+    replicas.put("127.0.0.1", "dc1");
     RepairRun run = storage.addRepairRun(
             RepairRun.builder("reaper", cf.getId())
                 .intensity(0.5)
@@ -655,12 +671,13 @@ public final class SegmentRunnerTest {
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .withReplicas(replicas)
                         .build(),
                     cf.getId())));
 
     storage.addCluster(Cluster.builder()
         .withName(cf.getClusterName())
-        .withPartitioner("murmur3")
+        .withPartitioner("Murmur3Partitioner")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
         .withState(Cluster.State.ACTIVE)
@@ -782,6 +799,8 @@ public final class SegmentRunnerTest {
                 .nodes(Sets.newHashSet("127.0.0.1"))
                 .repairThreadCount(1));
 
+    Map<String, String> replicas = Maps.newHashMap();
+    replicas.put("127.0.0.1", "dc1");
     RepairRun run = storage.addRepairRun(
             RepairRun.builder("reaper", cf.getId())
                 .intensity(0.5)
@@ -792,12 +811,13 @@ public final class SegmentRunnerTest {
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .withReplicas(replicas)
                         .build(),
                     cf.getId())));
 
     storage.addCluster(Cluster.builder()
         .withName(cf.getClusterName())
-        .withPartitioner("murmur3")
+        .withPartitioner("Murmur3Partitioner")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
         .withState(Cluster.State.ACTIVE)
@@ -920,6 +940,8 @@ public final class SegmentRunnerTest {
                 .nodes(Sets.newHashSet("127.0.0.1"))
                 .repairThreadCount(1));
 
+    Map<String, String> replicas = Maps.newHashMap();
+    replicas.put("127.0.0.1", "dc1");
     RepairRun run = storage.addRepairRun(
             RepairRun.builder("reaper", cf.getId())
                 .intensity(0.5)
@@ -930,12 +952,13 @@ public final class SegmentRunnerTest {
                 RepairSegment.builder(
                     Segment.builder()
                         .withTokenRange(new RingRange(BigInteger.ONE, BigInteger.ZERO))
+                        .withReplicas(replicas)
                         .build(),
                     cf.getId())));
 
     storage.addCluster(Cluster.builder()
         .withName(cf.getClusterName())
-        .withPartitioner("murmur3")
+        .withPartitioner("Murmur3Partitioner")
         .withSeedHosts(cf.getNodes())
         .withJmxPort(7199)
         .withState(Cluster.State.ACTIVE)
@@ -1119,7 +1142,7 @@ public final class SegmentRunnerTest {
     Mockito.when(((CassandraStorage) context.storage).getCluster(any()))
         .thenReturn(Cluster.builder()
           .withName("test")
-          .withPartitioner("murmur3")
+          .withPartitioner("Murmur3Partitioner")
           .withSeedHosts(ImmutableSet.of("test"))
           .withJmxPort(7199)
           .build());

--- a/src/ui/app/jsx/segment-list.jsx
+++ b/src/ui/app/jsx/segment-list.jsx
@@ -175,6 +175,7 @@ const SegmentList = CreateReactClass({
                                 <th>Fail count</th>
                                 <th>State</th>
                                 <th>Host</th>
+                                <th>Replicas</th>
                                 <th>Started</th>
                                 <th></th>
                             </tr>
@@ -204,6 +205,7 @@ const SegmentList = CreateReactClass({
                                 <th>Fail count</th>
                                 <th>State</th>
                                 <th>Host</th>
+                                <th>Replicas</th>
                                 <th>Started</th>
                                 <th>Ended</th>
                                 <th>Duration</th>
@@ -233,6 +235,7 @@ const SegmentList = CreateReactClass({
                                 <th>Start token</th>
                                 <th>End token</th>
                                 <th>Fail count</th>
+                                <th>Replicas</th>
                                 <th>State</th>
                             </tr>
                         </thead>
@@ -362,12 +365,14 @@ const Segment = CreateReactClass({
     },
 
     render: function() {
+        var replicas = Object.keys(this.props.segment.replicas).map(replica => replica + " (" + this.props.segment.replicas[replica] + ")");
         if (this.props.segment.state === 'NOT_STARTED') {
             return  <tr>
                 <td>{this.props.segment.id}</td>
                 <td>{this.props.segment.tokenRange.baseRange.start}</td>
                 <td>{this.props.segment.tokenRange.baseRange.end}</td>
                 <td>{this.props.segment.failCount}</td>
+                <td><CFsListRender list={replicas} /></td>
                 <td className="table-data-label-primary">{this.props.segment.state}</td>
             </tr>
         } else if (this.props.segment.state === 'RUNNING' || this.props.segment.state === 'STARTED') {
@@ -378,6 +383,7 @@ const Segment = CreateReactClass({
                 <td>{this.props.segment.failCount}</td>
                 <td className='table-data-label-warning'>{this.props.segment.state}</td>
                 <td>{this.props.segment.coordinatorHost}</td>
+                <td><CFsListRender list={replicas} /></td>
                 <td>{moment(this.props.segment.startTime).format("LLL")}</td>
                 <td><Button className='btn-xs btn-danger' onClick={() => this._abortSegment()}>Abort</Button></td>
             </tr>
@@ -389,6 +395,7 @@ const Segment = CreateReactClass({
                 <td>{this.props.segment.failCount}</td>
                 <td className='table-data-label-success'>{this.props.segment.state}</td>
                 <td>{this.props.segment.coordinatorHost}</td>
+                <td><CFsListRender list={replicas} /></td>
                 <td>{moment(this.props.segment.startTime).format("LLL")}</td>
                 <td>{moment(this.props.segment.endTime).format("LLL")}</td>
                 <td>{moment.duration(moment(this.props.segment.endTime).diff(moment(this.props.segment.startTime))).humanize()}</td>


### PR DESCRIPTION
This will allow to get more visibility on which nodes are involved in segments, reduce the number of JMX calls to perform when starting a segment.
It is also a first step to build a new segment scheduler that will not rely on JMX metrics for limiting the number of repair per node but rather use backend storage with locks.