### PR TITLE
New segment orchestration / concurrent repairs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,20 +33,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -101,20 +93,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -196,20 +181,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -266,20 +244,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -336,20 +307,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -445,20 +409,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -526,20 +482,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -607,20 +556,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -680,20 +622,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Setup CCM Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.ccm/repository
-          key: ${{ runner.os }}-ccm-${{ hashFiles('**') }}
-          restore-keys: |
-            ${{ runner.os }}-ccm-
 
       - name: Setup Java
         uses: actions/setup-java@v1
@@ -749,7 +684,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ src/packaging/data
 src/packaging/ssl-stores
 /src/server/nbproject/
 src/ui/theming/bootstrap/node_modules
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.cassandrareaper</groupId>
     <artifactId>cassandra-reaper-pom</artifactId>
-    <version>2.2.O-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Cassandra Reaper project</name>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.cassandrareaper</groupId>
         <artifactId>cassandra-reaper-pom</artifactId>
-        <version>2.2.O-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Cassandra Reaper server</name>

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -174,7 +174,9 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
         .addMapping("/prometheusMetrics");
 
     int repairThreads = config.getRepairRunThreadCount();
-    LOG.info("initializing runner thread pool with {} threads", repairThreads);
+    int maxParallelRepairs = config.getMaxParallelRepairs();
+    LOG.info("initializing runner thread pool with {} threads and {} repair runners",
+        repairThreads, maxParallelRepairs);
 
     tryInitializeStorage(config, environment);
 
@@ -189,7 +191,8 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
         config.getHangingRepairTimeoutMins(),
         TimeUnit.MINUTES,
         config.getRepairManagerSchedulingIntervalSeconds(),
-        TimeUnit.SECONDS);
+        TimeUnit.SECONDS,
+        maxParallelRepairs);
 
     // Enable cross-origin requests for using external GUI applications.
     if (config.isEnableCrossOrigin() || System.getProperty("enableCrossOrigin") != null) {

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -90,6 +90,10 @@ public final class ReaperApplicationConfiguration extends Configuration {
   private Integer repairRunThreadCount;
 
   @JsonProperty
+  @Nullable
+  private Integer maxParallelRepairs;
+
+  @JsonProperty
   @NotNull
   private Integer hangingRepairTimeoutMins;
 
@@ -254,6 +258,16 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
   public void setRepairRunThreadCount(int repairRunThreadCount) {
     this.repairRunThreadCount = repairRunThreadCount;
+  }
+
+  public int getMaxParallelRepairs() {
+    return maxParallelRepairs == null
+        ? 2
+        : maxParallelRepairs;
+  }
+
+  public void setMaxParallelRepairs(int maxParallelRepairs) {
+    this.maxParallelRepairs = maxParallelRepairs;
   }
 
   public String getStorageType() {

--- a/src/server/src/main/java/io/cassandrareaper/core/CompactionStats.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/CompactionStats.java
@@ -17,13 +17,14 @@
 package io.cassandrareaper.core;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 @JsonDeserialize(builder = CompactionStats.Builder.class)
 public final class CompactionStats {
-  private Integer pendingCompactions;
+  private Optional<Integer> pendingCompactions;
   private List<Compaction> activeCompactions;
 
   private CompactionStats(Builder builder) {
@@ -31,7 +32,7 @@ public final class CompactionStats {
     this.activeCompactions = builder.activeCompactions;
   }
 
-  public Integer getPendingCompactions() {
+  public Optional<Integer> getPendingCompactions() {
     return pendingCompactions;
   }
 
@@ -45,12 +46,12 @@ public final class CompactionStats {
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "with")
   public static final class Builder {
-    private Integer pendingCompactions;
+    private Optional<Integer> pendingCompactions;
     private List<Compaction> activeCompactions;
 
     private Builder() {}
 
-    public Builder withPendingCompactions(Integer pendingCompactions) {
+    public Builder withPendingCompactions(Optional<Integer> pendingCompactions) {
       this.pendingCompactions = pendingCompactions;
       return this;
     }

--- a/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
@@ -40,6 +40,7 @@ import javax.management.JMException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
@@ -62,7 +63,7 @@ public final class MetricsService {
 
   private final AppContext context;
   private final ClusterFacade clusterFacade;
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper;
   private final String localClusterName;
 
   private MetricsService(AppContext context, Supplier<ClusterFacade> clusterFacadeSupplier) throws ReaperException {
@@ -78,6 +79,8 @@ public final class MetricsService {
     } else {
       localClusterName = null;
     }
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new Jdk8Module());
   }
 
   @VisibleForTesting

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -21,11 +21,9 @@ import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperApplicationConfiguration.DatacenterAvailability;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
-import io.cassandrareaper.core.NodeMetrics;
 import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.jmx.ClusterFacade;
-import io.cassandrareaper.jmx.EndpointSnitchInfoProxy;
 import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.jmx.RepairStatusHandler;
 import io.cassandrareaper.jmx.SnapshotProxy;
@@ -35,25 +33,15 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.management.JMException;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -64,10 +52,7 @@ import com.sun.management.UnixOperatingSystemMXBean;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.progress.ProgressEventType;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.concurrent.ConcurrentException;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
-import org.apache.commons.lang3.tuple.Pair;
 import org.joda.time.DateTime;
 import org.joda.time.Seconds;
 import org.slf4j.Logger;
@@ -82,16 +67,11 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(SegmentRunner.class);
 
   private static final int MAX_TIMEOUT_EXTENSIONS = 10;
-  private static final int LOCK_DURATION = 30;
   private static final Pattern REPAIR_UUID_PATTERN
       = Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
 
   private static final long SLEEP_TIME_AFTER_POSTPONE_IN_MS
       = Integer.getInteger(SegmentRunner.class.getName() + ".sleep_time_after_postpone_in_ms", 10000);
-
-  private static final ExecutorService METRICS_GRABBER_EXECUTOR = Executors.newFixedThreadPool(10);
-  private static final long METRICS_POLL_INTERVAL_MS = TimeUnit.SECONDS.toMillis(5);
-  private static final long METRICS_MAX_WAIT_MS = TimeUnit.MINUTES.toMillis(2);
 
   private final AppContext context;
   private final UUID segmentId;
@@ -110,7 +90,6 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
   private final AtomicBoolean completeNotified = new AtomicBoolean(false);
   private final ClusterFacade clusterFacade;
   private final Set<String> tablesToRepair;
-  private final AtomicBoolean releasedSegmentRunner = new AtomicBoolean(false);
 
 
   private SegmentRunner(
@@ -176,11 +155,12 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
   @Override
   public void run() {
     boolean ran = false;
-    if (takeLead()) {
+    RepairSegment segment = context.storage.getRepairSegment(repairRunner.getRepairRunId(), segmentId).get();
+    if (takeLead(segment)) {
       try {
         ran = runRepair();
       } finally {
-        releaseLead();
+        releaseLead(segment);
       }
     }
     if (ran) {
@@ -194,7 +174,22 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
   }
 
   static void postponeSegment(AppContext context, RepairSegment segment) {
-    postpone(context, segment, context.storage.getRepairUnit(segment.getRepairUnitId()));
+    LOG.info("Reset segment {}", segment.getId());
+    RepairUnit unit = context.storage.getRepairUnit(segment.getRepairUnitId());
+    RepairSegment postponed
+        = segment
+          .reset()
+          // set coordinator host to null only for full repairs
+          .withCoordinatorHost(unit.getIncrementalRepair() ? segment.getCoordinatorHost() : null)
+          .withFailCount(segment.getFailCount() + 1)
+          .withId(segment.getId())
+          .build();
+
+    if ( context.storage instanceof IDistributedStorage ) {
+      ((IDistributedStorage)context.storage).updateRepairSegmentUnsafe(postponed);
+    } else {
+      context.storage.updateRepairSegment(postponed);
+    }
   }
 
   private static void postpone(AppContext context, RepairSegment segment, RepairUnit repairUnit) {
@@ -265,20 +260,12 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
     Thread.currentThread().setName(clusterName + ":" + segment.getRunId() + ":" + segmentId);
 
     try (Timer.Context cxt = context.metricRegistry.timer(metricNameForRunRepair(segment)).time()) {
-      Cluster cluster = context.storage.getCluster(clusterName);
-      JmxProxy coordinator = clusterFacade.connect(cluster, potentialCoordinators);
-
       if (SEGMENT_RUNNERS.containsKey(segmentId)) {
         LOG.error("SegmentRunner already exists for segment with ID: {}", segmentId);
         throw new ReaperException("SegmentRunner already exists for segment with ID: " + segmentId);
       }
 
-      String keyspace = repairUnit.getKeyspaceName();
-      boolean fullRepair = !repairUnit.getIncrementalRepair();
-
-      LazyInitializer<Set<String>> busyHosts = new BusyHostsInitializer(cluster);
-
-      if (!canRepair(segment, keyspace, coordinator, cluster, busyHosts)) {
+      if (RepairSegment.State.NOT_STARTED != segment.getState()) {
         LOG.info(
             "Cannot run segment {} for repair {} at the moment. Will try again later", segmentId, segment.getRunId());
 
@@ -288,41 +275,22 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         return false;
       }
 
+      Cluster cluster = context.storage.getCluster(clusterName);
+      JmxProxy coordinator = clusterFacade.connect(cluster, potentialCoordinators);
+      String keyspace = repairUnit.getKeyspaceName();
+      boolean fullRepair = !repairUnit.getIncrementalRepair();
+
       try (Timer.Context cxt1 = context.metricRegistry.timer(metricNameForRepairing(segment)).time()) {
-        boolean segmentsLocked = false;
         try {
           LOG.debug("Enter synchronized section with segment ID {}", segmentId);
           synchronized (condition) {
-            if (!(segmentsLocked = lockSegmentRunners())) {
-              // XXX – not expected to happen, STARTED run state should be "good" (opportunistic) enough
-              LOG.warn(
-                  "Cannot run segment {} as another Reaper holds the lock on repair run {}. Will try again later",
-                  segmentId,
-                  segment.getRunId());
-
-              return false;
-            }
-
-            // ~double-checking idiom, only applies to non-incremental and distributed storage
-            if (!repairUnit.getIncrementalRepair() && context.storage instanceof IDistributedStorage) {
-              Map<String, String> dcByNode = segment.getReplicas();
-              if (isRepairRunningOnNodes(segment, dcByNode, keyspace, cluster)) {
-                LOG.warn(
-                    "Post-lock, cannot run segment {} for repair {} at the moment. Will try again later",
-                    segmentId,
-                    segment.getRunId());
-
-                try {
-                  Thread.sleep(SLEEP_TIME_AFTER_POSTPONE_IN_MS);
-                } catch (InterruptedException ignore) { }
-                return false;
-              }
-            }
-
+            String coordinatorHost = context.config.getDatacenterAvailability() == DatacenterAvailability.SIDECAR
+                ? context.getLocalNodeAddress()
+                : coordinator.getHost();
             segment = segment
                     .with()
                     .withState(RepairSegment.State.STARTED)
-                    .withCoordinatorHost(coordinator.getHost())
+                    .withCoordinatorHost(coordinatorHost)
                     .withStartTime(DateTime.now())
                     .withId(segmentId)
                     .build();
@@ -342,8 +310,8 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
                     repairUnit.getRepairThreadCount());
 
             if (0 != repairNo) {
-              releaseSegmentRunners();
-              segmentsLocked = false;
+              //releaseSegmentRunners();
+              //segmentsLocked = false;
               processTriggeredSegment(segment, coordinator, repairNo);
             } else {
               LOG.info("Nothing to repair for segment {} in keyspace {}", segmentId, keyspace);
@@ -361,9 +329,6 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
           }
         } finally {
           LOG.debug("Exiting synchronized section with segment ID {}", segmentId);
-          if (segmentsLocked) {
-            releaseSegmentRunners();
-          }
         }
       }
     } catch (RuntimeException | ReaperException e) {
@@ -406,7 +371,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         if (isDoneOrFailed) {
           break;
         }
-        renewLead();
+        renewLead(segment);
       }
     } catch (InterruptedException e) {
       LOG.warn("Repair command {} on segment {} interrupted", this.repairNo, segmentId, e);
@@ -450,7 +415,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
           abort(resultingSegment, coordinator);
       }
       // Repair is still running, we'll renew lead on the segment when using Cassandra as storage backend
-      renewLead();
+      renewLead(segment);
     }
   }
 
@@ -488,266 +453,6 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         cleanHostName,
         clusterName.replaceAll("[^A-Za-z0-9]", ""),
         repairUnit.getKeyspaceName().replaceAll("[^A-Za-z0-9]", ""));
-  }
-
-  boolean canRepair(
-      RepairSegment segment,
-      String keyspace,
-      JmxProxy coordinator,
-      Cluster cluster,
-      LazyInitializer<Set<String>> busyHosts) {
-
-    if (RepairSegment.State.NOT_STARTED == segment.getState()) {
-      try {
-        Map<String, String> dcByNode = segment.getReplicas();
-
-        return !isRepairRunningOnNodes(segment, dcByNode, keyspace, cluster)
-            && nodesReadyForNewRepair(coordinator, segment, dcByNode, busyHosts);
-
-      } catch (RuntimeException e) {
-        LOG.warn("SegmentRunner couldn't get token ranges from coordinator: ", e);
-        String msg = "SegmentRunner couldn't get token ranges from coordinator";
-        repairRunner.updateLastEvent(msg);
-      }
-    }
-    return false;
-  }
-
-  static boolean okToRepairSegment(
-      boolean allHostsChecked,
-      boolean allLocalDcHostsChecked,
-      DatacenterAvailability dcAvailability) {
-
-    return allHostsChecked || (allLocalDcHostsChecked && DatacenterAvailability.LOCAL == dcAvailability);
-  }
-
-  private void handlePotentialStuckRepairs(LazyInitializer<Set<String>> busyHosts, String hostName)
-      throws ConcurrentException {
-
-    if (!busyHosts.get().contains(hostName) && context.storage instanceof IDistributedStorage) {
-      try {
-        JmxProxy hostProxy = clusterFacade.connect(context.storage.getCluster(clusterName), Arrays.asList(hostName));
-
-        // We double check that repair is still running there before actually cancelling repairs
-        if (hostProxy.isRepairRunning()) {
-          LOG.warn(
-              "A host ({}) reported that it is involved in a repair, but there is no record "
-                  + "of any ongoing repair involving the host. Sending command to abort all repairs "
-                  + "on the host.",
-              hostName);
-          hostProxy.cancelAllRepairs();
-        }
-      } catch (ReaperException | RuntimeException | JMException e) {
-        LOG.debug("failed to cancel repairs on host {}", hostName, e);
-      }
-    }
-  }
-
-  Pair<String, Callable<Optional<NodeMetrics>>> getNodeMetrics(String node, String localDc, String nodeDc) {
-
-    return Pair.of(node, () -> {
-      LOG.debug("getMetricsForHost {} / {} / {}", node, localDc, nodeDc);
-
-      if (clusterFacade.nodeIsAccessibleThroughJmx(nodeDc, node)) {
-        try {
-          JmxProxy nodeProxy = clusterFacade.connect(context.storage.getCluster(clusterName), Arrays.asList(node));
-
-          NodeMetrics metrics = NodeMetrics.builder()
-                  .withNode(node)
-                  .withDatacenter(nodeDc)
-                  .withCluster(nodeProxy.getClusterName())
-                  .withPendingCompactions(nodeProxy.getPendingCompactions())
-                  .withHasRepairRunning(nodeProxy.isRepairRunning())
-                  .withActiveAnticompactions(0) // for future use
-                  .build();
-
-          return Optional.of(metrics);
-        } catch (RuntimeException | ReaperException e) {
-          LOG.debug("failed to query metrics for host {}, trying to get metrics from storage...", node, e);
-        }
-      }
-
-      return !context.config.getDatacenterAvailability().isInCollocatedMode()
-          ? Optional.empty()
-          : maybeGetRemoteNodeMetrics(node, nodeDc);
-    });
-  }
-
-  private Optional<NodeMetrics> maybeGetRemoteNodeMetrics(String node, String nodeDc) {
-    Preconditions.checkState(context.storage instanceof IDistributedStorage);
-
-    return context.isDistributed.get() || context.config.getEnforcedLocalNode().isPresent()
-        ? getRemoteNodeMetrics(node, nodeDc)
-        : Optional.empty();
-  }
-
-  private Optional<NodeMetrics> getRemoteNodeMetrics(String node, String nodeDc) {
-    Preconditions.checkState(context.storage instanceof IDistributedStorage);
-    Preconditions.checkState(context.config.getDatacenterAvailability().isInCollocatedMode());
-    Preconditions.checkState(context.isDistributed.get() || context.config.getEnforcedLocalNode().isPresent());
-
-    IDistributedStorage storage = ((IDistributedStorage) context.storage);
-    Optional<NodeMetrics> result = storage.getNodeMetrics(repairRunner.getRepairRunId(), node);
-    if (!result.isPresent() || result.get().isRequested()) {
-      // Sending a request for metrics to the other reaper instances through the Cassandra backend
-      if (!result.isPresent()) {
-        storeNodeMetrics(
-            NodeMetrics.builder()
-                .withCluster(clusterName)
-                .withDatacenter(nodeDc)
-                .withNode(node)
-                .withRequested(true)
-                .build());
-      }
-
-      long start = System.currentTimeMillis();
-
-      while ( (!result.isPresent() || result.get().isRequested())
-          && start + METRICS_MAX_WAIT_MS > System.currentTimeMillis()) {
-
-        try {
-          Thread.sleep(METRICS_POLL_INTERVAL_MS);
-        } catch (InterruptedException ignore) { }
-        LOG.info("Trying to get metrics from remote DCs for {} in {} of {}", node, nodeDc, clusterName);
-        result = storage.getNodeMetrics(repairRunner.getRepairRunId(), node);
-        if (result.isPresent() && !result.get().isRequested()) {
-          // delete the metrics to force other instances to get a refreshed value
-          storage.deleteNodeMetrics(repairRunner.getRepairRunId(), node);
-        }
-      }
-    }
-    return result;
-  }
-
-  private boolean nodesReadyForNewRepair(
-      JmxProxy coordinator,
-      RepairSegment segment,
-      Map<String, String> dcByNode,
-      LazyInitializer<Set<String>> busyHosts) {
-
-    Collection<String> nodes = getNodesInvolvedInSegment(dcByNode);
-    String dc = EndpointSnitchInfoProxy.create(coordinator).getDataCenter();
-    boolean requireAllHostMetrics = DatacenterAvailability.LOCAL != context.config.getDatacenterAvailability();
-    boolean allLocalDcHostsChecked = true;
-    boolean allHostsChecked = true;
-    Set<String> unreachableNodes = Sets.newHashSet();
-
-    List<Pair<String, Future<Optional<NodeMetrics>>>> nodeMetricsTasks = nodes.stream()
-        .map(node -> getNodeMetrics(node, dc != null ? dc : "", dcByNode.get(node) != null ? dcByNode.get(node) : ""))
-        .map(pair -> Pair.of(pair.getLeft(), METRICS_GRABBER_EXECUTOR.submit(pair.getRight())))
-        .collect(Collectors.toList());
-
-    for (Pair<String, Future<Optional<NodeMetrics>>> pair : nodeMetricsTasks) {
-      try {
-        Optional<NodeMetrics> result = pair.getRight().get();
-        if (result.isPresent() && !result.get().isRequested()) {
-          NodeMetrics metrics = result.get();
-          int pendingCompactions = metrics.getPendingCompactions();
-          if (pendingCompactions > context.config.getMaxPendingCompactions()) {
-            String msg = String.format(
-                "postponed repair segment %s because of too many pending compactions (%s > %s) on host %s",
-                segmentId, pendingCompactions, context.config.getMaxPendingCompactions(), metrics.getNode());
-
-            repairRunner.updateLastEvent(msg);
-            return false;
-          }
-          if (metrics.hasRepairRunning()) {
-            String msg = String.format(
-                "postponed repair segment %s because one of the hosts (%s) was already involved in a repair",
-                segmentId, metrics.getNode());
-
-            repairRunner.updateLastEvent(msg);
-            handlePotentialStuckRepairs(busyHosts, metrics.getNode());
-            return false;
-          }
-          continue;
-        }
-      } catch (InterruptedException | ExecutionException | ConcurrentException e) {
-        LOG.info("Failed grabbing metrics from {}", pair.getLeft(), e);
-      }
-      allHostsChecked = false;
-      if (dcByNode.get(pair.getLeft()).equals(dc)) {
-        allLocalDcHostsChecked = false;
-      }
-      if (requireAllHostMetrics || dcByNode.get(pair.getLeft()).equals(dc)) {
-        unreachableNodes.add(pair.getLeft());
-      }
-    }
-
-    if (okToRepairSegment(allHostsChecked, allLocalDcHostsChecked, context.config.getDatacenterAvailability())) {
-      LOG.info("Ok to repair segment '{}' on repair run with id '{}'", segment.getId(), segment.getRunId());
-      return true;
-    } else {
-      String msg = String.format(
-          "Postponed repair segment %s on repair run with id %s because we couldn't get %shosts metrics on %s",
-          segment.getId(),
-          segment.getRunId(),
-          (requireAllHostMetrics ? "" : "datacenter "),
-          StringUtils.join(unreachableNodes, ' '));
-
-      repairRunner.updateLastEvent(msg);
-      return false;
-    }
-  }
-
-  private boolean isRepairRunningOnNodes(
-      RepairSegment segment,
-      Map<String, String> dcByNode,
-      String keyspace,
-      Cluster cluster) {
-
-    Collection<String> nodes = repairUnit.getIncrementalRepair()
-        ? Collections.EMPTY_SET
-        : getNodesInvolvedInSegment(dcByNode);
-
-    Collection<RepairSegment> segments;
-    {
-      UUID repairRunId = segment.getRunId();
-      // this only checks whether any segments from this repair are running,
-      //   so `nodesReadyForNewRepair(..)` should always also be called with this method
-      segments = Sets.newHashSet(context.storage.getSegmentsWithState(repairRunId, RepairSegment.State.RUNNING));
-      segments.addAll(context.storage.getSegmentsWithState(repairRunId, RepairSegment.State.STARTED));
-    }
-
-    for (RepairSegment seg : segments) {
-      // incremental repairs only one segment is allowed at once (one segment == the full primary range of one node)
-      if (repairUnit.getIncrementalRepair() || hasReplicaInNodes(cluster, keyspace, seg, nodes)) {
-
-        String msg = String.format(
-            "postponed repair segment %s because segment %s is running on host %s",
-            segment.getId(), seg.getId(), seg.getCoordinatorHost());
-
-        repairRunner.updateLastEvent(msg);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private Collection<String> getNodesInvolvedInSegment(Map<String, String> dcByNode) {
-    Set<String> datacenters = repairUnit.getDatacenters();
-
-    return dcByNode.keySet().stream()
-        .filter(node -> datacenters.isEmpty() || datacenters.contains(dcByNode.get(node)))
-        .collect(Collectors.toList());
-  }
-
-  private boolean hasReplicaInNodes(
-      Cluster cluster,
-      String keyspace,
-      RepairSegment segment,
-      Collection<String> nodes) {
-
-    return !Collections.disjoint(
-        clusterFacade.tokenRangeToEndpoint(cluster, keyspace, segment.getTokenRange()),
-        nodes);
-  }
-
-  private void storeNodeMetrics(NodeMetrics metrics) {
-    assert context.storage instanceof IDistributedStorage;
-    if (DatacenterAvailability.ALL != context.config.getDatacenterAvailability()) {
-      ((IDistributedStorage) context.storage).storeNodeMetrics(repairRunner.getRepairRunId(), metrics);
-    }
   }
 
   /**
@@ -799,6 +504,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
             progress,
             jmxProxy);
       }
+
       // New repair API – Cassandra-2.2 onwards
       if (progress.isPresent()) {
         failOutsideSynchronizedBlock = handleJmxNotificationForCassandra22(
@@ -811,7 +517,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
     }
 
     if (failOutsideSynchronizedBlock) {
-      if (takeLead() || renewLead()) {
+      if (takeLead(segment) || renewLead(segment)) {
         try {
           postponeCurrentSegment();
           tryClearSnapshots(message);
@@ -819,7 +525,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
           // if someone else does hold the lease, ie renewLead(..) was true,
           // then their writes to repair_run table and any call to releaseLead(..) will throw an exception
           try {
-            releaseLead();
+            releaseLead(segment);
           } catch (AssertionError ignore) { }
         }
       }
@@ -839,7 +545,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
           // avoid changing state to RUNNING if later notifications have already arrived
           if (!successOrFailedNotified.get()
               && RepairSegment.State.STARTED == currentSegment.getState()
-              && renewLead()) {
+              && renewLead(currentSegment)) {
 
             context.storage.updateRepairSegment(
                 currentSegment
@@ -852,7 +558,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
             break;
           }
         } catch (AssertionError er) {
-          // ignore. segment repair has since timed out.
+          LOG.debug("Failed processing START notification for segment {}", segmentId, er);
         }
         segmentFailed.set(true);
         break;
@@ -862,6 +568,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
         Preconditions.checkState(
             !successOrFailedNotified.get(),
             "illegal multiple 'SUCCESS' and 'FAILURE', %s:%s", repairRunner.getRepairRunId(), segmentId);
+        successOrFailedNotified.set(true);
 
         try {
           if (segmentFailed.get()) {
@@ -869,8 +576,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
                 "Got SUCCESS for segment with id '{}' and repair number '{}', but it had already timed out",
                 segmentId,
                 repairNumber);
-          } else if (renewLead()) {
-            successOrFailedNotified.set(true);
+          } else if (renewLead(currentSegment)) {
             LOG.debug(
                 "repair session succeeded for segment with id '{}' and repair number '{}'",
                 segmentId,
@@ -894,7 +600,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
             break;
           }
         } catch (AssertionError er) {
-          // ignore. segment repair has since timed out.
+          LOG.debug("Failed processing SUCCESS notification for segment {}", segmentId, er);
         }
         segmentFailed.set(true);
         break;
@@ -966,7 +672,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
           // avoid changing state to RUNNING if later notifications have already arrived
           if (!successOrFailedNotified.get()
               && RepairSegment.State.STARTED == currentSegment.getState()
-              && renewLead()) {
+              && renewLead(currentSegment)) {
 
             context.storage.updateRepairSegment(
                 currentSegment
@@ -992,6 +698,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
               "illegal multiple 'SUCCESS' and 'FAILURE', %s:%s",
               repairRunner.getRepairRunId(),
               segmentId);
+          successOrFailedNotified.set(true);
 
           try {
             if (segmentFailed.get()) {
@@ -999,8 +706,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
                   "Got SESSION_SUCCESS for segment with id '{}' and repair number '{}', but it had already timed out",
                   segmentId,
                   repairNumber);
-            } else if (renewLead()) {
-              successOrFailedNotified.set(true);
+            } else if (renewLead(currentSegment)) {
               LOG.debug(
                   "repair session succeeded for segment with id '{}' and repair number '{}'",
                   segmentId,
@@ -1148,49 +854,21 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
     }
   }
 
-  private boolean lockSegmentRunners() {
-    if (this.repairUnit.getIncrementalRepair() || !context.config.getDatacenterAvailability().isInCollocatedMode()) {
-      return true;
-    }
-    UUID lockId = com.datastax.driver.core.utils.UUIDs.startOf(repairUnit.getClusterName().hashCode());
-    try (Timer.Context cx
-        = context.metricRegistry.timer(MetricRegistry.name(SegmentRunner.class, "lockSegmentRunners")).time()) {
-
-      boolean result = context.storage instanceof IDistributedStorage
-          ? ((IDistributedStorage) context.storage).takeLead(
-              lockId,
-              LOCK_DURATION)
-          : true;
-
-      if (!result) {
-        context.metricRegistry.counter(MetricRegistry.name(SegmentRunner.class, "lockSegmentRunners", "failed")).inc();
-      }
-      return result;
-    }
-  }
-
-  private void releaseSegmentRunners() {
-    if (!this.repairUnit.getIncrementalRepair()
-        && releasedSegmentRunner.compareAndSet(false, true)
-        && context.config.getDatacenterAvailability().isInCollocatedMode()) {
-      UUID uuid = com.datastax.driver.core.utils.UUIDs.startOf(repairUnit.getClusterName().hashCode());
-      try (Timer.Context cx
-          = context.metricRegistry.timer(MetricRegistry.name(SegmentRunner.class, "releaseSegmentRunners")).time()) {
-        if (context.storage instanceof IDistributedStorage) {
-          ((IDistributedStorage) context.storage).releaseLead(uuid);
-        }
-      }
-    }
-  }
-
-  private boolean takeLead() {
+  private boolean takeLead(RepairSegment segment) {
     try (Timer.Context cx
         = context.metricRegistry.timer(MetricRegistry.name(SegmentRunner.class, "takeLead")).time()) {
 
-      boolean result = context.storage instanceof IDistributedStorage
-          ? ((IDistributedStorage) context.storage).takeLead(leaderElectionId)
-          : true;
-
+      boolean result = false;
+      if (repairUnit.getIncrementalRepair()) {
+        result = context.storage instanceof IDistributedStorage
+            ? ((IDistributedStorage) context.storage).takeLead(leaderElectionId)
+            : true;
+      } else {
+        result = context.storage instanceof IDistributedStorage
+            ? ((IDistributedStorage) context.storage).lockRunningRepairsForNodes(this.repairRunner.getRepairRunId(),
+                segment.getId(), segment.getReplicas().keySet())
+            : true;
+      }
       if (!result) {
         context.metricRegistry.counter(MetricRegistry.name(SegmentRunner.class, "takeLead", "failed")).inc();
       }
@@ -1198,26 +876,44 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
     }
   }
 
-  private boolean renewLead() {
+  private boolean renewLead(RepairSegment segment) {
     try (Timer.Context cx
         = context.metricRegistry.timer(MetricRegistry.name(SegmentRunner.class, "renewLead")).time()) {
 
-      boolean result = context.storage instanceof IDistributedStorage
-          ? ((IDistributedStorage) context.storage).renewLead(leaderElectionId)
-          : true;
+      if (repairUnit.getIncrementalRepair()) {
+        boolean result = context.storage instanceof IDistributedStorage
+            ? ((IDistributedStorage) context.storage).renewLead(leaderElectionId)
+            : true;
 
-      if (!result) {
-        context.metricRegistry.counter(MetricRegistry.name(SegmentRunner.class, "renewLead", "failed")).inc();
+        if (!result) {
+          context.metricRegistry.counter(MetricRegistry.name(SegmentRunner.class, "renewLead", "failed")).inc();
+        }
+        return result;
+      } else {
+        boolean resultLock2 = context.storage instanceof IDistributedStorage
+            ? ((IDistributedStorage) context.storage).renewRunningRepairsForNodes(this.repairRunner.getRepairRunId(),
+                segment.getId(), segment.getReplicas().keySet())
+            : true;
+        if (!resultLock2) {
+          context.metricRegistry.counter(MetricRegistry.name(SegmentRunner.class, "renewLead", "failed")).inc();
+          releaseLead(segment);
+        }
+
+        return resultLock2;
       }
-      return result;
     }
   }
 
-  private void releaseLead() {
+  private void releaseLead(RepairSegment segment) {
     try (Timer.Context cx
         = context.metricRegistry.timer(MetricRegistry.name(SegmentRunner.class, "releaseLead")).time()) {
       if (context.storage instanceof IDistributedStorage) {
-        ((IDistributedStorage) context.storage).releaseLead(leaderElectionId);
+        if (repairUnit.getIncrementalRepair()) {
+          ((IDistributedStorage) context.storage).releaseLead(leaderElectionId);
+        } else {
+          ((IDistributedStorage) context.storage).releaseRunningRepairsForNodes(this.repairRunner.getRepairRunId(),
+              segment.getId(), segment.getReplicas().keySet());
+        }
       }
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -25,6 +25,7 @@ import io.cassandrareaper.service.RingRange;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 
@@ -45,6 +46,23 @@ public interface IDistributedStorage {
 
   void releaseLead(UUID leaderId);
 
+  boolean lockRunningRepairsForNodes(
+      UUID repairId,
+      UUID segmentId,
+      Set<String> replicas);
+
+  boolean renewRunningRepairsForNodes(
+      UUID repairId,
+      UUID segmentId,
+      Set<String> replicas);
+
+  boolean releaseRunningRepairsForNodes(
+      UUID repairId,
+      UUID segmentId,
+      Set<String> replicas);
+
+  Set<UUID> getLockedSegmentsForRun(UUID runId);
+
   int countRunningReapers();
 
   void saveHeartbeat();
@@ -61,12 +79,11 @@ public interface IDistributedStorage {
    * Gets the next free segment from the backend that is both within the parallel range and the local node ranges.
    *
    * @param runId id of the repair run
-   * @param parallelRange list of ranges that can run in parallel
    * @param ranges list of ranges we're looking a segment for
    * @return an optional repair segment to process
    */
-  Optional<RepairSegment> getNextFreeSegmentForRanges(
-      UUID runId, Optional<RingRange> parallelRange, List<RingRange> ranges);
+  List<RepairSegment> getNextFreeSegmentsForRanges(
+      UUID runId, List<RingRange> ranges);
 
   List<GenericMetric> getMetrics(
       String clusterName,
@@ -95,4 +112,12 @@ public interface IDistributedStorage {
    * Purges old node operation info from the database (no-op for databases w/ TTL)
    */
   void purgeNodeOperations();
+
+  /**
+   * Update the repair segment without a lock as it couldn't be grabbed.
+   *
+   * @param newRepairSegment repair segment to update
+   * @return true if the segment was updated, false otherwise
+   */
+  boolean updateRepairSegmentUnsafe(RepairSegment newRepairSegment);
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -27,9 +27,9 @@ import io.cassandrareaper.core.Snapshot;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.service.RepairParameters;
-import io.cassandrareaper.service.RingRange;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.SortedSet;
 import java.util.UUID;
@@ -100,7 +100,7 @@ public interface IStorage {
    *      handled. When start = end, consider that as a range that covers the whole ring.
    * @return a segment enclosed by the range with state NOT_STARTED, or nothing.
    */
-  Optional<RepairSegment> getNextFreeSegmentInRange(UUID runId, Optional<RingRange> range);
+  List<RepairSegment> getNextFreeSegments(UUID runId);
 
   Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState);
 

--- a/src/server/src/main/resources/db/cassandra/027_concurrent_repairs_part2.cql
+++ b/src/server/src/main/resources/db/cassandra/027_concurrent_repairs_part2.cql
@@ -1,0 +1,28 @@
+--
+--  Copyright 2020-2020 Datastax inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Add a table to control the number of concurrent repairs
+
+CREATE TABLE running_repairs(
+     repair_id uuid,
+     node text,
+     reaper_instance_host text,
+     reaper_instance_id uuid,
+     segment_id uuid,
+     PRIMARY KEY(repair_id, node))
+WITH CLUSTERING ORDER BY (node ASC)
+ AND default_time_to_live = 300
+ AND gc_grace_seconds = 300
+ AND compaction = {'class':'LeveledCompactionStrategy'};

--- a/src/server/src/main/resources/db/h2/V20_0_0__concurrent_repairs.sql
+++ b/src/server/src/main/resources/db/h2/V20_0_0__concurrent_repairs.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS running_repairs (
+  repair_id BIGINT,
+  node VARCHAR,
+  reaper_instance_host VARCHAR,
+  reaper_instance_id BIGINT,
+  segment_id INT,
+  last_heartbeat TIMESTAMP WITH TIME ZONE,
+  PRIMARY KEY(repair_id, node)
+); 

--- a/src/server/src/main/resources/db/postgres/V20_0_0__concurrent_repairs.sql
+++ b/src/server/src/main/resources/db/postgres/V20_0_0__concurrent_repairs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "running_repairs" (
+  "repair_id" BIGINT,
+  "node" TEXT,
+  "reaper_instance_host" TEXT,
+  "reaper_instance_id" BIGINT,
+  "segment_id" BIGINT,
+  "last_heartbeat" TIMESTAMP WITH TIME ZONE,
+  PRIMARY KEY("repair_id", "node")
+); 
+

--- a/src/server/src/test/java/io/cassandrareaper/jmx/JmxProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/JmxProxyTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import javax.management.MBeanServerConnection;
 
 import com.google.common.base.Preconditions;
+import org.apache.cassandra.db.compaction.CompactionManagerMBean;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
 import org.apache.cassandra.service.StorageServiceMBean;
 import org.apache.cassandra.streaming.StreamManagerMBean;
@@ -59,6 +60,11 @@ public final class JmxProxyTest {
   public static void mockGetEndpointSnitchInfoMBean(JmxProxy proxy, EndpointSnitchInfoMBean endpointSnitchInfoMBean) {
     Preconditions.checkArgument(proxy instanceof JmxProxyImpl, "only JmxProxyImpl is supported");
     Mockito.when(((JmxProxyImpl)proxy).getEndpointSnitchInfoMBean()).thenReturn(endpointSnitchInfoMBean);
+  }
+
+  public static void mockGetCompactionManagerMBean(JmxProxy proxy, CompactionManagerMBean compactionManagerMBean) {
+    Preconditions.checkArgument(proxy instanceof JmxProxyImpl, "only JmxProxyImpl is supported");
+    Mockito.when(((JmxProxyImpl)proxy).getCompactionManagerMBean()).thenReturn(compactionManagerMBean);
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -121,7 +121,8 @@ public final class RepairRunResourceTest {
         REPAIR_TIMEOUT_S,
         TimeUnit.SECONDS,
         RETRY_DELAY_S,
-        TimeUnit.SECONDS);
+        TimeUnit.SECONDS,
+        1);
 
     context.storage = new MemoryStorage();
 

--- a/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
@@ -154,7 +154,8 @@ public final class HeartTest {
         REPAIR_TIMEOUT_S,
         TimeUnit.SECONDS,
         RETRY_DELAY_S,
-        TimeUnit.SECONDS);
+        TimeUnit.SECONDS,
+        1);
 
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
@@ -185,7 +186,8 @@ public final class HeartTest {
         REPAIR_TIMEOUT_S,
         TimeUnit.SECONDS,
         RETRY_DELAY_S,
-        TimeUnit.SECONDS);
+        TimeUnit.SECONDS,
+        1);
 
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
@@ -224,7 +226,8 @@ public final class HeartTest {
         REPAIR_TIMEOUT_S,
         TimeUnit.SECONDS,
         RETRY_DELAY_S,
-        TimeUnit.SECONDS);
+        TimeUnit.SECONDS,
+        1);
 
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
@@ -276,7 +279,8 @@ public final class HeartTest {
         REPAIR_TIMEOUT_S,
         TimeUnit.SECONDS,
         RETRY_DELAY_S,
-        TimeUnit.SECONDS);
+        TimeUnit.SECONDS,
+        1);
 
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
@@ -334,7 +338,8 @@ public final class HeartTest {
         REPAIR_TIMEOUT_S,
         TimeUnit.SECONDS,
         RETRY_DELAY_S,
-        TimeUnit.SECONDS);
+        TimeUnit.SECONDS,
+        1);
 
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -32,7 +32,9 @@ import io.cassandrareaper.storage.IStorage;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -86,7 +88,8 @@ public final class RepairManagerTest {
         500,
         TimeUnit.MILLISECONDS,
         1,
-        TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS,
+        1);
 
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
@@ -120,7 +123,8 @@ public final class RepairManagerTest {
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
     when(context.storage.getSegmentsWithState(any(), any())).thenReturn(Arrays.asList(segment));
-    when(((IDistributedStorage) context.storage).getLeaders()).thenReturn(Collections.emptyList());
+    when(((IDistributedStorage) context.storage).getLockedSegmentsForRun(any())).thenReturn(Collections.emptySet());
+    when(context.storage.getRepairUnit(any(UUID.class))).thenReturn(cf);
 
     context.repairManager.resumeRunningRepairRuns();
 
@@ -161,7 +165,8 @@ public final class RepairManagerTest {
         500,
         TimeUnit.MILLISECONDS,
         1,
-        TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS,
+        1);
 
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
@@ -197,7 +202,9 @@ public final class RepairManagerTest {
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
     when(context.storage.getSegmentsWithState(any(), any())).thenReturn(Arrays.asList(segment));
-    when(((IDistributedStorage) context.storage).getLeaders()).thenReturn(Arrays.asList(segment.getId()));
+    when(context.storage.getRepairUnit(any(UUID.class))).thenReturn(cf);
+    when(((IDistributedStorage) context.storage).getLockedSegmentsForRun(any())).thenReturn(
+        new HashSet<UUID>(Arrays.asList(segment.getId())));
 
     context.repairManager.resumeRunningRepairRuns();
 
@@ -238,7 +245,8 @@ public final class RepairManagerTest {
         500,
         TimeUnit.MILLISECONDS,
         1,
-        TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS,
+        1);
 
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
@@ -266,12 +274,14 @@ public final class RepairManagerTest {
             .withId(UUIDs.timeBased())
             .build();
 
+
     context.repairManager.repairRunners.put(run.getId(), mock(RepairRunner.class));
     Mockito.doNothing().when(context.repairManager).abortSegments(any(), any());
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
     when(context.storage.getSegmentsWithState(any(), any())).thenReturn(Arrays.asList(segment));
+    when(context.storage.getRepairUnit(any(UUID.class))).thenReturn(cf);
 
     context.repairManager.resumeRunningRepairRuns();
 
@@ -312,7 +322,8 @@ public final class RepairManagerTest {
         500,
         TimeUnit.MILLISECONDS,
         1,
-        TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS,
+        1);
 
     repairManager = Mockito.spy(repairManager);
     context.repairManager = repairManager;
@@ -345,6 +356,7 @@ public final class RepairManagerTest {
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.RUNNING)).thenReturn(Arrays.asList(run));
     when(context.storage.getRepairRunsWithState(RepairRun.RunState.PAUSED)).thenReturn(Collections.emptyList());
     when(context.storage.getSegmentsWithState(any(), any())).thenReturn(Arrays.asList(segment));
+    when(context.storage.getRepairUnit(any(UUID.class))).thenReturn(cf);
 
     context.repairManager.resumeRunningRepairRuns();
 
@@ -369,7 +381,8 @@ public final class RepairManagerTest {
         500,
         TimeUnit.MILLISECONDS,
         1,
-        TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS,
+        1);
 
     final String ksName = "reaper";
     final Set<String> cfNames = Sets.newHashSet("reaper");

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -22,6 +22,7 @@ import io.cassandrareaper.ReaperApplicationConfiguration;
 import io.cassandrareaper.ReaperApplicationConfiguration.DatacenterAvailability;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
+import io.cassandrareaper.core.CompactionStats;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSegment;
@@ -33,11 +34,15 @@ import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.jmx.JmxProxyTest;
 import io.cassandrareaper.jmx.RepairStatusHandler;
+import io.cassandrareaper.storage.CassandraStorage;
+import io.cassandrareaper.storage.IDistributedStorage;
 import io.cassandrareaper.storage.IStorage;
 import io.cassandrareaper.storage.MemoryStorage;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.net.UnknownHostException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -45,12 +50,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.collect.Collections2;
+import javax.management.JMException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ReflectionException;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -60,6 +69,9 @@ import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.progress.ProgressEventType;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Duration;
+import org.awaitility.core.ConditionTimeoutException;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.junit.Before;
@@ -68,20 +80,26 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public final class RepairRunnerTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(RepairRunnerTest.class);
   private static final Set<String> TABLES = ImmutableSet.of("table1");
+  private static final Duration POLL_INTERVAL = Duration.TWO_SECONDS;
 
   private final Cluster cluster = Cluster.builder()
             .withName("test_" + RandomStringUtils.randomAlphabetic(12))
@@ -98,7 +116,7 @@ public final class RepairRunnerTest {
   }
 
   @Test
-  public void testHangingRepair() throws InterruptedException, ReaperException {
+  public void testHangingRepair() throws InterruptedException, ReaperException, JMException, IOException {
     final String KS_NAME = "reaper";
     final Set<String> CF_NAMES = Sets.newHashSet("reaper");
     final boolean INCREMENTAL_REPAIR = false;
@@ -109,7 +127,6 @@ public final class RepairRunnerTest {
     final double INTENSITY = 0.5f;
     final int REPAIR_THREAD_COUNT = 1;
     final IStorage storage = new MemoryStorage();
-
     storage.addCluster(cluster);
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -122,7 +139,6 @@ public final class RepairRunnerTest {
             .blacklistedTables(BLACKLISTED_TABLES)
             .repairThreadCount(REPAIR_THREAD_COUNT));
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
-
     RepairRun run = storage.addRepairRun(
             RepairRun.builder(cluster.getName(), cf.getId())
                 .intensity(INTENSITY)
@@ -137,7 +153,7 @@ public final class RepairRunnerTest {
                            .build(),
                     cf.getId())));
     final UUID RUN_ID = run.getId();
-    final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(), RepairSegment.State.NOT_STARTED);
     AppContext context = new AppContext();
     context.storage = storage;
@@ -217,6 +233,8 @@ public final class RepairRunnerTest {
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any())).thenReturn(Lists.newArrayList(NODES));
+    when(clusterFacade.listActiveCompactions(any())).thenReturn(CompactionStats.builder().withActiveCompactions(
+        Collections.emptyList()).withPendingCompactions(Optional.of(0)).build());
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
         .thenReturn((Map)ImmutableMap.of(Lists.newArrayList("0", "100"), Lists.newArrayList(NODES)));
 
@@ -227,7 +245,8 @@ public final class RepairRunnerTest {
             500,
             TimeUnit.MILLISECONDS,
             1,
-            TimeUnit.MILLISECONDS);
+            TimeUnit.MILLISECONDS,
+            1);
     context.jmxConnectionFactory = new JmxConnectionFactory(context, new NoopCrypotograph()) {
           @Override
           protected JmxProxy connectImpl(Node host) throws ReaperException {
@@ -239,7 +258,6 @@ public final class RepairRunnerTest {
       try {
         mutex.acquire();
         LOG.info("MUTEX ACQUIRED");
-        // TODO: refactor so that we can properly wait for the repair runner to finish rather than using this sleep()
         Thread.sleep(1000);
         return true;
       } catch (InterruptedException ex) {
@@ -250,7 +268,8 @@ public final class RepairRunnerTest {
   }
 
   @Test
-  public void testHangingRepairNewAPI() throws InterruptedException, ReaperException {
+  public void testHangingRepairNewAPI() throws InterruptedException, ReaperException, MalformedObjectNameException,
+      ReflectionException, IOException {
     final String KS_NAME = "reaper";
     final Set<String> CF_NAMES = Sets.newHashSet("reaper");
     final boolean INCREMENTAL_REPAIR = false;
@@ -261,9 +280,7 @@ public final class RepairRunnerTest {
     final double INTENSITY = 0.5f;
     final int REPAIR_THREAD_COUNT = 1;
     final IStorage storage = new MemoryStorage();
-
     storage.addCluster(cluster);
-
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -288,7 +305,7 @@ public final class RepairRunnerTest {
                            .build(),
                     cf.getId())));
     final UUID RUN_ID = run.getId();
-    final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(), RepairSegment.State.NOT_STARTED);
     AppContext context = new AppContext();
     context.storage = storage;
@@ -307,7 +324,6 @@ public final class RepairRunnerTest {
     }
     JmxProxyTest.mockGetEndpointSnitchInfoMBean(jmx, endpointSnitchInfoMBean);
     final AtomicInteger repairAttempts = new AtomicInteger(1);
-
     when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
@@ -369,6 +385,8 @@ public final class RepairRunnerTest {
         .thenReturn(Lists.newArrayList(NODES));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
         .thenReturn((Map)ImmutableMap.of(Lists.newArrayList("0", "100"), Lists.newArrayList(NODES)));
+    when(clusterFacade.listActiveCompactions(any())).thenReturn(CompactionStats.builder().withActiveCompactions(
+        Collections.emptyList()).withPendingCompactions(Optional.of(0)).build());
     context.repairManager
         = RepairManager.create(
             context,
@@ -377,7 +395,8 @@ public final class RepairRunnerTest {
             500,
             TimeUnit.MILLISECONDS,
             1,
-            TimeUnit.MILLISECONDS);
+            TimeUnit.MILLISECONDS,
+            1);
     context.jmxConnectionFactory = new JmxConnectionFactory(context, new NoopCrypotograph()) {
           @Override
           protected JmxProxy connectImpl(Node host) throws ReaperException {
@@ -400,7 +419,8 @@ public final class RepairRunnerTest {
   }
 
   @Test
-  public void testResumeRepair() throws InterruptedException, ReaperException {
+  public void testResumeRepair() throws InterruptedException, ReaperException, MalformedObjectNameException,
+      ReflectionException, IOException {
     final String KS_NAME = "reaper";
     final Set<String> CF_NAMES = Sets.newHashSet("reaper");
     final boolean INCREMENTAL_REPAIR = false;
@@ -433,34 +453,10 @@ public final class RepairRunnerTest {
             .blacklistedTables(BLACKLISTED_TABLES)
             .repairThreadCount(REPAIR_THREAD_COUNT))
         .getId();
-
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
-
-    RepairRun run = storage.addRepairRun(
-            RepairRun.builder(cluster.getName(), cf)
-                .intensity(INTENSITY)
-                .segmentCount(1)
-                .repairParallelism(RepairParallelism.PARALLEL)
-                .tables(TABLES),
-            Lists.newArrayList(
-                RepairSegment.builder(
-                        Segment.builder()
-                            .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
-                            .withReplicas(replicas)
-                            .build(),
-                        cf)
-                    .withState(RepairSegment.State.RUNNING)
-                    .withStartTime(DateTime.now())
-                    .withCoordinatorHost("reaper"),
-                RepairSegment.builder(
-                    Segment.builder()
-                        .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
-                        .withReplicas(replicas)
-                        .build(),
-                    cf)));
-
+    RepairRun run = generateRepairRunForPendingCompactions(INTENSITY, storage, cf);
     final UUID RUN_ID = run.getId();
-    final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(), RepairSegment.State.NOT_STARTED);
     final JmxProxy jmx = JmxProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
@@ -485,6 +481,8 @@ public final class RepairRunnerTest {
         .thenReturn((Map)ImmutableMap.of(
             Lists.newArrayList("0", "100"), Lists.newArrayList(NODES),
             Lists.newArrayList("100", "200"), Lists.newArrayList(NODES)));
+    when(clusterFacade.listActiveCompactions(any())).thenReturn(CompactionStats.builder().withActiveCompactions(
+        Collections.emptyList()).withPendingCompactions(Optional.of(0)).build());
 
     context.repairManager = RepairManager.create(
         context,
@@ -493,7 +491,8 @@ public final class RepairRunnerTest {
         500,
         TimeUnit.MILLISECONDS,
         1,
-        TimeUnit.MILLISECONDS);
+        TimeUnit.MILLISECONDS,
+        1);
     AtomicInteger repairNumberCounter = new AtomicInteger(1);
 
     when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
@@ -551,72 +550,167 @@ public final class RepairRunnerTest {
     assertEquals(RepairRun.RunState.DONE, storage.getRepairRun(RUN_ID).get().getRunState());
   }
 
-  @Test
-  public void getPossibleParallelRepairsTest() throws Exception {
-    Map<List<String>, List<String>> map = RepairRunnerTest.threeNodeCluster();
-    Map<String, String> endpointsThreeNodes = RepairRunnerTest.threeNodeClusterEndpoint();
-    assertEquals(1, RepairRunner.getPossibleParallelRepairsCount(map, endpointsThreeNodes, DatacenterAvailability.ALL));
+  @Test(expected = ConditionTimeoutException.class)
+  public void testTooManyPendingCompactions()
+    throws InterruptedException, ReaperException, MalformedObjectNameException,
+      ReflectionException, IOException {
+    final String KS_NAME = "reaper";
+    final Set<String> CF_NAMES = Sets.newHashSet("reaper");
+    final boolean INCREMENTAL_REPAIR = false;
+    final Set<String> NODES = Sets.newHashSet("127.0.0.1");
+    final Map<String, String> NODES_MAP = ImmutableMap.of("127.0.0.1", "dc1");
+    final Set<String> DATACENTERS = Collections.emptySet();
+    final Set<String> BLACKLISTED_TABLES = Collections.emptySet();
+    final long TIME_RUN = 41L;
+    final double INTENSITY = 0.5f;
+    final int REPAIR_THREAD_COUNT = 1;
+    final List<BigInteger> TOKENS = Lists.newArrayList(
+        BigInteger.valueOf(0L),
+        BigInteger.valueOf(100L),
+        BigInteger.valueOf(200L));
+    final IStorage storage = new MemoryStorage();
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = new ReaperApplicationConfiguration();
+    storage.addCluster(cluster);
+    UUID cf = storage.addRepairUnit(
+        RepairUnit.builder()
+            .clusterName(cluster.getName())
+            .keyspaceName(KS_NAME)
+            .columnFamilies(CF_NAMES)
+            .incrementalRepair(INCREMENTAL_REPAIR)
+            .nodes(NODES)
+            .datacenters(DATACENTERS)
+            .blacklistedTables(BLACKLISTED_TABLES)
+            .repairThreadCount(REPAIR_THREAD_COUNT))
+        .getId();
+    DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
+    RepairRun run = generateRepairRunForPendingCompactions(INTENSITY, storage, cf);
+    final UUID RUN_ID = run.getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegments(run.getId()).get(0).getId();
+    assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(), RepairSegment.State.NOT_STARTED);
+    final JmxProxy jmx = JmxProxyTest.mockJmxProxyImpl();
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(jmx.getEndpointToHostId()).thenReturn(NODES_MAP);
+    when(jmx.getTokens()).thenReturn(TOKENS);
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    JmxProxyTest.mockGetEndpointSnitchInfoMBean(jmx, endpointSnitchInfoMBean);
+    ClusterFacade clusterFacade = mock(ClusterFacade.class);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
+    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
+        .thenReturn(Lists.newArrayList(NODES));
+    when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
+        .thenReturn((Map)ImmutableMap.of(
+            Lists.newArrayList("0", "100"), Lists.newArrayList(NODES),
+            Lists.newArrayList("100", "200"), Lists.newArrayList(NODES)));
+    when(clusterFacade.listActiveCompactions(any())).thenReturn(CompactionStats.builder().withActiveCompactions(
+        Collections.emptyList()).withPendingCompactions(Optional.of(100)).build());
 
-    map = RepairRunnerTest.sixNodeCluster();
-    Map<String, String> endpointsSixNodes = RepairRunnerTest.sixNodeClusterEndpoint();
-    assertEquals(2, RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes, DatacenterAvailability.ALL));
-    assertEquals(1,
-        RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes, DatacenterAvailability.SIDECAR));
+    context.repairManager = RepairManager.create(
+        context,
+        clusterFacade,
+        Executors.newScheduledThreadPool(1),
+        500,
+        TimeUnit.MILLISECONDS,
+        1,
+        TimeUnit.MILLISECONDS,
+        1);
+    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+        .then(
+            (invocation) -> {
+              final int repairNumber = repairNumberCounter.getAndIncrement();
+
+              new Thread() {
+                @Override
+                public void run() {
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.STARTED),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.FINISHED),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                }
+              }.start();
+              return repairNumber;
+            });
+    context.jmxConnectionFactory = new JmxConnectionFactory(context, new NoopCrypotograph()) {
+          @Override
+          protected JmxProxy connectImpl(Node host) throws ReaperException {
+            return jmx;
+          }
+        };
+    ClusterFacade clusterProxy = ClusterFacade.create(context);
+    ClusterFacade clusterProxySpy = Mockito.spy(clusterProxy);
+    Mockito.doReturn(Collections.singletonList("")).when(clusterProxySpy).tokenRangeToEndpoint(any(), any(), any());
+
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRun(RUN_ID).get().getRunState());
+    context.repairManager.resumeRunningRepairRuns();
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRun(RUN_ID).get().getRunState());
+
+    storage.updateRepairRun(
+        run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(RUN_ID));
+
+    context.repairManager.resumeRunningRepairRuns();
+    // Make sure it's still in RUNNING state as segments can't be processed due to pending compactions
+    await().with().pollInterval(POLL_INTERVAL).atMost(30, SECONDS).until(() -> {
+      if (RepairRun.RunState.RUNNING != storage.getRepairRun(RUN_ID).get().getRunState()) {
+        return true;
+      }
+      return false;
+    });
+    // If we get here then there's a problem...
+    // An exception should be thrown by Awaitility as we should not reach a status different than RUNNING
+    assertEquals(RepairRun.RunState.RUNNING, storage.getRepairRun(RUN_ID).get().getRunState());
   }
 
-  @Test
-  public void getParallelSegmentsTest() throws ReaperException {
-    List<BigInteger> tokens = Lists
-        .transform(Lists.newArrayList("0", "50", "100", "150", "200", "250"), (string) -> new BigInteger(string));
-
-    SegmentGenerator generator = new SegmentGenerator(new BigInteger("0"), new BigInteger("299"));
-
-    List<Segment> segments = generator.generateSegments(
-            32,
-            tokens,
-            Boolean.FALSE,
-            RepairRunService.buildReplicasToRangeMap(RepairRunnerTest.sixNodeCluster()),
-            "2.2.10");
-
-    Map<List<String>, List<String>> map = RepairRunnerTest.sixNodeCluster();
-    Map<String, String> endpointsSixNodes = RepairRunnerTest.sixNodeClusterEndpoint();
-
-    List<RingRange> ranges = RepairRunner.getParallelRanges(
-            RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes, DatacenterAvailability.ALL),
+  private RepairRun generateRepairRunForPendingCompactions(final double intensity, final IStorage storage, UUID cf) {
+    return storage.addRepairRun(
+            RepairRun.builder(cluster.getName(), cf)
+                .intensity(intensity)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL)
+                .tables(TABLES),
             Lists.newArrayList(
-                Collections2.transform(segments, segment -> segment.getBaseRange())));
-
-    assertEquals(2, ranges.size());
-    assertEquals("0", ranges.get(0).getStart().toString());
-    assertEquals("150", ranges.get(0).getEnd().toString());
-    assertEquals("150", ranges.get(1).getStart().toString());
-    assertEquals("0", ranges.get(1).getEnd().toString());
-  }
-
-  @Test
-  public void getParallelSegmentsTest2() throws ReaperException {
-    List<BigInteger> tokens = Lists.transform(
-        Lists.newArrayList("0", "25", "50", "75", "100", "125", "150", "175", "200", "225", "250"),
-        (string) -> new BigInteger(string));
-
-    SegmentGenerator generator = new SegmentGenerator(new BigInteger("0"), new BigInteger("299"));
-
-    Map<List<String>, List<String>> map = RepairRunnerTest.sixNodeCluster();
-    Map<String, String> endpointsSixNodes = RepairRunnerTest.sixNodeClusterEndpoint();
-
-    List<Segment> segments = generator.generateSegments(
-            32, tokens, Boolean.FALSE, RepairRunService.buildReplicasToRangeMap(map), "2.2.10");
-
-    List<RingRange> ranges = RepairRunner.getParallelRanges(
-            RepairRunner.getPossibleParallelRepairsCount(map, endpointsSixNodes, DatacenterAvailability.ALL),
-            Lists.newArrayList(
-                Collections2.transform(segments, segment -> segment.getBaseRange())));
-
-    assertEquals(2, ranges.size());
-    assertEquals("0", ranges.get(0).getStart().toString());
-    assertEquals("150", ranges.get(0).getEnd().toString());
-    assertEquals("150", ranges.get(1).getStart().toString());
-    assertEquals("0", ranges.get(1).getEnd().toString());
+                RepairSegment.builder(
+                        Segment.builder()
+                            .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                            .withReplicas(replicas)
+                            .build(),
+                        cf)
+                    .withState(RepairSegment.State.RUNNING)
+                    .withStartTime(DateTime.now())
+                    .withCoordinatorHost("reaper"),
+                RepairSegment.builder(
+                    Segment.builder()
+                        .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
+                        .withReplicas(replicas)
+                        .build(),
+                    cf)));
   }
 
   @Test
@@ -709,7 +803,252 @@ public final class RepairRunnerTest {
   }
 
   @Test
-  public void testFailRepairAfterTopologyChange() throws InterruptedException, ReaperException {
+  public void testFailRepairAfterTopologyChange() throws InterruptedException, ReaperException,
+      MalformedObjectNameException, ReflectionException, IOException {
+    final String KS_NAME = "reaper";
+    final Set<String> CF_NAMES = Sets.newHashSet("reaper");
+    final boolean INCREMENTAL_REPAIR = false;
+    final Set<String> NODES = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
+    final List<String> NODES_AFTER_TOPOLOGY_CHANGE = Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.4");
+    final Map<String, String> NODES_MAP = ImmutableMap.of(
+        "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1"
+        );
+    final Set<String> DATACENTERS = Collections.emptySet();
+    final Set<String> BLACKLISTED_TABLES = Collections.emptySet();
+    final long TIME_RUN = 41L;
+    final double INTENSITY = 0.5f;
+    final int REPAIR_THREAD_COUNT = 1;
+    final List<BigInteger> TOKENS = Lists.newArrayList(
+        BigInteger.valueOf(0L),
+        BigInteger.valueOf(100L),
+        BigInteger.valueOf(200L));
+    final IStorage storage = new MemoryStorage();
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = new ReaperApplicationConfiguration();
+    storage.addCluster(cluster);
+    UUID cf = storage.addRepairUnit(
+        RepairUnit.builder()
+            .clusterName(cluster.getName())
+            .keyspaceName(KS_NAME)
+            .columnFamilies(CF_NAMES)
+            .incrementalRepair(INCREMENTAL_REPAIR)
+            .nodes(NODES)
+            .datacenters(DATACENTERS)
+            .blacklistedTables(BLACKLISTED_TABLES)
+            .repairThreadCount(REPAIR_THREAD_COUNT))
+        .getId();
+    RepairRun run = storage.addRepairRun(
+            RepairRun.builder(cluster.getName(), cf)
+                .intensity(INTENSITY)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL)
+                .tables(TABLES),
+            Lists.newArrayList(
+                RepairSegment.builder(
+                        Segment.builder()
+                            .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                            .withReplicas(NODES_MAP)
+                            .build(), cf)
+                    .withState(RepairSegment.State.RUNNING)
+                    .withStartTime(DateTime.now())
+                    .withCoordinatorHost("reaper"),
+                RepairSegment.builder(
+                    Segment.builder()
+                        .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
+                        .withReplicas(NODES_MAP)
+                        .build(), cf)));
+    final UUID RUN_ID = run.getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegments(run.getId()).get(0).getId();
+    assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(), RepairSegment.State.NOT_STARTED);
+    final JmxProxy jmx = JmxProxyTest.mockJmxProxyImpl();
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(jmx.getEndpointToHostId()).thenReturn(NODES_MAP);
+    when(jmx.getTokens()).thenReturn(TOKENS);
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    JmxProxyTest.mockGetEndpointSnitchInfoMBean(jmx, endpointSnitchInfoMBean);
+    ClusterFacade clusterFacade = mock(ClusterFacade.class);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
+    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
+        .thenReturn(Lists.newArrayList(NODES));
+    when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
+        .thenReturn((Map)ImmutableMap.of(
+            Lists.newArrayList("0", "100"), Lists.newArrayList(NODES),
+            Lists.newArrayList("100", "200"), Lists.newArrayList(NODES)));
+    when(clusterFacade.getEndpointToHostId(any())).thenReturn(NODES_MAP);
+    when(clusterFacade.listActiveCompactions(any())).thenReturn(
+        CompactionStats.builder()
+          .withActiveCompactions(Collections.emptyList())
+          .withPendingCompactions(Optional.of(0))
+          .build());
+    context.repairManager = RepairManager.create(
+        context,
+        clusterFacade,
+        Executors.newScheduledThreadPool(10),
+        500,
+        TimeUnit.MILLISECONDS,
+        1,
+        TimeUnit.MILLISECONDS,
+        1);
+    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+        .then(
+            (invocation) -> {
+              final int repairNumber = repairNumberCounter.getAndIncrement();
+              new Thread() {
+                @Override
+                public void run() {
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.STARTED),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                  ((RepairStatusHandler)invocation.getArgument(7))
+                      .handle(
+                          repairNumber,
+                          Optional.of(ActiveRepairService.Status.FINISHED),
+                          Optional.empty(),
+                          null,
+                          jmx);
+                }
+              }.start();
+              return repairNumber;
+            });
+    context.jmxConnectionFactory = new JmxConnectionFactory(context, new NoopCrypotograph()) {
+          @Override
+          protected JmxProxy connectImpl(Node host) throws ReaperException {
+            return jmx;
+          }
+        };
+    ClusterFacade clusterProxy = ClusterFacade.create(context);
+    ClusterFacade clusterProxySpy = Mockito.spy(clusterProxy);
+    Mockito.doReturn(NODES_AFTER_TOPOLOGY_CHANGE).when(clusterProxySpy).tokenRangeToEndpoint(any(), any(), any());
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRun(RUN_ID).get().getRunState());
+    storage.updateRepairRun(
+        run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(RUN_ID));
+    // We'll now change the list of replicas for any segment, making the stored ones obsolete
+    when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
+      .thenReturn(Lists.newArrayList(NODES_AFTER_TOPOLOGY_CHANGE));
+    context.repairManager.resumeRunningRepairRuns();
+    // The repair should now fail as the list of replicas for the segments are different from storage
+    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+      return RepairRun.RunState.ERROR == storage.getRepairRun(RUN_ID).get().getRunState();
+    });
+    assertEquals(RepairRun.RunState.ERROR, storage.getRepairRun(RUN_ID).get().getRunState());
+  }
+
+  @Test
+  public void isItOkToRepairTest() {
+    assertFalse(RepairRunner.okToRepairSegment(false, true, DatacenterAvailability.ALL));
+    assertFalse(RepairRunner.okToRepairSegment(false, false, DatacenterAvailability.ALL));
+    assertTrue(RepairRunner.okToRepairSegment(true, true, DatacenterAvailability.ALL));
+
+    assertTrue(RepairRunner.okToRepairSegment(false, true, DatacenterAvailability.LOCAL));
+    assertFalse(RepairRunner.okToRepairSegment(false, false, DatacenterAvailability.LOCAL));
+    assertTrue(RepairRunner.okToRepairSegment(true, true, DatacenterAvailability.LOCAL));
+
+    assertFalse(RepairRunner.okToRepairSegment(false, true, DatacenterAvailability.EACH));
+    assertFalse(RepairRunner.okToRepairSegment(false, false, DatacenterAvailability.EACH));
+    assertTrue(RepairRunner.okToRepairSegment(true, true, DatacenterAvailability.EACH));
+  }
+
+  @Test
+  public void getNodeMetricsInLocalDCAvailabilityForRemoteDCNodeTest() throws Exception {
+    final String KS_NAME = "reaper";
+    final Set<String> CF_NAMES = Sets.newHashSet("reaper");
+    final boolean INCREMENTAL_REPAIR = false;
+    final Set<String> NODES = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
+    final List<String> NODES_AFTER_TOPOLOGY_CHANGE = Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.4");
+    final Map<String, String> NODES_MAP = ImmutableMap.of(
+        "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1"
+        );
+    final Set<String> DATACENTERS = Collections.emptySet();
+    final Set<String> BLACKLISTED_TABLES = Collections.emptySet();
+    final long TIME_RUN = 41L;
+    final double INTENSITY = 0.5f;
+    final int REPAIR_THREAD_COUNT = 1;
+    final List<BigInteger> TOKENS = Lists.newArrayList(
+        BigInteger.valueOf(0L),
+        BigInteger.valueOf(100L),
+        BigInteger.valueOf(200L));
+    final AppContext context = new AppContext();
+    context.storage = Mockito.mock(CassandraStorage.class);
+    RepairUnit repairUnit = RepairUnit.builder()
+          .clusterName(cluster.getName())
+          .keyspaceName(KS_NAME)
+          .columnFamilies(CF_NAMES)
+          .incrementalRepair(INCREMENTAL_REPAIR)
+          .nodes(NODES)
+          .datacenters(DATACENTERS)
+          .blacklistedTables(BLACKLISTED_TABLES)
+          .repairThreadCount(REPAIR_THREAD_COUNT).build(UUID.randomUUID());
+
+    RepairRun run = RepairRun.builder(cluster.getName(), repairUnit.getId())
+          .intensity(INTENSITY)
+          .segmentCount(1)
+          .repairParallelism(RepairParallelism.PARALLEL)
+          .tables(TABLES).build(UUID.randomUUID());
+
+    when(((IDistributedStorage) context.storage).getNodeMetrics(any(), any()))
+        .thenReturn(Optional.empty());
+    Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
+    Mockito.when(((CassandraStorage) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
+    Mockito.when(((CassandraStorage) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
+
+    Mockito.when(context.storage.getCluster(any())).thenReturn(cluster);
+    JmxConnectionFactory jmxConnectionFactory = mock(JmxConnectionFactory.class);
+    JmxProxy jmx = mock(JmxProxy.class);
+    when(jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(jmx.getEndpointToHostId()).thenReturn(NODES_MAP);
+    when(jmx.getTokens()).thenReturn(TOKENS);
+    when(jmx.isRepairRunning()).thenReturn(true);
+    when(jmx.getPendingCompactions()).thenReturn(3);
+    context.jmxConnectionFactory = jmxConnectionFactory;
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setDatacenterAvailability(DatacenterAvailability.LOCAL);
+
+    ClusterFacade clusterFacade = mock(ClusterFacade.class);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
+    when(clusterFacade.listActiveCompactions(any())).thenReturn(null);
+    when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
+      .thenReturn((Map)ImmutableMap.of(Lists.newArrayList("0", "100"), Lists.newArrayList(NODES)));
+
+    RepairRunner repairRunner = RepairRunner.create(
+        context,
+        UUID.randomUUID(),
+        clusterFacade);
+
+    Pair<String, Callable<Optional<CompactionStats>>> result = repairRunner.getNodeMetrics("node-some", "dc1", "dc2");
+    assertFalse(result.getRight().call().isPresent());
+    verify(jmxConnectionFactory, times(0)).connectAny(any(Collection.class));
+    // Verify that we didn't call any method that is used in getRemoteNodeMetrics()
+    verify((CassandraStorage)context.storage, times(0)).storeNodeMetrics(any(), any());
+    verify((CassandraStorage)context.storage, times(0)).getNodeMetrics(any(), any());
+  }
+
+  @Test
+  public void getNodeMetricsInLocalDCAvailabilityForLocalDCNodeTest() throws Exception {
     final String KS_NAME = "reaper";
     final Set<String> CF_NAMES = Sets.newHashSet("reaper");
     final boolean INCREMENTAL_REPAIR = false;
@@ -766,98 +1105,46 @@ public final class RepairRunnerTest {
                         .withReplicas(NODES_MAP)
                         .build(),
                     cf)));
-
     final UUID RUN_ID = run.getId();
-    final UUID SEGMENT_ID = storage.getNextFreeSegmentInRange(run.getId(), Optional.empty()).get().getId();
+    final UUID SEGMENT_ID = storage.getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegment(RUN_ID, SEGMENT_ID).get().getState(), RepairSegment.State.NOT_STARTED);
-    final JmxProxy jmx = JmxProxyTest.mockJmxProxyImpl();
-    when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
-    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
-    when(jmx.getEndpointToHostId()).thenReturn(NODES_MAP);
-    when(jmx.getTokens()).thenReturn(TOKENS);
-    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
-    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
-    try {
-      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
-    } catch (UnknownHostException ex) {
-      throw new AssertionError(ex);
-    }
-    JmxProxyTest.mockGetEndpointSnitchInfoMBean(jmx, endpointSnitchInfoMBean);
+    final JmxProxy proxy = JmxProxyTest.mockJmxProxyImpl();
+    when(proxy.getClusterName()).thenReturn(cluster.getName());
+    when(proxy.isConnectionAlive()).thenReturn(true);
+    when(proxy.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(proxy.getEndpointToHostId()).thenReturn(NODES_MAP);
+    when(proxy.getTokens()).thenReturn(TOKENS);
+    when(proxy.isRepairRunning()).thenReturn(true);
+    when(proxy.getPendingCompactions()).thenReturn(3);
+
+    EndpointSnitchInfoMBean endpointSnitchInfoMBeanMock = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBeanMock.getDatacenter(any())).thenReturn("dc1");
+    JmxProxyTest.mockGetEndpointSnitchInfoMBean(proxy, endpointSnitchInfoMBeanMock);
+
+    JmxConnectionFactory jmxConnectionFactory = mock(JmxConnectionFactory.class);
+    when(jmxConnectionFactory.connectAny(any(Collection.class))).thenReturn(proxy);
+    when(jmxConnectionFactory.getAccessibleDatacenters()).thenReturn(Sets.newHashSet("dc1"));
+    context.jmxConnectionFactory = jmxConnectionFactory;
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setDatacenterAvailability(DatacenterAvailability.LOCAL);
+
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
-    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(proxy);
     when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
-    when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
-        .thenReturn(Lists.newArrayList(NODES));
+    when(clusterFacade.listActiveCompactions(any())).thenReturn(CompactionStats.builder().withActiveCompactions(
+        Collections.emptyList()).withPendingCompactions(Optional.of(3)).build());
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
-        .thenReturn((Map)ImmutableMap.of(
-            Lists.newArrayList("0", "100"), Lists.newArrayList(NODES),
-            Lists.newArrayList("100", "200"), Lists.newArrayList(NODES)));
-    when(clusterFacade.getEndpointToHostId(any())).thenReturn(NODES_MAP);
-    context.repairManager = RepairManager.create(
+      .thenReturn((Map)ImmutableMap.of(Lists.newArrayList("0", "100"), Lists.newArrayList(NODES)));
+
+    RepairRunner repairRunner = RepairRunner.create(
         context,
-        clusterFacade,
-        Executors.newScheduledThreadPool(10),
-        500,
-        TimeUnit.MILLISECONDS,
-        1,
-        TimeUnit.MILLISECONDS);
-    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+        RUN_ID,
+        clusterFacade);
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
-        .then(
-            (invocation) -> {
-              final int repairNumber = repairNumberCounter.getAndIncrement();
-
-              new Thread() {
-                @Override
-                public void run() {
-                  ((RepairStatusHandler)invocation.getArgument(7))
-                      .handle(
-                          repairNumber,
-                          Optional.of(ActiveRepairService.Status.STARTED),
-                          Optional.empty(),
-                          null,
-                          jmx);
-                  ((RepairStatusHandler)invocation.getArgument(7))
-                      .handle(
-                          repairNumber,
-                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
-                          Optional.empty(),
-                          null,
-                          jmx);
-                  ((RepairStatusHandler)invocation.getArgument(7))
-                      .handle(
-                          repairNumber,
-                          Optional.of(ActiveRepairService.Status.FINISHED),
-                          Optional.empty(),
-                          null,
-                          jmx);
-                }
-              }.start();
-              return repairNumber;
-            });
-    context.jmxConnectionFactory = new JmxConnectionFactory(context, new NoopCrypotograph()) {
-          @Override
-          protected JmxProxy connectImpl(Node host) throws ReaperException {
-            return jmx;
-          }
-        };
-    ClusterFacade clusterProxy = ClusterFacade.create(context);
-    ClusterFacade clusterProxySpy = Mockito.spy(clusterProxy);
-    Mockito.doReturn(NODES_AFTER_TOPOLOGY_CHANGE).when(clusterProxySpy).tokenRangeToEndpoint(any(), any(), any());
-    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRun(RUN_ID).get().getRunState());
-    storage.updateRepairRun(
-        run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(RUN_ID));
-    // We'll now change the list of replicas for any segment, making the stored ones obsolete
-    when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
-      .thenReturn(Lists.newArrayList(NODES_AFTER_TOPOLOGY_CHANGE));
-    context.repairManager.resumeRunningRepairRuns();
-    // The repair should now fail as the list of replicas for the segments are different from storage
-    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
-      return RepairRun.RunState.ERROR == storage.getRepairRun(RUN_ID).get().getRunState();
-    });
-    assertEquals(RepairRun.RunState.ERROR, storage.getRepairRun(RUN_ID).get().getRunState());
+    Pair<String, Callable<Optional<CompactionStats>>> result = repairRunner.getNodeMetrics("node-some", "dc1", "dc1");
+    Optional<CompactionStats> optional = result.getRight().call();
+    assertTrue(optional.isPresent());
+    CompactionStats metrics = optional.get();
+    assertEquals(3, metrics.getPendingCompactions().get().intValue());
   }
-
 }


### PR DESCRIPTION
An alternate model is proposed to remove the reliance on thread pool stats to check if a node is currently running a repair session. This should fully avoid concurrent reaper instances conflicting after the LWT and one of them canceling segment processing startup.
This new model will try to interact the least it can with nodes through JMX once the locks are successful.
By relying on backend data, it will also permit multiple repairs to run concurrently on different repair runs. This will allow users to repair several keyspaces at the same time.
