### PR TITLE
Prevent migration 25 from failing if repairs are missing from the repair_run table

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration025.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Migration025.java
@@ -47,9 +47,12 @@ public final class Migration025 {
         LOG.info("Converting {} table...", V1_TABLE);
         ResultSet results = session.execute("SELECT * FROM " + V1_TABLE);
         for (Row row:results) {
-          String state = session.execute("SELECT distinct state from repair_run where id = " + row.getUUID("id")).one()
-              .getString("state");
-          session.execute(v2_insert.bind(row.getString("cluster_name"), row.getUUID("id"), state));
+          ResultSet runResults = session.execute(
+              "SELECT distinct state from repair_run where id = " + row.getUUID("id"));
+          for (Row runRow:runResults) {
+            String state = runRow.getString("state");
+            session.execute(v2_insert.bind(row.getString("cluster_name"), row.getUUID("id"), state));
+          }
         }
         session.execute("DROP TABLE " + V1_TABLE);
       }
@@ -57,5 +60,4 @@ public final class Migration025 {
       LOG.error("Failed transferring rows to " + V2_TABLE, e);
     }
   }
-
 }


### PR DESCRIPTION
Fixes #975 

The migration assumed that the `repair_run` table contained all the repair runs that exist in `repair_run_by_cluster`.
If it's not the case, the current migration code will throw an exception and the migration won't be complete.
This change will use a different approach and gracefully ignore missing repair runs.