### PR TITLE
Add basic support for scylla 4.4 repair

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
@@ -64,6 +64,7 @@ public final class NodesStatus {
   private static final Pattern ENDPOINT_RELEASE_21_PATTERN = Pattern.compile("(RELEASE_VERSION)(:)([0-9.]+)");
   private static final Pattern ENDPOINT_SEVERITY_21_PATTERN = Pattern.compile("(SEVERITY)(:)([0-9.]+)");
   private static final Pattern ENDPOINT_HOSTID_21_PATTERN = Pattern.compile("(HOST_ID)(:)([0-9a-z-]+)");
+  private static final Pattern ENDPOINT_LOAD_SCYLLA_44_PATTERN = Pattern.compile("(LOAD)(:)([0-9eE.\\+]+)");
 
   private static final String NOT_AVAILABLE = "Not available";
 
@@ -114,7 +115,10 @@ public final class NodesStatus {
     // Cleanup hostnames from simpleStates keys
     Map<String, String> simpleStatesCopy = new HashMap<>();
     for (Map.Entry<String, String> entry: simpleStates.entrySet()) {
-      String entryKey = entry.getKey().substring(entry.getKey().indexOf('/'));
+      String entryKey = "/" + entry.getKey();
+      if (entry.getKey().indexOf('/') != -1) {
+        entryKey = entry.getKey().substring(entry.getKey().indexOf('/'));
+      }
       simpleStatesCopy.put(entryKey, entry.getValue());
     }
     simpleStates = simpleStatesCopy;
@@ -197,7 +201,8 @@ public final class NodesStatus {
         Arrays.asList(ENDPOINT_STATUS_40_PATTERN, ENDPOINT_STATUS_22_PATTERN, ENDPOINT_STATUS_21_PATTERN));
     ENDPOINT_DC_PATTERNS.addAll(Arrays.asList(ENDPOINT_DC_22_PATTERN, ENDPOINT_DC_21_PATTERN));
     ENDPOINT_RACK_PATTERNS.addAll(Arrays.asList(ENDPOINT_RACK_22_PATTERN, ENDPOINT_RACK_21_PATTERN));
-    ENDPOINT_LOAD_PATTERNS.addAll(Arrays.asList(ENDPOINT_LOAD_22_PATTERN, ENDPOINT_LOAD_21_PATTERN));
+    ENDPOINT_LOAD_PATTERNS.addAll(Arrays.asList(ENDPOINT_LOAD_22_PATTERN, ENDPOINT_LOAD_SCYLLA_44_PATTERN,
+            ENDPOINT_LOAD_21_PATTERN));
     ENDPOINT_RELEASE_PATTERNS.addAll(Arrays.asList(ENDPOINT_RELEASE_22_PATTERN, ENDPOINT_RELEASE_21_PATTERN));
     ENDPOINT_SEVERITY_PATTERNS.addAll(Arrays.asList(ENDPOINT_SEVERITY_22_PATTERN, ENDPOINT_SEVERITY_21_PATTERN));
     ENDPOINT_HOSTID_PATTERNS.addAll(Arrays.asList(ENDPOINT_HOSTID_22_PATTERN, ENDPOINT_HOSTID_21_PATTERN));

--- a/src/server/src/test/java/io/cassandrareaper/jmx/ClusterFacadeTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/ClusterFacadeTest.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,6 +41,8 @@ import com.google.common.io.Resources;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static io.cassandrareaper.service.RepairRunnerTest.scyllaThreeNodeClusterWithIps;
+import static io.cassandrareaper.service.RepairRunnerTest.threeNodeClusterWithIps;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -169,6 +172,23 @@ public class ClusterFacadeTest {
     String compactionJson = "";
     CompactionStats compactionStats = ClusterFacade.parseCompactionStats(compactionJson);
     assertFalse(compactionStats.getPendingCompactions().isPresent());
+  }
+
+  @Test
+  public void endpointCleanupCassandra() {
+    Map<List<String>, List<String>> endpoints = ClusterFacade.maybeCleanupEndpointFromScylla(threeNodeClusterWithIps());
+    for (Map.Entry<List<String>, List<String>> entry : endpoints.entrySet()) {
+      assertEquals(endpoints,threeNodeClusterWithIps());
+    }
+  }
+
+  @Test
+  public void endpointCleanupScylla() {
+    Map<List<String>, List<String>> endpoints
+            = ClusterFacade.maybeCleanupEndpointFromScylla(scyllaThreeNodeClusterWithIps());
+    for (Map.Entry<List<String>, List<String>> entry : endpoints.entrySet()) {
+      assertEquals(endpoints,threeNodeClusterWithIps());
+    }
   }
 
 }

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -760,6 +760,15 @@ public final class RepairRunnerTest {
     return map;
   }
 
+  public static Map<List<String>, List<String>> scyllaThreeNodeClusterWithIps() {
+    Map<List<String>, List<String>> map = new HashMap<List<String>, List<String>>();
+    map = addRangeToMap(map, "", "0", "127.0.0.3", "127.0.0.1", "127.0.0.2");
+    map = addRangeToMap(map, "0", "100", "127.0.0.1", "127.0.0.2", "127.0.0.3");
+    map = addRangeToMap(map, "100", "200", "127.0.0.2", "127.0.0.3", "127.0.0.1");
+    map = addRangeToMap(map, "200", "", "127.0.0.3", "127.0.0.1", "127.0.0.2");
+    return map;
+  }
+
   public static Map<List<String>, List<String>> sixNodeCluster() {
     Map<List<String>, List<String>> map = new HashMap<List<String>, List<String>>();
     map = addRangeToMap(map, "0", "50", "a1", "a2", "a3");


### PR DESCRIPTION
On scylla 4.4 release includes this [change](https://github.com/scylladb/scylla/commit/48c3c94aa6c4c301c02c0dddac0711eb6dc262c7) which can now be used from cassandra reaper to run repairs (see #968 for some context). Sadly the data returned from that method have a slightly different format, for example if cassandra return as example:
```
  public static Map<List<String>, List<String>> threeNodeClusterWithIps() {
    Map<List<String>, List<String>> map = new HashMap<List<String>, List<String>>();
    map = addRangeToMap(map, "0", "100", "127.0.0.1", "127.0.0.2", "127.0.0.3");
    map = addRangeToMap(map, "100", "200", "127.0.0.2", "127.0.0.3", "127.0.0.1");
    map = addRangeToMap(map, "200", "0", "127.0.0.3", "127.0.0.1", "127.0.0.2");
    return map;
  }
```
scylla example:

```
  public static Map<List<String>, List<String>> scyllaThreeNodeClusterWithIps() {
    Map<List<String>, List<String>> map = new HashMap<List<String>, List<String>>();
    map = addRangeToMap(map, "", "0", "127.0.0.3", "127.0.0.1", "127.0.0.2");
    map = addRangeToMap(map, "0", "100", "127.0.0.1", "127.0.0.2", "127.0.0.3");
    map = addRangeToMap(map, "100", "200", "127.0.0.2", "127.0.0.3", "127.0.0.1");
    map = addRangeToMap(map, "200", "", "127.0.0.3", "127.0.0.1", "127.0.0.2");
    return map;
  }
```

this PR is to handle correctly scylla format, plus some string cleanup/handling. It's not aimed at supporting scylla for all cassandra reaper features, but mostly to be able to run repair/scheduled repairs, in particular with changes included in this PR you would be able to:
- add a scylla cluster to cassandra reaper without causing exception/issues on the web UI
- create a repair/scheduled repair and execute it


