### PR TITLE
Fix segment count per node not being correctly accounted for in schedules

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -100,7 +100,7 @@ public final class RepairRunResource {
       @QueryParam("tables") Optional<String> tableNamesParam,
       @QueryParam("owner") Optional<String> owner,
       @QueryParam("cause") Optional<String> cause,
-      @QueryParam("segmentCount") Optional<Integer> segmentCountPerNode,
+      @QueryParam("segmentCountPerNode") Optional<Integer> segmentCountPerNode,
       @QueryParam("repairParallelism") Optional<String> repairParallelism,
       @QueryParam("intensity") Optional<String> intensityStr,
       @QueryParam("incrementalRepair") Optional<String> incrementalRepairStr,

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -185,7 +185,7 @@ const repairForm = CreateReactClass({
     }
 
     if (this.state.tables) repair.tables = this.state.tables;
-    if (this.state.segments) repair.segmentCount = this.state.segments;
+    if (this.state.segments) repair.segmentCountPerNode = this.state.segments;
     if (this.state.parallelism) repair.repairParallelism = this.state.parallelism;
     if (this.state.intensity) repair.intensity = this.state.intensity;
     if (this.state.cause) repair.cause = this.state.cause;


### PR DESCRIPTION
The segment count per node was ignored in schedules as the UI didn't set the right query param:
The repair run resource was expecting `segmentCount` while the repair schedule resource was expecting `segmentCountPerNode`.

I've made both consistent to use `segmentCountPerNode` so that the setting is properly accounted for in both schedule and run creation.

Fixes #1030 