### PR TITLE
Cassandra Reaper docker container does not start without setting REAPER_JMX_AUTH_USERNAME

### DIFF
--- a/src/server/src/main/docker/cassandra-reaper.yml
+++ b/src/server/src/main/docker/cassandra-reaper.yml
@@ -50,10 +50,6 @@ autoScheduling:
 
 jmxPorts: ${REAPER_JMX_PORTS}
 
-jmxAuth:
-  username: ${REAPER_JMX_AUTH_USERNAME}
-  password: ${REAPER_JMX_AUTH_PASSWORD}
-
 jmxmp:
   enabled: ${REAPER_JMXMP_ENABLED}
   ssl: ${REAPER_JMXMP_SSL}

--- a/src/server/src/main/docker/configure-jmx-credentials.sh
+++ b/src/server/src/main/docker/configure-jmx-credentials.sh
@@ -38,3 +38,14 @@ EOT
   done
 
 fi
+
+
+if [ ! -z "${REAPER_JMX_AUTH_USERNAME}" ]; then
+
+cat <<EOT >> /etc/cassandra-reaper.yml
+jmxAuth:
+  username: ${REAPER_JMX_AUTH_USERNAME}
+  password: ${REAPER_JMX_AUTH_PASSWORD}
+EOT
+
+fi


### PR DESCRIPTION
### Problem
The Cassandra Reaper docker container does not start without setting REAPER_JMX_AUTH_USERNAME due to internal validation checks in Reapers configuration code.
I get the following stacktrace when I try:

```
/usr/local/bin $ ./entrypoint.sh cassandra-reaper
io.dropwizard.configuration.ConfigurationParsingException: /etc/cassandra-reaper.yml has an error:
  * Failed to parse configuration at: jmxAuth.username; N/A (through reference chain: io.cassandrareaper.ReaperApplicationConfiguration["jmxAuth"]->io.cassandrareaper.core.JmxCredentials$Builder["username"])

	at io.dropwizard.configuration.ConfigurationParsingException$Builder.build(ConfigurationParsingException.java:279)
	at io.dropwizard.configuration.BaseConfigurationFactory.build(BaseConfigurationFactory.java:156)
	at io.dropwizard.configuration.BaseConfigurationFactory.build(BaseConfigurationFactory.java:89)
	at io.dropwizard.cli.ConfiguredCommand.parseConfiguration(ConfiguredCommand.java:126)
	at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:74)
	at io.dropwizard.cli.Cli.run(Cli.java:78)
	at io.dropwizard.Application.run(Application.java:93)
	at io.cassandrareaper.ReaperApplication.main(ReaperApplication.java:123)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: N/A (through reference chain: io.cassandrareaper.ReaperApplicationConfiguration["jmxAuth"]->io.cassandrareaper.core.JmxCredentials$Builder["username"])
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:277)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:611)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:599)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:622)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.setAndReturn(MethodProperty.java:195)
	at com.fasterxml.jackson.module.afterburner.deser.OptimizedSettableBeanProperty.setAndReturn(OptimizedSettableBeanProperty.java:111)
	at com.fasterxml.jackson.module.afterburner.deser.SettableStringMethodProperty.setAndReturn(SettableStringMethodProperty.java:9)
	at com.fasterxml.jackson.module.afterburner.deser.SettableStringMethodProperty.deserializeSetAndReturn(SettableStringMethodProperty.java:74)
	at com.fasterxml.jackson.databind.deser.BuilderBasedDeserializer.vanillaDeserialize(BuilderBasedDeserializer.java:269)
	at com.fasterxml.jackson.databind.deser.BuilderBasedDeserializer.deserialize(BuilderBasedDeserializer.java:193)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:127)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:252)
	at com.fasterxml.jackson.module.afterburner.deser.SuperSonicBeanDeserializer.deserialize(SuperSonicBeanDeserializer.java:155)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:3984)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2276)
	at io.dropwizard.configuration.BaseConfigurationFactory.build(BaseConfigurationFactory.java:127)
	... 6 more
Caused by: java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:787)
	at io.cassandrareaper.core.JmxCredentials$Builder.withUsername(JmxCredentials.java:61)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.setAndReturn(MethodProperty.java:191)
	... 17 more
```

### Proposed solution

The validation logic in Reaper only runs if the `jmxAuth` is defined in the configuration file.
In the docker configuration template, the `jmxAuth` element is always present - even when the username and password are empty.

The following are possible solutions:
1. Remove the validation logic from JmxCredentials.java:61
1. Adjust the configuration loader so it recognizes the empty environment variable as an empty string instead of null. This is handled by Dropwizards configuration loader in combination with Jackson and will probably affect other parts of Cassandra Reaper.
1. Only insert the `jmxAuth`element when the user wants to specify a username and password using environment variables.

Option 1 removes valid logic for non-docker users.
Option 2 could affect other parts of the system
Option 3 seems least intrusive and fixes the problem.

This PR is an implementation of option 3.