### PR TITLE
Fix failing tests due to CASSANDRA-16083

### DIFF
--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -1663,11 +1663,11 @@ public final class BasicSteps {
               }
 
               long readDroppedTotal = dropped.stream()
-                  .filter(drop -> "READ".equals(drop.getName()) || "READ_REQ".equals(drop.getName()))
+                  .filter(drop -> "READ".equals(drop.getName()))
                   .count();
 
               long readDroppedCount = dropped.stream()
-                  .filter(drop -> "READ".equals(drop.getName()) || "READ_REQ".equals(drop.getName()) )
+                  .filter(drop -> "READ".equals(drop.getName()))
                   .filter(drop -> drop.getCount() >= 0)
                   .count();
 


### PR DESCRIPTION
CASSANDRA-16083 brought back the "READ" thread pool as alias for "READ_REQ" that it had been renamed into in 4.0. Since we were checking both indifferently to get tests passing for both 4.0 and prior versions, the test was breaking due to the alias as it altered the counts.