### PR TITLE
Docker - actually pass auto-scheduling env vars to Reaper's yaml

### DIFF
--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -92,6 +92,7 @@ ADD configure-persistence.sh /usr/local/bin/configure-persistence.sh
 ADD configure-metrics.sh /usr/local/bin/configure-metrics.sh
 ADD configure-webui-authentication.sh /usr/local/bin/configure-webui-authentication.sh
 ADD configure-jmx-credentials.sh /usr/local/bin/configure-jmx-credentials.sh
+ADD configure-autoscheduling.sh /usr/local/bin/configure-autoscheduling.sh
 ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
 ADD spreaper /usr/local/bin/spreaper
 
@@ -114,6 +115,7 @@ RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
         /usr/local/bin/configure-webui-authentication.sh \
         /usr/local/bin/configure-metrics.sh \
         /usr/local/bin/configure-jmx-credentials.sh \
+        /usr/local/bin/configure-autoscheduling.sh \
         /usr/local/bin/spreaper \
         /etc/shiro.ini && \
     chown -R reaper:reaper \
@@ -126,6 +128,7 @@ RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
         /usr/local/bin/configure-webui-authentication.sh \
         /usr/local/bin/configure-metrics.sh \
         /usr/local/bin/configure-jmx-credentials.sh \
+        /usr/local/bin/configure-autoscheduling.sh \
         /usr/local/bin/spreaper
 
 VOLUME /var/lib/cassandra-reaper

--- a/src/server/src/main/docker/configure-autoscheduling.sh
+++ b/src/server/src/main/docker/configure-autoscheduling.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Copyright 2018-2019 The Last Pickle Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "false" = "${REAPER_AUTO_SCHEDULING_ENABLED}" ]; then
+  exit 0
+fi
+
+cat <<EOT >> /etc/cassandra-reaper.yml
+
+autoScheduling:
+  enabled: ${REAPER_AUTO_SCHEDULING_ENABLED}
+  initialDelayPeriod: ${REAPER_AUTO_SCHEDULING_INITIAL_DELAY_PERIOD}
+  periodBetweenPolls: ${REAPER_AUTO_SCHEDULING_PERIOD_BETWEEN_POLLS}
+  timeBeforeFirstSchedule: ${REAPER_AUTO_SCHEDULING_TIME_BEFORE_FIRST_SCHEDULE}
+  scheduleSpreadPeriod: ${REAPER_AUTO_SCHEDULING_SCHEDULE_SPREAD_PERIOD}
+  excludedKeyspaces: ${REAPER_AUTO_SCHEDULING_EXCLUDED_KEYSPACES}
+  excludedClusters: ${REAPER_AUTO_SCHEDULING_EXCLUDED_CLUSTERS}
+
+EOT

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -40,6 +40,7 @@ if [ "$1" = 'cassandra-reaper' ]; then
     /usr/local/bin/configure-webui-authentication.sh
     /usr/local/bin/configure-metrics.sh
     /usr/local/bin/configure-jmx-credentials.sh
+    /usr/local/bin/configure-autoscheduling.sh
     exec java \
             ${JAVA_OPTS} \
             -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication server \


### PR DESCRIPTION
As a test, I've built the docker image locally using
```
mvn -B -f src/server/pom.xml docker:build -Ddocker.directory=src/server/src/main/docker -DskipTests
```

I've then started the container:
```
docker run -it -e REAPER_AUTO_SCHEDULING_ENABLED=true cassandra-reaper cassandra-reaper
```

The quickest way to see if it worked that I could work out was to dump the container's file system and inspect the file:
```
docker export c97114f6befc > fs.tar
tar -xf fs.tar -C fs
tail fs/etc/cassandra-reaper.yml

autoScheduling:
  enabled: true
  initialDelayPeriod: PT15S
  periodBetweenPolls: PT10M
  timeBeforeFirstSchedule: PT5M
  scheduleSpreadPeriod: PT6H
  excludedKeyspaces: []
  excludedClusters: []

rm -rf fs.tar fs/*
```