### PR TITLE
Limit repair runners per cluster instead of globally

### DIFF
--- a/src/docs/content/docs/configuration/docker_vars.md
+++ b/src/docs/content/docs/configuration/docker_vars.md
@@ -50,6 +50,7 @@ The Docker environment variables listed in this section map directly to Reaper s
 <code class="codeLarge">REAPER_SERVER_APP_PORT</code> | [port]({{< relref "reaper_specific.md#port" >}}) | 8080
 <code class="codeLarge">REAPER_STORAGE_TYPE</code> | [storageType]({{< relref "reaper_specific.md#storagetype" >}}) | memory
 <code class="codeLarge">REAPER_USE_ADDRESS_TRANSLATOR</code> | [useAddressTranslator]({{< relref "reaper_specific.md#useaddresstranslator" >}}) | false
+<code class="codeLarge">REAPER_MAX_PARALLEL_REPAIRS</code> | [maxParallelRepairs]({{< relref "reaper_specific.md#maxParallelRepairs" >}}) | false
 
 <br/>
 

--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -74,7 +74,8 @@ ENV REAPER_SEGMENT_COUNT_PER_NODE=64 \
     REAPER_SHIRO_INI="" \
     REAPER_JMXMP_ENABLED="false" \
     REAPER_JMXMP_SSL="false" \
-    JAVA_OPTS=""
+    JAVA_OPTS="" \
+    REAPER_MAX_PARALLEL_REPAIRS=2
 
 # used to run spreaper cli
 RUN apk add --update \

--- a/src/server/src/main/docker/cassandra-reaper.yml
+++ b/src/server/src/main/docker/cassandra-reaper.yml
@@ -28,6 +28,7 @@ enableDynamicSeedList: ${REAPER_ENABLE_DYNAMIC_SEED_LIST}
 repairManagerSchedulingIntervalSeconds: ${REAPER_REPAIR_MANAGER_SCHEDULING_INTERVAL_SECONDS}
 jmxConnectionTimeoutInSeconds: ${REAPER_JMX_CONNECTION_TIMEOUT_IN_SECONDS}
 useAddressTranslator: ${REAPER_USE_ADDRESS_TRANSLATOR}
+maxParallelRepairs: ${REAPER_MAX_PARALLEL_REPAIRS}
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.codahale.metrics.Gauge;
@@ -68,8 +67,6 @@ final class RepairRunner implements Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(RepairRunner.class);
   private static final ExecutorService METRICS_GRABBER_EXECUTOR = Executors.newFixedThreadPool(10);
-  private static final long METRICS_POLL_INTERVAL_MS = TimeUnit.SECONDS.toMillis(5);
-  private static final long METRICS_MAX_WAIT_MS = TimeUnit.MINUTES.toMillis(2);
 
   private final AppContext context;
   private final ClusterFacade clusterFacade;
@@ -98,9 +95,7 @@ final class RepairRunner implements Runnable {
     this.cluster = context.storage.getCluster(repairRun.get().getClusterName());
     repairUnit = context.storage.getRepairUnit(repairRun.get().getRepairUnitId());
     this.clusterName = cluster.getName();
-    String keyspace = repairUnit.getKeyspaceName();
 
-    Collection<RepairSegment> repairSegments = context.storage.getRepairSegmentsForRun(repairRunId);
     localEndpointRanges = context.config.isInSidecarMode()
         ? clusterFacade.getRangesForLocalEndpoint(cluster, repairUnit.getKeyspaceName())
         : Collections.emptyList();
@@ -679,5 +674,9 @@ final class RepairRunner implements Runnable {
       return newRepairRun;
     }
     return repairRun;
+  }
+
+  public Cluster getCluster() {
+    return this.cluster;
   }
 }


### PR DESCRIPTION
2.2 introduced parallel repairs with a limit on the number of repair runners to manage overall repair pressure.
This was done globally instead of per cluster, which will be very limiting for Reapers managing several clusters.

This PR applies the limit per cluster.