### PR TITLE
Batch metric inserts by partition to reduce Reaper write throughput

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/Heart.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/Heart.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017-2017 Spotify AB
  * Copyright 2017-2019 The Last Pickle Ltd
+ * Copyright 2021-2021 DataStax, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +51,7 @@ public final class Heart implements AutoCloseable {
 
   private static final AtomicBoolean GAUGES_REGISTERED = new AtomicBoolean(false);
   private static final Logger LOG = LoggerFactory.getLogger(Heart.class);
-  private static final long DEFAULT_MAX_FREQUENCY = TimeUnit.SECONDS.toMillis(30);
+  private static final long DEFAULT_MAX_FREQUENCY = TimeUnit.SECONDS.toMillis(60);
 
   private final AtomicLong lastBeat = new AtomicLong(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1));
   private final AtomicLong lastMetricBeat = new AtomicLong(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1));

--- a/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/MetricsService.java
@@ -146,9 +146,8 @@ public final class MetricsService {
     List<GenericMetric> metrics
         = convertToGenericMetrics(ClusterFacade.create(context).collectMetrics(node, COLLECTED_METRICS), node);
 
-    for (GenericMetric metric:metrics) {
-      ((IDistributedStorage)context.storage).storeMetric(metric);
-    }
+    ((IDistributedStorage)context.storage).storeMetrics(metrics);
+
     LOG.debug("Grabbing and storing metrics for {}", node.getHostname());
 
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -82,7 +82,7 @@ public interface IDistributedStorage {
       String metricType,
       long since);
 
-  void storeMetric(GenericMetric metric);
+  void storeMetrics(List<GenericMetric> metric);
 
   void storeOperations(String clusterName, OpType operationType, String host, String operationsJson);
 

--- a/src/server/src/test/java/io/cassandrareaper/storage/PostgresStorageTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/storage/PostgresStorageTest.java
@@ -42,7 +42,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.ImmutableList;
 import com.ibatis.common.jdbc.ScriptRunner;
+
 import org.fest.assertions.api.Assertions;
 import org.h2.tools.Server;
 import org.joda.time.DateTime;
@@ -259,8 +261,7 @@ public class PostgresStorageTest {
         .withValue(14)
         .build();
 
-    storage.storeMetric(metric1);
-    storage.storeMetric(metric2);
+    storage.storeMetrics(ImmutableList.of(metric1, metric2));
 
     // verify that the two metrics above can be queried by cluster name
     Set<String> expectedMetrics = new HashSet<>();
@@ -316,7 +317,7 @@ public class PostgresStorageTest {
         .withMetricAttribute("fake_attribute")
         .withValue(12)
         .build();
-    storage.storeMetric(expiredMetric);
+    storage.storeMetrics(ImmutableList.of(expiredMetric));
 
     // verify that the metric was stored in the DB
     List<GenericMetric> retrievedMetrics = storage.getMetrics(


### PR DESCRIPTION
Reaper stores extracts metrics from nodes during heartbeats and stores them in the backend when using collocated modes (SIDECAR, EACH, LOCAL).
Such metrics can be then be viewed in the UI.
This commit optimizes the inserts of metrics that belong to the same partition, which are now batched together.