### PR TITLE
Publish releases to Cloudsmith

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -846,72 +846,22 @@ jobs:
           DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: ./.github/scripts/before_deploy.sh
 
-      - name: Upload deb package to Bintray
+      - name: Locate deb and rpm packages for upload
         run: |
           REPO=reaper-deb
           PACKAGE=cassandra-reaper
           VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
           if [ "${GITHUB_REF}" = "refs/heads/master" ]
           then
-            REPO=reaper-deb-beta
-            PACKAGE=cassandra-reaper-beta
+            echo "BETA_RELEASE=yes" >> $GITHUB_ENV
+          else
+            echo "BETA_RELEASE=no" >> $GITHUB_ENV
           fi
 
-          releaseFile=$(ls src/packages/*.deb |grep ${VERSION})
-          targetName=reaper_${VERSION}_amd64.deb
-          echo "uploading ${releaseFile} to Bintray"
-          echo "Upload url : https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${targetName}"
-          curl -T ${releaseFile} \
-            -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} \
-            -H X-Bintray-Debian-Distribution:wheezy,jessie,stretch -H X-Bintray-Debian-Component:main -H X-Bintray-Debian-Architecture:i386,amd64 -H X-Bintray-Version:${VERSION} \
-            https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${targetName}
-          echo "Publishing release in Bintray"
-          curl -X POST -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${VERSION}/publish
-
-      - name: Upload rpm package to Bintray
-        run: |
-          REPO=reaper-rpm
-          PACKAGE=cassandra-reaper
-          VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
-          RPM_VERSION=$(echo "${VERSION}" | sed "s/-/_/")
-          if [ "${GITHUB_REF}" = "refs/heads/master" ]
-          then
-            REPO=reaper-rpm-beta
-            PACKAGE=cassandra-reaper-beta
-          fi
-
-          releaseFile=$(ls src/packages/*.rpm)
-          targetName=reaper-${RPM_VERSION}-1.x86_64.rpm
-          echo "uploading ${releaseFile} to Bintray"
-          echo "Upload url : https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${targetName}"
-          curl -T ${releaseFile} \
-            -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} \
-            -H X-Bintray-Version:${VERSION} \
-            https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${targetName}
-          echo "Publishing release in Bintray"
-          curl -X POST -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${VERSION}/publish
-
-      - name: Upload tarball package to Bintray
-        run: |
-          REPO=reaper-tarball
-          PACKAGE=cassandra-reaper
-          VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
-          if [ "${GITHUB_REF}" = "refs/heads/master" ]
-          then
-            REPO=reaper-tarball-beta
-            PACKAGE=cassandra-reaper-beta
-          fi
-
-          releaseFile=$(ls src/packages/*.tar.gz |grep ${VERSION})
-          targetName=cassandra-reaper-${VERSION}.tar.gz
-          echo "uploading ${releaseFile} to Bintray"
-          echo "Upload url : https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${targetName}"
-          curl -T ${releaseFile} \
-            -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} \
-            -H X-Bintray-Version:${VERSION} \
-            https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${targetName}
-          echo "Publishing release in Bintray"
-          curl -X POST -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${VERSION}/publish
+          debReleaseFile=$(ls src/packages/*.deb |grep ${VERSION})
+          rpmReleaseFile=$(ls src/packages/*.rpm)
+          echo "DEB_RELEASE_FILE=${releaseFile}" >> $GITHUB_ENV
+          echo "RPM_RELEASE_FILE=${releaseFile}" >> $GITHUB_ENV
 
       - name: Upload artifacts to GitHub Release
         uses: fnkr/github-action-ghr@v1
@@ -920,49 +870,65 @@ jobs:
           GHR_PATH: src/packages
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload maven artifacts to Bintray
-        run: |
-          REPO=reaper-maven
-          PACKAGE=io.cassandrareaper:cassandra-reaper
-          VERSION=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
-          if [ "${GITHUB_REF}" = "refs/heads/master" ]
-          then
-            REPO=reaper-maven-beta
-          fi
+      ## Stable releases
+      - name: Push Debian to Cloudsmith
+        id: push-deb
+        if: ${{ env.BETA_RELEASE == 'no' }}
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: 'push'
+          format: 'deb'
+          owner: 'thelastpickle'
+          repo: 'reaper'
+          distro: 'any-distro'
+          release: 'any-version'
+          republish: 'true'
+          file: ${{ env.DEB_RELEASE_FILE }}
 
-          jarFile=cassandra-reaper-${VERSION}.jar
-          releaseFile=$(ls src/server/target/${jarFile})
-          sourceFile=cassandra-reaper-${VERSION}-sources.jar
-          javadocFile=cassandra-reaper-${VERSION}-javadoc.jar
-          echo "uploading ${releaseFile} to Bintray"
-          echo "Upload url : https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/io/cassandrareaper/cassandra-reaper/${VERSION}"
+      - name: Push RPM to Cloudsmith
+        id: push-rpm
+        if: ${{ env.BETA_RELEASE == 'no' }}
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: "push"
+          format: "rpm"
+          owner: 'thelastpickle'
+          repo: 'reaper'
+          distro: 'any-distro'
+          release: 'any-version'
+          republish: 'true'
+          file: ${{ env.RPM_RELEASE_FILE }}
+      
+      ## Beta releases
+      - name: Push Debian Beta to Cloudsmith
+        id: push-beta-deb
+        if: ${{ env.BETA_RELEASE == 'yes' }}
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: 'push'
+          format: 'deb'
+          owner: 'thelastpickle'
+          repo: 'reaper-beta'
+          distro: 'any-distro'
+          release: 'any-version'
+          republish: 'true'
+          file: ${{ env.DEB_RELEASE_FILE }}
 
-          # Upload the main jar
-          curl -T src/server/target/${jarFile} \
-            -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} \
-            -H X-Bintray-Version:${VERSION} \
-            https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/io/cassandrareaper/cassandra-reaper/${VERSION}/${jarFile}
-          # Upload the sources jar
-          curl -T src/server/target/${sourceFile} \
-            -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} \
-            -H X-Bintray-Version:${VERSION} \
-            https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/io/cassandrareaper/cassandra-reaper/${VERSION}/${sourceFile}
-          # Upload the javadoc jar
-          curl -T src/server/target/${javadocFile} \
-            -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} \
-            -H X-Bintray-Version:${VERSION} \
-            https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/io/cassandrareaper/cassandra-reaper/${VERSION}/${javadocFile}
-          # Upload the pom file
-          curl -T src/server/pom.xml \
-            -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} \
-            -H X-Bintray-Version:${VERSION} \
-            https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/io/cassandrareaper/cassandra-reaper/${VERSION}/cassandra-reaper-${VERSION}.pom
-          # Upload the root pom file
-          curl -T pom.xml \
-            -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} \
-            -H X-Bintray-Version:${VERSION} \
-            https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/io/cassandrareaper/cassandra-reaper/${VERSION}/cassandra-reaper-pom-${VERSION}.pom
-
-          # Publish the release
-          echo "Publishing release in Bintray"
-          curl -X POST -u${{ secrets.BINTRAY_USERNAME }}:${{ secrets.BINTRAY_API_KEY }} https://api.bintray.com/content/thelastpickle/${REPO}/${PACKAGE}/${VERSION}/publish
+      - name: Push RPM Beta to Cloudsmith
+        id: push-beta-rpm
+        if: ${{ env.BETA_RELEASE == 'yes' }}
+        uses: cloudsmith-io/action@master
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          command: "push"
+          format: "rpm"
+          owner: 'thelastpickle'
+          repo: 'reaper-beta'
+          distro: 'any-distro'
+          release: 'any-version'
+          republish: 'true'
+          file: ${{ env.RPM_RELEASE_FILE }}
+      

--- a/README.md
+++ b/README.md
@@ -1,30 +1,24 @@
 Reaper for Apache Cassandra
 ============================
 
-[![Join the chat at https://gitter.im/thelastpickle/cassandra-reaper](https://badges.gitter.im/thelastpickle/cassandra-reaper.svg)](https://gitter.im/thelastpickle/cassandra-reaper?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://github.com/thelastpickle/cassandra-reaper/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/thelastpickle/cassandra-reaper/actions?query=branch%3Amaster)
 
-[![Build Status](https://travis-ci.org/thelastpickle/cassandra-reaper.svg?branch=master)](https://travis-ci.org/thelastpickle/cassandra-reaper/branches)
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square)](https://cloudsmith.io/~thelastpickle/repos/reaper/packages/)
 
-*Note: This repo is a fork from the original Reaper project, created by the awesome folks at Spotify.  The WebUI has been merged in with support for incremental repairs added.* 
+Reaper is a centralized, stateful, and highly configurable tool for running Apache Cassandra repairs against single or multi-site clusters.
 
-Reaper is a centralized, stateful, and highly configurable tool for running Apache Cassandra
-repairs against single or multi-site clusters.
-
-The current version supports running Apache Cassandra cluster repairs in a segmented manner, 
-opportunistically running multiple parallel repairs at the same time on different nodes
-within the cluster. Basic repair scheduling functionality is also supported.
+The current version supports running Apache Cassandra cluster repairs in a segmented manner,  opportunistically running multiple parallel repairs at the same time on different nodes within the cluster. Basic repair scheduling functionality is also supported.
 
 Reaper comes with a GUI, which if you're running in local mode can be at http://localhost:8080/webui/ 
 
-Please see the [Issues](https://github.com/thelastpickle/cassandra-reaper/issues) section for more
-information on planned development, and known issues.
+Please see the [Issues](https://github.com/thelastpickle/cassandra-reaper/issues) section for more information on planned development, and known issues.
 
 Documentation and Help
 ------------------------
 
 The full documentation is available at the [Reaper website](http://cassandra-reaper.io/).  The source for the site is located in this repo at `src/docs`.
 
-Have a question?  Please ask on the [reaper mailing list](https://groups.google.com/forum/#!forum/tlp-apache-cassandra-reaper-users)! 
+Have a question?  Join us on [the ASF Slack](https://the-asf.slack.com/) in the #cassandra-reaper channel.
 
 
 System Overview
@@ -44,3 +38,5 @@ be used only for testing purposes.
 This project is built on top of Dropwizard:
 http://dropwizard.io/
 
+
+*Note: This repo is a fork from the original Reaper project, created by the awesome folks at Spotify.* 

--- a/src/docs/content/docs/download/install.md
+++ b/src/docs/content/docs/download/install.md
@@ -23,7 +23,7 @@ Reaper can also be accessed using the REST API exposed on port 8080, or using th
 
 ## Installing and Running as a Service
 
-We provide prebuilt packages for reaper on the [Bintray](https://bintray.com/thelastpickle).
+We provide prebuilt packages for reaper on [Cloudsmith](https://cloudsmith.io/~thelastpickle/repos/).
 
 
 ### RPM Install (CentOS, Fedora, RHEK)
@@ -36,64 +36,37 @@ sudo rpm -ivh reaper-*.*.*.x86_64.rpm
 
 #### Using yum (stable releases)
 
-1/ Run the following to get a generated .repo file:
+1/ Run the following to install the repo:
 ```
-wget https://bintray.com/thelastpickle/reaper-rpm/rpm -O bintray-thelastpickle-reaper-rpm.repo
-```
-
-or - Copy this text into a 'bintray-thelastpickle-reaper-rpm.repo' file on your Linux machine:
-
-```
-#bintraybintray-thelastpickle-reaper-rpm - packages by thelastpickle from Bintray
-[bintraybintray-thelastpickle-reaper-rpm]
-name=bintray-thelastpickle-reaper-rpm
-baseurl=https://dl.bintray.com/thelastpickle/reaper-rpm
-gpgcheck=0
-repo_gpgcheck=0
-enabled=1
-``` 
-
-2/ Run the following command : 
-```
-sudo mv bintray-thelastpickle-reaper-rpm.repo /etc/yum.repos.d/
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/thelastpickle/reaper/setup.rpm.sh' \
+  | sudo -E bash
 ```
 
-3/ Install reaper : 
+2/ Install reaper : 
 
 ```
 sudo yum install reaper
 ```
+
+In case of problem, check the alternate procedure on [cloudsmith.io](https://cloudsmith.io/~thelastpickle/repos/reaper/setup/#formats-rpm).
 
 #### Using yum (development builds)
 
-1/ Run the following to get a generated .repo file:
+1/ Run the following to install the repo:
 ```
-wget https://bintray.com/thelastpickle/reaper-rpm-beta/rpm -O bintray-thelastpickle-reaper-rpm-beta.repo
-```
-
-or - Copy this text into a 'bintray-thelastpickle-reaper-rpm-beta.repo' file on your Linux machine:
-
-```
-#bintraybintray-thelastpickle-reaper-rpm-beta - packages by thelastpickle from Bintray
-[bintraybintray-thelastpickle-reaper-rpm-beta]
-name=bintray-thelastpickle-reaper-rpm-beta
-baseurl=https://dl.bintray.com/thelastpickle/reaper-rpm-beta
-gpgcheck=0
-repo_gpgcheck=0
-enabled=1
-```  
-
-2/ Run the following command : 
-```
-sudo mv bintray-thelastpickle-reaper-rpm-beta.repo /etc/yum.repos.d/
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/thelastpickle/reaper-beta/setup.rpm.sh' \
+  | sudo -E bash
 ```
 
-3/ Install reaper : 
+2/ Install reaper : 
 
 ```
 sudo yum install reaper
 ```
 
+In case of problem, check the alternate procedure on [cloudsmith.io](https://cloudsmith.io/~thelastpickle/repos/reaper-beta/setup/#formats-rpm).
 
 ### DEB (Debian based distros like Ubuntu)
 
@@ -105,54 +78,39 @@ sudo dpkg -i reaper_*.*.*_amd64.deb
 
 #### Using apt-get (stable releases)
 
-1/ Using the command line, add the following to your /etc/apt/sources.list system config file: 
+1/ Using the command line, run the following:
 ```
-echo "deb https://dl.bintray.com/thelastpickle/reaper-deb wheezy main" | sudo tee -a /etc/apt/sources.list
-```
-
-Or, add the repository URLs using the "Software Sources" admin UI:
-
-```
-deb https://dl.bintray.com/thelastpickle/reaper-deb wheezy main
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/thelastpickle/reaper/setup.deb.sh' \
+  | sudo -E bash
 ```
 
-2/ Install the public key:
-```
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 2895100917357435
-```
-
-3/ Install reaper :
+2/ Install reaper :
 
 ```
 sudo apt-get update
 sudo apt-get install reaper
 ```
+
+In case of problem, check the alternate procedure on [cloudsmith.io](https://cloudsmith.io/~thelastpickle/repos/reaper/setup/#formats-deb).
 
 #### Using apt-get (development builds)
 
-1/ Using the command line, add the following to your /etc/apt/sources.list system config file:
+1/ Using the command line, run the following command:
 ```
-echo "deb https://dl.bintray.com/thelastpickle/reaper-deb-beta wheezy main" | sudo tee -a /etc/apt/sources.list
-```
-
-Or, add the repository URLs using the "Software Sources" admin UI:
-
-```
-deb https://dl.bintray.com/thelastpickle/reaper-deb-beta wheezy main
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/thelastpickle/reaper-beta/setup.deb.sh' \
+  | sudo -E bash
 ```
 
-2/ Install the public key:
-```
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 2895100917357435
-```
-
-3/ Install reaper :
+2/ Install reaper :
 
 ```
 sudo apt-get update
 sudo apt-get install reaper
 ```
 
+In case of problem, check the alternate procedure on [cloudsmith.io](https://cloudsmith.io/~thelastpickle/repos/reaper-beta/setup/#formats-deb).
 
 ## Service Configuration
 


### PR DESCRIPTION
Bintray is closing down on May 1st and Cloudsmith looks like a solid replacement for it, providing most of the features we were getting from JFrog's tool (minus the Maven Central sync).