### PR TITLE
Fix gossip state parsing for 4.0 rc1

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
@@ -49,6 +49,7 @@ public final class NodesStatus {
   private static final Pattern ENDPOINT_NAME_PATTERN_IP6
           = Pattern.compile("^([0-9:a-fA-F\\]\\[]{3,41})", Pattern.MULTILINE | Pattern.DOTALL);
   private static final Pattern ENDPOINT_STATUS_22_PATTERN = Pattern.compile("(STATUS):([0-9]*):(\\w+)");
+  private static final Pattern ENDPOINT_STATUS_40_PATTERN = Pattern.compile("(STATUS_WITH_PORT):([0-9]*):(\\w+)");
   private static final Pattern ENDPOINT_DC_22_PATTERN = Pattern.compile("(DC):([0-9]*):([0-9a-zA-Z-\\.]+)");
   private static final Pattern ENDPOINT_RACK_22_PATTERN = Pattern.compile("(RACK):([0-9]*):([0-9a-zA-Z-\\.]+)");
   private static final Pattern ENDPOINT_LOAD_22_PATTERN = Pattern.compile("(LOAD):([0-9]*):([0-9eE.]+)");
@@ -192,7 +193,8 @@ public final class NodesStatus {
 
   private static void initPatterns() {
     ENDPOINT_NAME_PATTERNS.addAll(Arrays.asList(ENDPOINT_NAME_PATTERN_IP4, ENDPOINT_NAME_PATTERN_IP6));
-    ENDPOINT_STATUS_PATTERNS.addAll(Arrays.asList(ENDPOINT_STATUS_22_PATTERN, ENDPOINT_STATUS_21_PATTERN));
+    ENDPOINT_STATUS_PATTERNS.addAll(
+        Arrays.asList(ENDPOINT_STATUS_40_PATTERN, ENDPOINT_STATUS_22_PATTERN, ENDPOINT_STATUS_21_PATTERN));
     ENDPOINT_DC_PATTERNS.addAll(Arrays.asList(ENDPOINT_DC_22_PATTERN, ENDPOINT_DC_21_PATTERN));
     ENDPOINT_RACK_PATTERNS.addAll(Arrays.asList(ENDPOINT_RACK_22_PATTERN, ENDPOINT_RACK_21_PATTERN));
     ENDPOINT_LOAD_PATTERNS.addAll(Arrays.asList(ENDPOINT_LOAD_22_PATTERN, ENDPOINT_LOAD_21_PATTERN));

--- a/src/server/src/test/java/io/cassandrareaper/resources/view/NodesStatusTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/view/NodesStatusTest.java
@@ -33,21 +33,45 @@ import static org.junit.Assert.assertTrue;
 public final class NodesStatusTest {
 
   @Test
-  public void testParseIPv4Endpoint22StatusString() {
+  public void testParseIPv4EndpointStatusString() {
     testParseEndpoint22StatusString(
         "127.0.0.1",
         "/127.0.0.1",
         "/127.0.0.2",
         "/127.0.0.3");
+
+    testParseEndpoint21StatusString(
+        "127.0.0.1",
+        "/127.0.0.1",
+        "/127.0.0.2",
+        "/127.0.0.3");
+
+    testParseEndpoint40StatusString(
+          "127.0.0.1",
+          "/127.0.0.1",
+          "/127.0.0.2",
+          "/127.0.0.3");
   }
 
   @Test
-  public void testParseIPv4Endpoint22WithHostnameStatusString() {
+  public void testParseIPv4EndpointWithHostnameStatusString() {
     testParseEndpoint22StatusString(
         "127.0.0.1",
         "localhost/127.0.0.1",
         "/127.0.0.2",
         "localhost3/127.0.0.3");
+
+    testParseEndpoint21StatusString(
+        "127.0.0.1",
+        "localhost/127.0.0.1",
+        "/127.0.0.2",
+        "localhost3/127.0.0.3");
+
+    testParseEndpoint40StatusString(
+          "127.0.0.1",
+          "localhost/127.0.0.1",
+          "/127.0.0.2",
+          "localhost3/127.0.0.3");
   }
 
   @Test
@@ -66,24 +90,6 @@ public final class NodesStatusTest {
         "a.example.com/2a02:6b8f:b010:61aa:34b3:7805:1d3d:3b20",
         "b.example.com/[2a02:6b8f:b010:61aa:34b3:7805:1d3d:3b21]",
         "c.example.com/2a:6:b0:61aa:34b3:7805:1d3d:32");
-  }
-
-  @Test
-  public void testParseIPv4Endpoint21StatusString() {
-    testParseEndpoint21StatusString(
-        "127.0.0.1",
-        "/127.0.0.1",
-        "/127.0.0.2",
-        "/127.0.0.3");
-  }
-
-  @Test
-  public void testParseIPv4Endpoint21WithHostnameStatusString() {
-    testParseEndpoint21StatusString(
-        "127.0.0.1",
-        "localhost1/127.0.0.1",
-        "localhost2/127.0.0.2",
-        "localhost3/127.0.0.3");
   }
 
   @Test
@@ -178,6 +184,89 @@ public final class NodesStatusTest {
             + "  generation:1496849191\n"
             + "  heartbeat:1230183\n"
             + "  STATUS:16:NORMAL,3074457345618258602\n"
+            + "  LOAD:1230134:3.974144E6\n"
+            + "  SCHEMA:10:2de0af6a-bf86-38e0-b62b-474ff6aefb51\n"
+            + "  DC:6:us-west-1\n"
+            + "  RACK:8:rack3\n"
+            + "  RELEASE_VERSION:4:3.0.8\n"
+            + "  RPC_ADDRESS:3:127.0.0.3\n"
+            + "  SEVERITY:1230182:0.0\n"
+            + "  NET_VERSION:1:10\n"
+            + "  HOST_ID:2:20769fed-7916-4b7a-a729-8b99bcdc9b95\n"
+            + "  RPC_READY:44:true\n"
+            + "  TOKENS:15:<hidden>\n";
+
+    simpleStates.put(endpoint1, "DOWN");
+    simpleStates.put(endpoint3, "UP");
+
+    NodesStatus nodesStatus = new NodesStatus(sourceNode, endpointsStatusString, simpleStates);
+
+    assertEquals(1, nodesStatus.endpointStates.size());
+    assertEquals(sourceNode, nodesStatus.endpointStates.get(0).sourceNode);
+
+    Map<String, Map<String, List<EndpointState>>> endpoints = nodesStatus.endpointStates.get(0).endpoints;
+    assertEquals(1, endpoints.get("datacenter1").keySet().size());
+    assertEquals(1, endpoints.get("datacenter1").get("rack1").size());
+    assertEquals("NORMAL - DOWN", endpoints.get("datacenter1").get("rack1").get(0).status);
+    assertEquals("NORMAL - UNKNOWN", endpoints.get("datacenter2").get("rack2").get(0).status);
+    assertEquals("NORMAL - UP", endpoints.get("us-west-1").get("rack3").get(0).status);
+    assertEquals(afterSlash(endpoint1), endpoints.get("datacenter1").get("rack1").get(0).endpoint);
+    assertEquals("f091f82b-ce2c-40ee-b30c-6e761e94e821", endpoints.get("datacenter1").get("rack1").get(0).hostId);
+    assertEquals("13", endpoints.get("datacenter1").get("rack1").get(0).tokens);
+    assertTrue(endpoints.get("datacenter1").get("rack1").get(0).severity.equals(0.0));
+    assertEquals("3.0.8", endpoints.get("datacenter1").get("rack1").get(0).releaseVersion);
+    assertEquals("datacenter2", endpoints.get("datacenter2").get("rack2").get(0).dc);
+    assertEquals("rack2", endpoints.get("datacenter2").get("rack2").get(0).rack);
+    assertEquals("us-west-1", endpoints.get("us-west-1").get("rack3").get(0).dc);
+    assertEquals("rack3", endpoints.get("us-west-1").get("rack3").get(0).rack);
+    assertEquals(afterSlash(endpoint3), endpoints.get("us-west-1").get("rack3").get(0).endpoint);
+    assertTrue(endpoints.get("us-west-1").get("rack3").get(0).load.equals(3974144.0));
+
+    assertTrue(nodesStatus.endpointStates.get(0).endpointNames.contains(afterSlash(endpoint1)));
+    assertTrue(nodesStatus.endpointStates.get(0).endpointNames.contains(afterSlash(endpoint2)));
+    assertTrue(nodesStatus.endpointStates.get(0).endpointNames.contains(afterSlash(endpoint3)));
+  }
+
+
+  private void testParseEndpoint40StatusString(String sourceNode,
+                                               String endpoint1, String endpoint2, String endpoint3) {
+    Map<String, String> simpleStates = Maps.newHashMap();
+
+    String endpointsStatusString = endpoint1 + "\n"
+            + "  generation:1496849190\n"
+            + "  heartbeat:1231900\n"
+            + "  STATUS_WITH_PORT:14:NORMAL,-9223372036854775808\n"
+            + "  LOAD:1231851:4043215.0\n"
+            + "  SCHEMA:10:2de0af6a-bf86-38e0-b62b-474ff6aefb51\n"
+            + "  DC:6:datacenter1\n"
+            + "  RACK:8:rack1\n"
+            + "  RELEASE_VERSION:4:3.0.8\n"
+            + "  RPC_ADDRESS:3:127.0.0.1\n"
+            + "  SEVERITY:1231899:0.0\n"
+            + "  NET_VERSION:1:10\n"
+            + "  HOST_ID:2:f091f82b-ce2c-40ee-b30c-6e761e94e821\n"
+            + "  RPC_READY:16:true\n"
+            + "  TOKENS:13:<hidden>\n"
+            + endpoint2 + "\n"
+            + "  generation:1497347537\n"
+            + "  heartbeat:27077\n"
+            + "  STATUS:14:NORMAL,-3074457345618258603\n"
+            + "  LOAD:1231851:3988763.0\n"
+            + "  SCHEMA:10:2de0af6a-bf86-38e0-b62b-474ff6aefb51\n"
+            + "  DC:6:datacenter2\n"
+            + "  RACK:8:rack2\n"
+            + "  RELEASE_VERSION:4:3.0.8\n"
+            + "  RPC_ADDRESS:3:127.0.0.2\n"
+            + "  SEVERITY:1231899:0.0\n"
+            + "  NET_VERSION:1:10\n"
+            + "  STATUS_WITH_PORT:14:NORMAL,-3074457345618258603\n"
+            + "  HOST_ID:2:08f819b5-d96f-444e-9d4d-ec4136e1b716\n"
+            + "  RPC_READY:16:true\n"
+            + "  TOKENS:13:<hidden>\n"
+            + endpoint3 + "\n"
+            + "  generation:1496849191\n"
+            + "  heartbeat:1230183\n"
+            + "  STATUS_WITH_PORT:16:NORMAL,3074457345618258602\n"
             + "  LOAD:1230134:3.974144E6\n"
             + "  SCHEMA:10:2de0af6a-bf86-38e0-b62b-474ff6aefb51\n"
             + "  DC:6:us-west-1\n"


### PR DESCRIPTION
fixes #1086 

4.0~rc1 introduced a new variable to replace STATUS named STATUS_WITH_PORT.
This PR takes it into account so that nodes can show up in the cluster view with the proper status.