### PR TITLE
Fix Astra migrations with LWTs not being properly allowed.

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -524,12 +524,15 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
     takeLeadPrepStmt = session
         .prepare(
             "INSERT INTO leader(leader_id, reaper_instance_id, reaper_instance_host, last_heartbeat)"
-                + "VALUES(?, ?, ?, " + timeUdf + "(now())) IF NOT EXISTS USING TTL ?");
+                + "VALUES(?, ?, ?, " + timeUdf + "(now())) IF NOT EXISTS USING TTL ?")
+        .setConsistencyLevel(ConsistencyLevel.QUORUM);
     renewLeadPrepStmt = session
         .prepare(
             "UPDATE leader USING TTL ? SET reaper_instance_id = ?, reaper_instance_host = ?,"
-                + " last_heartbeat = " + timeUdf + "(now()) WHERE leader_id = ? IF reaper_instance_id = ?");
-    releaseLeadPrepStmt = session.prepare("DELETE FROM leader WHERE leader_id = ? IF reaper_instance_id = ?");
+                + " last_heartbeat = " + timeUdf + "(now()) WHERE leader_id = ? IF reaper_instance_id = ?")
+        .setConsistencyLevel(ConsistencyLevel.QUORUM);
+    releaseLeadPrepStmt = session.prepare("DELETE FROM leader WHERE leader_id = ? IF reaper_instance_id = ?")
+        .setConsistencyLevel(ConsistencyLevel.QUORUM);
   }
 
   private void prepareMetricStatements() {

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -211,7 +211,7 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
 
     this.reaperInstanceId = reaperInstanceId;
     CassandraFactory cassandraFactory = config.getCassandraFactory();
-    overrideQueryOptions(cassandraFactory);
+    overrideQueryOptions(cassandraFactory, mode);
     overrideRetryPolicy(cassandraFactory);
     overridePoolingOptions(cassandraFactory);
 
@@ -1676,13 +1676,19 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
   }
 
 
-  private static void overrideQueryOptions(CassandraFactory cassandraFactory) {
-    // all INSERT and DELETE stmt prepared in this class are idempoten
+  private static void overrideQueryOptions(CassandraFactory cassandraFactory, CassandraMode mode) {
+    // all INSERT and DELETE stmt prepared in this class are idempotent
+    ConsistencyLevel requiredCl = mode.equals(CassandraMode.ASTRA)
+        ? ConsistencyLevel.LOCAL_QUORUM
+        : ConsistencyLevel.LOCAL_ONE;
     if (cassandraFactory.getQueryOptions().isPresent()
         && ConsistencyLevel.LOCAL_ONE != cassandraFactory.getQueryOptions().get().getConsistencyLevel()) {
       LOG.warn("Customization of cassandra's queryOptions is not supported and will be overridden");
     }
-    cassandraFactory.setQueryOptions(java.util.Optional.of(new QueryOptions().setDefaultIdempotence(true)));
+    cassandraFactory.setQueryOptions(java.util.Optional.of(
+        new QueryOptions()
+          .setConsistencyLevel(requiredCl)
+          .setDefaultIdempotence(true)));
   }
 
   private static void overrideRetryPolicy(CassandraFactory cassandraFactory) {


### PR DESCRIPTION
Astra rejects LWTs when the statements don't have a (non serial) CL set to ONE or LOCAL_ONE.
This PR enforces using LOCAL_QUORUM as default CL when using Astra as storage backend.