### PR TITLE
Add schema migration startup mode

### DIFF
--- a/src/docs/content/docs/_index.md
+++ b/src/docs/content/docs/_index.md
@@ -8,7 +8,7 @@ show_menu = true
 
 Reaper is an open source tool that aims to schedule and orchestrate repairs of Apache Cassandra clusters.
 
-It improves the existing nodetool repair process by
+It improves the existing nodetool repair process by:  
 
 * Splitting repair jobs into smaller tunable segments.
 * Handling back-pressure through monitoring running repairs and pending compactions.

--- a/src/docs/content/docs/configuration/docker_vars.md
+++ b/src/docs/content/docs/configuration/docker_vars.md
@@ -50,7 +50,7 @@ The Docker environment variables listed in this section map directly to Reaper s
 <code class="codeLarge">REAPER_SERVER_APP_PORT</code> | [port]({{< relref "reaper_specific.md#port" >}}) | 8080
 <code class="codeLarge">REAPER_STORAGE_TYPE</code> | [storageType]({{< relref "reaper_specific.md#storagetype" >}}) | memory
 <code class="codeLarge">REAPER_USE_ADDRESS_TRANSLATOR</code> | [useAddressTranslator]({{< relref "reaper_specific.md#useaddresstranslator" >}}) | false
-<code class="codeLarge">REAPER_MAX_PARALLEL_REPAIRS</code> | [maxParallelRepairs]({{< relref "reaper_specific.md#maxParallelRepairs" >}}) | false
+<code class="codeLarge">REAPER_MAX_PARALLEL_REPAIRS</code> | [maxParallelRepairs]({{< relref "reaper_specific.md#maxParallelRepairs" >}}) | 2
 
 <br/>
 

--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -538,4 +538,3 @@ Type: *String*
 
 The key of a system property that holds the shared secret for the symmetric encryption.  If encrypted text is required, then this key and its value need to be defined in the environment before reaper can be started.  
 ```export SOME_SYSTEM_PROPERTY_KEY=mysharedsecret```
-

--- a/src/docs/content/docs/usage/_index.md
+++ b/src/docs/content/docs/usage/_index.md
@@ -5,6 +5,23 @@ weight = 25
 identifier = "usage"
 +++
 
+# Starting Reaper
+
+The preferred way of running Reaper is to make it a service, which is the default for debian and RPM packaged installations.
+It can also be started from the command line for tarball/source installs, in two different ways:
+
+- by invoking `src/packaging/bin/cassandra-reaper`
+- by running `java -jar <path/to/cassandra-reaper-X.X.X.jar> server <path/to/cassandra-reaper.yaml>`
+
+# Schema migrations
+
+Schema migrations are executed on startup and assume that the database/keyspace already exists.
+Reaper can run in schema migration mode only, exiting right after the database schema was upgraded, by running the following command:
+
+```
+java -jar <path/to/cassandra-reaper-X.X.X.jar> schema-migration <path/to/cassandra-reaper.yaml>
+```
+
 # Using Reaper
 
 This section discusses the normal usage of Reaper on a day to day basis.

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -46,6 +46,21 @@ if [ "$1" = 'cassandra-reaper' ]; then
             /etc/cassandra-reaper.yml
 fi
 
+if [ "$1" = 'schema-migration' ]; then
+
+    # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper.yml: Interrupted system call` unknown error
+    touch /etc/cassandra-reaper.yml
+
+    /usr/local/bin/configure-persistence.sh
+    /usr/local/bin/configure-webui-authentication.sh
+    /usr/local/bin/configure-metrics.sh
+    /usr/local/bin/configure-jmx-credentials.sh
+    exec java \
+            ${JAVA_OPTS} \
+            -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication schema-migration \
+            /etc/cassandra-reaper.yml
+fi
+
 if [ "$1" = 'register-clusters' ]; then
 
   if [ -z "$2" ]; then

--- a/src/server/src/main/java/io/cassandrareaper/ReaperDbMigrationCommand.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperDbMigrationCommand.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper;
+
+import io.cassandrareaper.storage.InitializeStorage;
+
+import javax.validation.Validation;
+
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+final class ReaperDbMigrationCommand extends ConfiguredCommand<ReaperApplicationConfiguration> {
+
+  protected ReaperDbMigrationCommand(
+      String name,
+      String description
+  ) {
+    super(name, description);
+  }
+
+  @Override
+  protected void run(
+      Bootstrap<ReaperApplicationConfiguration> bootstrap,
+      Namespace namespace,
+      ReaperApplicationConfiguration configuration
+  ) throws Exception {
+    final Environment environment = new Environment(bootstrap.getApplication().getName(),
+                                                        bootstrap.getObjectMapper(),
+                                                        Validation.buildDefaultValidatorFactory()
+                                                                  .getValidator(),
+                                                        bootstrap.getMetricRegistry(),
+                                                        bootstrap.getClassLoader());
+    InitializeStorage.initializeStorage(configuration, environment).initializeStorageBackend();
+    System.exit(0);
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/InitializeStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/InitializeStorage.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage;
+
+import io.cassandrareaper.ReaperApplicationConfiguration;
+import io.cassandrareaper.ReaperException;
+
+import java.util.UUID;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.setup.Environment;
+import org.apache.commons.lang3.StringUtils;
+import org.flywaydb.core.Flyway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class InitializeStorage {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InitializeStorage.class);
+  private final ReaperApplicationConfiguration config;
+  private final Environment environment;
+  private final UUID reaperInstanceId;
+
+  private InitializeStorage(ReaperApplicationConfiguration config, Environment environment, UUID reaperInstanceId) {
+    this.config = config;
+    this.environment = environment;
+    this.reaperInstanceId = reaperInstanceId;
+  }
+
+  public static InitializeStorage initializeStorage(ReaperApplicationConfiguration config, Environment environment) {
+    return new InitializeStorage(config, environment, UUID.randomUUID());
+  }
+
+  public static InitializeStorage initializeStorage(
+      ReaperApplicationConfiguration config,
+      Environment environment,
+      UUID reaperInstanceId) {
+    return new InitializeStorage(config, environment, reaperInstanceId);
+  }
+
+  public IStorage initializeStorageBackend()
+    throws ReaperException {
+    IStorage storage;
+    LOG.info("Initializing the database and performing schema migrations");
+
+    if ("memory".equalsIgnoreCase(config.getStorageType())) {
+      storage = new MemoryStorage();
+    } else if (Lists.newArrayList("cassandra", "astra").contains(config.getStorageType())) {
+      CassandraStorage.CassandraMode mode = config.getStorageType().equals("cassandra")
+          ? CassandraStorage.CassandraMode.CASSANDRA
+          : CassandraStorage.CassandraMode.ASTRA;
+      storage = new CassandraStorage(reaperInstanceId, config, environment, mode);
+    } else if ("postgres".equalsIgnoreCase(config.getStorageType())
+        || "h2".equalsIgnoreCase(config.getStorageType())
+        || "database".equalsIgnoreCase(config.getStorageType())) {
+      // create DBI instance
+      final DBIFactory factory = new DBIFactory();
+      if (StringUtils.isEmpty(config.getDataSourceFactory().getDriverClass())
+          && "postgres".equalsIgnoreCase(config.getStorageType())) {
+        config.getDataSourceFactory().setDriverClass("org.postgresql.Driver");
+      } else if (StringUtils.isEmpty(config.getDataSourceFactory().getDriverClass())
+          && "h2".equalsIgnoreCase(config.getStorageType())) {
+        config.getDataSourceFactory().setDriverClass("org.h2.Driver");
+      }
+      // instantiate store
+      storage = new PostgresStorage(
+          reaperInstanceId,
+          factory.build(environment, config.getDataSourceFactory(), "postgresql")
+      );
+      initDatabase(config);
+    } else {
+      LOG.error("invalid storageType: {}", config.getStorageType());
+      throw new ReaperException("invalid storage type: " + config.getStorageType());
+    }
+    Preconditions.checkState(storage.isStorageConnected(), "Failed to connect storage");
+    return storage;
+  }
+
+  private void initDatabase(ReaperApplicationConfiguration config) throws ReaperException {
+    Flyway flyway = new Flyway();
+    DataSourceFactory dsfactory = config.getDataSourceFactory();
+    flyway.setDataSource(
+        dsfactory.getUrl(),
+        dsfactory.getUser(),
+        dsfactory.getPassword());
+
+    if ("database".equals(config.getStorageType())) {
+      LOG.warn("!!!!!!!!!!    USAGE 'database' AS STORAGE TYPE IS NOW DEPRECATED   !!!!!!!!!!!!!!");
+      LOG.warn("!!!!!!!!!!    PLEASE USE EITHER 'postgres' OR 'h2' FROM NOW ON     !!!!!!!!!!!!!!");
+      if (config.getDataSourceFactory().getUrl().contains("h2")) {
+        flyway.setLocations("/db/h2");
+      } else {
+        flyway.setLocations("/db/postgres");
+      }
+    } else {
+      flyway.setLocations("/db/".concat(config.getStorageType().toLowerCase()));
+    }
+    flyway.setBaselineOnMigrate(true);
+    flyway.repair();
+    flyway.migrate();
+  }
+}


### PR DESCRIPTION
This will help performing migrations pre deployment of Reaper when it makes sense. In the context of k8s, the main containers will have probes set to values that won't allow all migrations to go through, leaving the schema in a state that's incompatible with the migrations that would be subsequently replayed (such as `ALTER TABLE ADD COLUMN` statements).