### PR TITLE
K8ssandra-483 rebrand

### DIFF
--- a/docs/docs/backends/index.html
+++ b/docs/docs/backends/index.html
@@ -321,7 +321,7 @@
                     <div class="col-md-9" id="blog-listing-medium">
 
                         <h1 id="backends">Backends</h1>
-<p>Cassandra Reaper can be used with either an ephemeral memory storage or persistent database. For persistent scalable database storage, a Cassandra cluster can be set up to back Reaper. To use a Cassandra cluster as the backed storage for Reaper set <code>storageType</code> to a value of <strong>cassandra</strong> in the Reaper configuration file. <strong>Astra</strong> can also be used as storage backend by setting <code>storageType</code> to a value of <strong>astra</strong>. With purge settings tuned appropriately, Reaper&rsquo;s workload should fit perfectly into the free tier of Astra.
+<p>Reaper for Apache Cassandra can be used with either an ephemeral memory storage or persistent database. For persistent scalable database storage, a Cassandra cluster can be set up to back Reaper. To use a Cassandra cluster as the backed storage for Reaper set <code>storageType</code> to a value of <strong>cassandra</strong> in the Reaper configuration file. <strong>Astra</strong> can also be used as storage backend by setting <code>storageType</code> to a value of <strong>astra</strong>. With purge settings tuned appropriately, Reaper&rsquo;s workload should fit perfectly into the free tier of Astra.
 Alternatively, a relational database storage; either H2 or Postgres can be set up to back Reaper. To use one of the relational database options as the backed storage for Reaper set <code>storageType</code> to a value of either <strong>h2</strong> or <strong>postrges</strong> in the Reaper configuration file.</p>
 <p>Further information on the available storage options is provided in the following section.</p>
 <ul>

--- a/docs/docs/configuration/reaper_specific/index.html
+++ b/docs/docs/configuration/reaper_specific/index.html
@@ -492,7 +492,7 @@ To match the example above, it could be something like : <code>10.0.10.5@cluster
 <!-- raw HTML omitted -->
 <h3 id="metrics"><code>metrics</code></h3>
 <p>Type: <em>Object</em></p>
-<p>Configuration parameters for sending metrics to a reporting system via the <a href="http://www.dropwizard.io/1.1.4/docs/manual/configuration.html#metrics">Dropwizard interface</a>. Cassandra Reaper ships the Graphite and DataDog reporters by default.</p>
+<p>Configuration parameters for sending metrics to a reporting system via the <a href="http://www.dropwizard.io/1.1.4/docs/manual/configuration.html#metrics">Dropwizard interface</a>. Reaper for Apache Cassandra ships the Graphite and DataDog reporters by default.</p>
 <p>Further information on metrics configuration can be found in the <a href="../../metrics">Metrics</a> section.</p>
 <!-- raw HTML omitted -->
 <h3 id="repairintensity"><code>repairIntensity</code></h3>

--- a/docs/docs/download/index.html
+++ b/docs/docs/download/index.html
@@ -357,7 +357,7 @@ Here is the upgrade procedure for each Reaper backend:</p>
 <li>Pointing to your current Reaper jar file (located in <code>/usr/share/cassandra-reaper</code> for packaged installs), run the following command :</li>
 </ul>
 <pre><code>java -cp /usr/share/cassandra-reaper/cassandra-reaper-1.2.*.jar org.h2.tools.Shell
-</code></pre><p>When asked, provide the JDBC URL from your Cassandra Reaper yaml file (for example : <code>jdbc:h2:~/reaper-db/db;MODE=PostgreSQL</code>), use the default <code>Driver</code> and leave username/password empty.
+</code></pre><p>When asked, provide the JDBC URL from your Reaper for Apache Cassandra yaml file (for example : <code>jdbc:h2:~/reaper-db/db;MODE=PostgreSQL</code>), use the default <code>Driver</code> and leave username/password empty.
 Then run the following statements:</p>
 <pre><code>ALTER TABLE REPAIR_UNIT DROP COLUMN repair_thread_count;
 ALTER TABLE REPAIR_SEGMENT DROP COLUMN TOKEN_RANGES;

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -320,7 +320,7 @@
                     </div>
                     <div class="col-md-9" id="blog-listing-medium">
 
-                        <h2 id="welcome-to-the-cassandra-reaper-documentation">Welcome to the Cassandra Reaper documentation!</h2>
+                        <h2 id="welcome-to-the-cassandra-reaper-documentation">Welcome to the Reaper for Apache Cassandra documentation!</h2>
 <h3 id="overview">Overview</h3>
 <p>Reaper is an open source tool that aims to schedule and orchestrate repairs of Apache Cassandra clusters.</p>
 <p>It improves the existing nodetool repair process by</p>

--- a/docs/docs/usage/index.xml
+++ b/docs/docs/usage/index.xml
@@ -79,7 +79,7 @@ Setup a Repair Schedule Click the schedule menu item on the left side to navigat
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>http://cassandra-reaper.io/docs/usage/sidecar_mode/</guid>
-      <description>Sidecar Mode Sidecar Mode is a way of deploying Cassandra Reaper with one reaper instance for each node in the cluster. The name &amp;ldquo;Sidecar&amp;rdquo; comes from the Sidecar Pattern which describes a mechanism for co-locating an auxiliary service with its supported application. See also Design Patterns for Container-based Distributed Systems. It is a pattern that is often used in Kubernetes, where the main application and the sidecar application are deployed as separate containers in the same pod.</description>
+      <description>Sidecar Mode Sidecar Mode is a way of deploying Reaper for Apache Cassandra with one reaper instance for each node in the cluster. The name &amp;ldquo;Sidecar&amp;rdquo; comes from the Sidecar Pattern which describes a mechanism for co-locating an auxiliary service with its supported application. See also Design Patterns for Container-based Distributed Systems. It is a pattern that is often used in Kubernetes, where the main application and the sidecar application are deployed as separate containers in the same pod.</description>
     </item>
     
     <item>

--- a/docs/docs/usage/sidecar_mode/index.html
+++ b/docs/docs/usage/sidecar_mode/index.html
@@ -325,7 +325,7 @@
                     <div class="col-md-9">
                         <div>
                           <h1 id="sidecar-mode">Sidecar Mode</h1>
-<p>Sidecar Mode is a way of deploying Cassandra Reaper with one reaper instance for each node in the cluster.
+<p>Sidecar Mode is a way of deploying Reaper for Apache Cassandra with one reaper instance for each node in the cluster.
 The name &ldquo;Sidecar&rdquo; comes from <a href="https://github.com/microsoftdocs/architecture-center/blob/master/docs/patterns/sidecar.md">the Sidecar Pattern</a> which describes a mechanism for co-locating an auxiliary service with its supported application.
 See also  <a href="https://www.usenix.org/conference/hotcloud16/workshop-program/presentation/burns">Design Patterns for Container-based Distributed Systems</a>.
 It is a pattern that is often used in Kubernetes, where the main application and the sidecar application are deployed as separate containers in the same pod.</p>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -281,7 +281,7 @@ Setup a Repair Schedule Click the schedule menu item on the left side to navigat
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>http://cassandra-reaper.io/docs/usage/sidecar_mode/</guid>
-      <description>Sidecar Mode Sidecar Mode is a way of deploying Cassandra Reaper with one reaper instance for each node in the cluster. The name &amp;ldquo;Sidecar&amp;rdquo; comes from the Sidecar Pattern which describes a mechanism for co-locating an auxiliary service with its supported application. See also Design Patterns for Container-based Distributed Systems. It is a pattern that is often used in Kubernetes, where the main application and the sidecar application are deployed as separate containers in the same pod.</description>
+      <description>Sidecar Mode Sidecar Mode is a way of deploying Reaper for Apache Cassandra with one reaper instance for each node in the cluster. The name &amp;ldquo;Sidecar&amp;rdquo; comes from the Sidecar Pattern which describes a mechanism for co-locating an auxiliary service with its supported application. See also Design Patterns for Container-based Distributed Systems. It is a pattern that is often used in Kubernetes, where the main application and the sidecar application are deployed as separate containers in the same pod.</description>
     </item>
     
     <item>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Cassandra Reaper project</name>
+    <name>Reaper for Apache Cassandra project</name>
     <url>https://cassandra-reaper.io</url>
     <description>Reaper is a centralized, stateful, and highly configurable tool for running Apache Cassandra repairs against single or multi-site clusters</description>
 

--- a/src/docs/content/docs/_index.md
+++ b/src/docs/content/docs/_index.md
@@ -2,7 +2,7 @@
 show_menu = true
 +++
 
-## Welcome to the Cassandra Reaper documentation!
+## Welcome to the Reaper for Apache Cassandra documentation!
 
 ### Overview
 

--- a/src/docs/content/docs/backends/_index.md
+++ b/src/docs/content/docs/backends/_index.md
@@ -7,7 +7,7 @@ weight = 10
 
 # Backends
 
-Cassandra Reaper can be used with either an ephemeral memory storage or persistent database. For persistent scalable database storage, a Cassandra cluster can be set up to back Reaper. To use a Cassandra cluster as the backed storage for Reaper set `storageType` to a value of **cassandra** in the Reaper configuration file. **Astra** can also be used as storage backend by setting `storageType` to a value of **astra**. With purge settings tuned appropriately, Reaper's workload should fit perfectly into the free tier of Astra.
+Reaper for Apache Cassandra can be used with either an ephemeral memory storage or persistent database. For persistent scalable database storage, a Cassandra cluster can be set up to back Reaper. To use a Cassandra cluster as the backed storage for Reaper set `storageType` to a value of **cassandra** in the Reaper configuration file. **Astra** can also be used as storage backend by setting `storageType` to a value of **astra**. With purge settings tuned appropriately, Reaper's workload should fit perfectly into the free tier of Astra.
 Alternatively, a relational database storage; either H2 or Postgres can be set up to back Reaper. To use one of the relational database options as the backed storage for Reaper set `storageType` to a value of either **h2** or **postrges** in the Reaper configuration file.
 
 Further information on the available storage options is provided in the following section.

--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -291,7 +291,7 @@ The number of archive log files stored in the log rotation sliding window. That 
 
 Type: *Object*
 
-Configuration parameters for sending metrics to a reporting system via the [Dropwizard interface](http://www.dropwizard.io/1.1.4/docs/manual/configuration.html#metrics). Cassandra Reaper ships the Graphite and DataDog reporters by default.
+Configuration parameters for sending metrics to a reporting system via the [Dropwizard interface](http://www.dropwizard.io/1.1.4/docs/manual/configuration.html#metrics). Reaper for Apache Cassandra ships the Graphite and DataDog reporters by default.
 
 Further information on metrics configuration can be found in the [Metrics](../../metrics) section.
 

--- a/src/docs/content/docs/download/_index.md
+++ b/src/docs/content/docs/download/_index.md
@@ -56,7 +56,7 @@ ALTER TABLE reaper_db.repair_unit_v1 DROP repair_thread_count;
 ```
 java -cp /usr/share/cassandra-reaper/cassandra-reaper-1.2.*.jar org.h2.tools.Shell
 ```
-When asked, provide the JDBC URL from your Cassandra Reaper yaml file (for example : `jdbc:h2:~/reaper-db/db;MODE=PostgreSQL`), use the default `Driver` and leave username/password empty.
+When asked, provide the JDBC URL from your Reaper for Apache Cassandra yaml file (for example : `jdbc:h2:~/reaper-db/db;MODE=PostgreSQL`), use the default `Driver` and leave username/password empty.
 Then run the following statements:
 
 ```

--- a/src/docs/content/docs/usage/sidecar_mode.md
+++ b/src/docs/content/docs/usage/sidecar_mode.md
@@ -9,7 +9,7 @@ parent = "usage"
 
 # Sidecar Mode
 
-Sidecar Mode is a way of deploying Cassandra Reaper with one reaper instance for each node in the cluster.
+Sidecar Mode is a way of deploying Reaper for Apache Cassandra with one reaper instance for each node in the cluster.
 The name "Sidecar" comes from [the Sidecar Pattern](https://github.com/microsoftdocs/architecture-center/blob/master/docs/patterns/sidecar.md) which describes a mechanism for co-locating an auxiliary service with its supported application.
 See also  [Design Patterns for Container-based Distributed Systems](https://www.usenix.org/conference/hotcloud16/workshop-program/presentation/burns).
 It is a pattern that is often used in Kubernetes, where the main application and the sidecar application are deployed as separate containers in the same pod.

--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -351,9 +351,9 @@ def _parse_arguments(command, description, usage=None, extra_arguments=None):
 # === The actual CLI ========================================================================
 
 SPREAPER_DESCRIPTION = \
-    """Cassandra Reaper is a centralized, stateful, and highly configurable
+    """Reaper for Apache Cassandra is a centralized, stateful, and highly configurable
     tool for running Cassandra repairs for multi-site clusters.
-    This CLI tool is used to control the Cassandra Reaper service through
+    This CLI tool is used to control the Reaper for Apache Cassandra service through
     its REST API.
 
     First register your cluster with "add-cluster" command,
@@ -502,7 +502,7 @@ class ReaperCLI(object):
         printq("# Sending PING to Reaper...")
         answer = reaper.get("ping")
         printq("# [Reply] {}".format(answer))
-        printq("# Cassandra Reaper is answering in: {0}:{1}".format(args.reaper_host, args.reaper_port))
+        printq("# Reaper for Apache Cassandra is answering in: {0}:{1}".format(args.reaper_host, args.reaper_port))
 
     def list_clusters(self):
         reaper, args = ReaperCLI.prepare_reaper(

--- a/src/packaging/debian/cassandra-reaper.service
+++ b/src/packaging/debian/cassandra-reaper.service
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [Unit]
-Description=Cassandra Reaper
+Description=Reaper for Apache Cassandra
 Documentation=http://cassandra-reaper.io/
 Wants=remote-fs.target syslog.socket
 After=remote-fs.target syslog.socket

--- a/src/packaging/resource/cassandra-reaper-astra.yaml
+++ b/src/packaging/resource/cassandra-reaper-astra.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # See a bit more complete example in:
 # src/server/src/test/resources/cassandra-reaper.yaml
 segmentCountPerNode: 64

--- a/src/packaging/resource/cassandra-reaper-cassandra-sidecar.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra-sidecar.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # See a bit more complete example in:
 # src/server/src/test/resources/cassandra-reaper.yaml
 segmentCountPerNode: 64

--- a/src/packaging/resource/cassandra-reaper-cassandra-ssl.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra-ssl.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # See a bit more complete example in:
 # src/server/src/test/resources/cassandra-reaper.yaml
 segmentCountPerNode: 64

--- a/src/packaging/resource/cassandra-reaper-cassandra.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # See a bit more complete example in:
 # src/server/src/test/resources/cassandra-reaper.yaml
 segmentCountPerNode: 64

--- a/src/packaging/resource/cassandra-reaper-h2.yaml
+++ b/src/packaging/resource/cassandra-reaper-h2.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # See a bit more complete example in:
 # src/server/src/test/resources/cassandra-reaper.yaml
 segmentCountPerNode: 64

--- a/src/packaging/resource/cassandra-reaper-memory.yaml
+++ b/src/packaging/resource/cassandra-reaper-memory.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # See a bit more complete example in:
 # src/server/src/test/resources/cassandra-reaper.yaml
 segmentCountPerNode: 64

--- a/src/packaging/resource/cassandra-reaper-postgres.yaml
+++ b/src/packaging/resource/cassandra-reaper-postgres.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # See a bit more complete example in:
 # src/server/src/test/resources/cassandra-reaper.yaml
 segmentCountPerNode: 64

--- a/src/packaging/resource/cassandra-reaper-ssl.properties
+++ b/src/packaging/resource/cassandra-reaper-ssl.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper SSL Configuration Example.
+# Reaper for Apache Cassandra SSL Configuration Example.
 #
 # * Replace keyStore/trustStore parameter values with the real paths to
 #   your credentials files.

--- a/src/packaging/resource/cassandra-reaper.yaml
+++ b/src/packaging/resource/cassandra-reaper.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # See a bit more complete example in:
 # src/server/src/test/resources/cassandra-reaper.yaml
 segmentCountPerNode: 64

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -24,7 +24,7 @@
         <version>2.3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <name>Cassandra Reaper server</name>
+    <name>Reaper for Apache Cassandra server</name>
     <artifactId>cassandra-reaper</artifactId>
     <packaging>jar</packaging>
 

--- a/src/server/src/test/resources/cassandra-reaper-access-control-enabled-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-access-control-enabled-at.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/cassandra-reaper-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-at.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-cassandra-at.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-h2-at.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/cassandra-reaper-postgres-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-postgres-at.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/cassandra-reaper.yaml
+++ b/src/server/src/test/resources/cassandra-reaper.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration Example.
+# Reaper for Apache Cassandra Configuration Example.
 # This configuration is used mainly for testing.
 # See the README.md file for explanations of configuration keys.
 #

--- a/src/server/src/test/resources/reaper-cassandra-sidecar1-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar1-at.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/reaper-cassandra-sidecar2-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar2-at.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/reaper-cassandra-sidecar3-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar3-at.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/reaper-cassandra-sidecar4-at.yaml
+++ b/src/server/src/test/resources/reaper-cassandra-sidecar4-at.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/reaper-postgres-sidecar1-at.yaml
+++ b/src/server/src/test/resources/reaper-postgres-sidecar1-at.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/server/src/test/resources/reaper-postgres-sidecar2-at.yaml
+++ b/src/server/src/test/resources/reaper-postgres-sidecar2-at.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Cassandra Reaper Configuration for Acceptance Tests.
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
 #
 segmentCountPerNode: 16
 repairParallelism: SEQUENTIAL

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -1,4 +1,4 @@
-### Cassandra Reaper UI
+### Reaper for Apache Cassandra UI
 
 #### Thanks to
 
@@ -7,7 +7,7 @@ This subdirectory is a fork of the original [cassandra-reaper-ui project](https:
 
 #### About
 
-Complimentary web UI for [Cassandra Reaper](https://github.com/thelastpickle/cassandra-reaper).
+Complimentary web UI for [Reaper for Apache Cassandra](https://github.com/thelastpickle/cassandra-reaper).
 
 #### Installation
 

--- a/src/ui/app/html_template.ejs
+++ b/src/ui/app/html_template.ejs
@@ -23,7 +23,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>Cassandra Reaper<%= htmlWebpackPlugin.options.title %></title>
+    <title>Reaper for Apache Cassandra<%= htmlWebpackPlugin.options.title %></title>
 
     <!-- <base href="/webui/"> -->
     <script type="text/javascript">

--- a/src/ui/app/jsx/login-form.jsx
+++ b/src/ui/app/jsx/login-form.jsx
@@ -69,7 +69,7 @@ const loginForm = CreateReactClass({
     const form = <div className="row">
       <div className="col-lg-12">
         <div className="col-lg-4">&nbsp;</div>
-        <div className="col-lg-4"><h2>Cassandra Reaper</h2></div>
+        <div className="col-lg-4"><h2>Reaper for Apache Cassandra</h2></div>
         <div className="col-lg-4">&nbsp;</div>
       </div>
       <div className="col-lg-12">

--- a/src/ui/bower.json
+++ b/src/ui/bower.json
@@ -4,7 +4,7 @@
   "authors": [
     "Stefan Podkowinski <github@midnightdrift.com>"
   ],
-  "description": "Interactive web UI for Cassandra Reaper",
+  "description": "Interactive web UI for Reaper for Apache Cassandra",
   "main": "index.js",
   "private": true,
   "keywords": [

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cassandra-reaper-ui",
   "version": "0.2.0",
-  "description": "Interactive web UI for Cassandra Reaper",
+  "description": "Interactive web UI for Reaper for Apache Cassandra",
   "main": "index.js",
   "keywords": [
     "cassandra"


### PR DESCRIPTION
A phased approach, which includes rebranding for general docs and comments in support of [k8ssandra-483](https://github.com/k8ssandra/k8ssandra/issues/483).

Change of naming per requirement to replace `Cassandra Reaper` with the rebranded wording `Reaper for Apache Cassandra`.