### PR TITLE
Add force option and warning for overlapping repair schedules

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -107,7 +107,8 @@ public final class RepairRunResource {
       @QueryParam("nodes") Optional<String> nodesToRepairParam,
       @QueryParam("datacenters") Optional<String> datacentersToRepairParam,
       @QueryParam("blacklistedTables") Optional<String> blacklistedTableNamesParam,
-      @QueryParam("repairThreadCount") Optional<Integer> repairThreadCountParam) {
+      @QueryParam("repairThreadCount") Optional<Integer> repairThreadCountParam,
+      @QueryParam("force") Optional<String> forceParam) {
 
     try {
       final Response possibleFailedResponse
@@ -124,7 +125,8 @@ public final class RepairRunResource {
           nodesToRepairParam,
           datacentersToRepairParam,
           blacklistedTableNamesParam,
-          repairThreadCountParam);
+          repairThreadCountParam,
+          forceParam);
 
       if (null != possibleFailedResponse) {
         return possibleFailedResponse;
@@ -272,7 +274,8 @@ public final class RepairRunResource {
       Optional<String> nodesStr,
       Optional<String> datacentersStr,
       Optional<String> blacklistedTableNamesParam,
-      Optional<Integer> repairThreadCountStr) throws ReaperException {
+      Optional<Integer> repairThreadCountStr,
+      Optional<String> forceParam) throws ReaperException {
 
     if (!clusterName.isPresent()) {
       return createMissingArgumentResponse("clusterName");
@@ -346,6 +349,15 @@ public final class RepairRunResource {
     if (tableNamesParam.isPresent() && blacklistedTableNamesParam.isPresent()) {
       return Response.status(Response.Status.BAD_REQUEST)
           .entity("invalid to specify a table list and a blacklist")
+          .build();
+    }
+
+    if (forceParam.isPresent()
+        && (!forceParam.get().toUpperCase().contentEquals("TRUE")
+        && !forceParam.get().toUpperCase().contentEquals("FALSE"))) {
+
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("invalid query parameter \"force\", expecting [True,False]")
           .build();
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -245,7 +245,13 @@ public final class RepairScheduleResource {
       boolean force) {
 
     Optional<RepairSchedule> conflictingRepairSchedule
-        = repairScheduleService.conflictingRepairSchedule(cluster, unitBuilder);
+        = repairScheduleService.identicalRepairUnit(cluster, unitBuilder);
+
+    if (conflictingRepairSchedule.isPresent()) {
+      return Response.noContent().location(buildRepairScheduleUri(uriInfo, conflictingRepairSchedule.get())).build();
+    }
+
+    conflictingRepairSchedule = repairScheduleService.conflictingRepairSchedule(cluster, unitBuilder);
 
     if (conflictingRepairSchedule.isPresent()) {
       RepairSchedule existingSchedule = conflictingRepairSchedule.get();
@@ -272,7 +278,7 @@ public final class RepairScheduleResource {
       }
     }
 
-    RepairUnit unit = repairUnitService.getOrCreateRepairUnit(cluster, unitBuilder);
+    RepairUnit unit = repairUnitService.getOrCreateRepairUnit(cluster, unitBuilder, force);
 
     Preconditions
         .checkState(unit.getIncrementalRepair() == incremental, "%s!=%s", unit.getIncrementalRepair(), incremental);

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -102,7 +102,8 @@ public final class RepairScheduleResource {
       @QueryParam("nodes") Optional<String> nodesToRepairParam,
       @QueryParam("datacenters") Optional<String> datacentersToRepairParam,
       @QueryParam("blacklistedTables") Optional<String> blacklistedTableNamesParam,
-      @QueryParam("repairThreadCount") Optional<Integer> repairThreadCountParam) {
+      @QueryParam("repairThreadCount") Optional<Integer> repairThreadCountParam,
+      @QueryParam("force") Optional<String> forceParam) {
 
     try {
       Response possibleFailResponse = RepairRunResource.checkRequestForAddRepair(
@@ -118,7 +119,8 @@ public final class RepairScheduleResource {
           nodesToRepairParam,
           datacentersToRepairParam,
           blacklistedTableNamesParam,
-          repairThreadCountParam);
+          repairThreadCountParam,
+          forceParam);
 
       if (null != possibleFailResponse) {
         return possibleFailResponse;
@@ -197,6 +199,9 @@ public final class RepairScheduleResource {
             .build();
       }
 
+      // explicitly force a schedule even if the schedule conflicts
+      boolean force = (forceParam.isPresent() ? Boolean.parseBoolean(forceParam.get()) : false);
+
       RepairUnit.Builder unitBuilder = RepairUnit.builder()
           .clusterName(cluster.getName())
           .keyspaceName(keyspace.get())
@@ -217,7 +222,8 @@ public final class RepairScheduleResource {
           incremental,
           nextActivation,
           getSegmentCount(segmentCountPerNode),
-          getIntensity(intensityStr));
+          getIntensity(intensityStr),
+          force);
 
     } catch (ReaperException e) {
       LOG.error(e.getMessage(), e);
@@ -235,7 +241,8 @@ public final class RepairScheduleResource {
       boolean incremental,
       DateTime next,
       int segments,
-      Double intensity) {
+      Double intensity,
+      boolean force) {
 
     Optional<RepairSchedule> conflictingRepairSchedule
         = repairScheduleService.conflictingRepairSchedule(cluster, unitBuilder);
@@ -250,29 +257,30 @@ public final class RepairScheduleResource {
         return Response.noContent().location(buildRepairScheduleUri(uriInfo, existingSchedule)).build();
       }
 
-      String msg = String.format(
-          "A repair schedule already exists for cluster \"%s\", keyspace \"%s\", and column families: %s",
-          cluster.getName(),
-          unitBuilder.keyspaceName,
-          unitBuilder.columnFamilies);
+      if (!force) {
+        String msg = String.format(
+            "A repair schedule already exists for cluster \"%s\", keyspace \"%s\", and column families: %s",
+            cluster.getName(),
+            unitBuilder.keyspaceName,
+            unitBuilder.columnFamilies);
 
-      return Response
-          .status(Response.Status.CONFLICT)
-          .location(buildRepairScheduleUri(uriInfo, existingSchedule))
-          .entity(msg)
-          .build();
-    } else {
-
-      RepairUnit unit = repairUnitService.getOrCreateRepairUnit(cluster, unitBuilder);
-
-      Preconditions
-          .checkState(unit.getIncrementalRepair() == incremental, "%s!=%s", unit.getIncrementalRepair(), incremental);
-
-      RepairSchedule newRepairSchedule = repairScheduleService
-          .storeNewRepairSchedule(cluster, unit, days, next, owner, segments, parallel, intensity);
-
-      return Response.created(buildRepairScheduleUri(uriInfo, newRepairSchedule)).build();
+        return Response
+            .status(Response.Status.CONFLICT)
+            .location(buildRepairScheduleUri(uriInfo, existingSchedule))
+            .entity(msg)
+            .build();
+      }
     }
+
+    RepairUnit unit = repairUnitService.getOrCreateRepairUnit(cluster, unitBuilder);
+
+    Preconditions
+        .checkState(unit.getIncrementalRepair() == incremental, "%s!=%s", unit.getIncrementalRepair(), incremental);
+
+    RepairSchedule newRepairSchedule = repairScheduleService
+        .storeNewRepairSchedule(cluster, unit, days, next, owner, segments, parallel, intensity, force);
+
+    return Response.created(buildRepairScheduleUri(uriInfo, newRepairSchedule)).build();
   }
 
   private int getDaysBetween(Optional<Integer> scheduleDaysBetween) {

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -135,7 +135,8 @@ public final class ClusterRepairScheduler {
             REPAIR_OWNER,
             context.config.getSegmentCountPerNode(),
             context.config.getRepairParallelism(),
-            context.config.getRepairIntensity());
+            context.config.getRepairIntensity(),
+            false);
 
     LOG.info("Scheduled repair created: {}", repairSchedule);
   }

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -77,10 +77,11 @@ public final class RepairScheduleService {
       String owner,
       int segmentCountPerNode,
       RepairParallelism repairParallelism,
-      Double intensity) {
+      Double intensity,
+      boolean force) {
 
     Preconditions.checkArgument(
-        !conflictingRepairSchedule(cluster, repairUnit.with()).isPresent(),
+        force || !conflictingRepairSchedule(cluster, repairUnit.with()).isPresent(),
         "A repair schedule already exists for cluster \"%s\", keyspace \"%s\", and column families: %s",
         cluster.getName(),
         repairUnit.getKeyspaceName(),

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -61,6 +61,24 @@ public final class RepairScheduleService {
     return Optional.empty();
   }
 
+  public Optional<RepairSchedule> identicalRepairUnit(Cluster cluster, RepairUnit.Builder repairUnit) {
+
+    Collection<RepairSchedule> repairSchedules = context.storage
+        .getRepairSchedulesForClusterAndKeyspace(repairUnit.clusterName, repairUnit.keyspaceName);
+
+    for (RepairSchedule sched : repairSchedules) {
+      RepairUnit repairUnitForSched = context.storage.getRepairUnit(sched.getRepairUnitId());
+      Preconditions.checkState(repairUnitForSched.getClusterName().equals(repairUnit.clusterName));
+      Preconditions.checkState(repairUnitForSched.getKeyspaceName().equals(repairUnit.keyspaceName));
+
+      // if the schedule is identical, return immediately
+      if (repairUnitService.identicalUnits(cluster, repairUnitForSched, repairUnit)) {
+        return Optional.of(sched);
+      }
+    }
+    return Optional.empty();
+  }
+
   /**
    * Instantiates a RepairSchedule and stores it in the storage backend.
    *

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -146,6 +146,26 @@ Feature: Using Reaper
 
   @sidecar
   @all_nodes_reachable
+  @cassandra_2_1_onwards
+  Scenario Outline: Adding a scheduled full repair and a scheduled incremental repair for the same keyspace with force option
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new daily "incremental" repair schedule is added for "test" and keyspace "test_keyspace3"
+    And a new daily "full" repair schedule is added that already exists for "test" and keyspace "test_keyspace3" with force option
+    Then reaper has 2 scheduled repairs for cluster called "test"
+    When reaper is upgraded to latest
+    Then reaper has 2 scheduled repairs for cluster called "test"
+    And deleting cluster called "test" fails
+    When all added schedules are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @all_nodes_reachable
   @cassandra_3_11_onwards
   Scenario Outline: Add a scheduled incremental repair and collect percent repaired metrics
     Given that reaper <version> is running

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -95,7 +95,7 @@ const repairForm = CreateReactClass({
       obs.subscribe(
         r => this.setState({
           addRepairResultMsg: null,
-          addRepairResultStatus: r.status,
+          addRepairResultStatus: null,
           showModal: false,
           force: "false",
         }),
@@ -399,10 +399,7 @@ const repairForm = CreateReactClass({
 
     let addMsg = null;
     if(this.state.addRepairResultMsg) {
-      if(this.state.addRepairResultStatus != 409) {
-        addMsg = <div className="alert alert-danger" role="alert">{this.state.addRepairResultMsg}</div>
-      }
-      else {
+      if(this.state.addRepairResultStatus && this.state.addRepairResultStatus === 409) {
         addMsg = (
                 <span>
                 <Modal show={this.state.showModal} onHide={this._onClose}>
@@ -415,12 +412,15 @@ const repairForm = CreateReactClass({
                     <p>For Cassandra 4.0 and later, you can force creating this schedule by clicking the "Force" button below.</p>
                   </Modal.Body>
                   <Modal.Footer>
-                    <Button variant="secondary" onClick={this._onClose}>Close</Button>
+                    <Button variant="secondary" onClick={this._onClose}>Cancel</Button>
                     <Button variant="primary" onClick={this._onForce}>Force</Button>
                   </Modal.Footer>
                 </Modal>
               </span>
         );
+      }
+      else {
+        addMsg = <div className="alert alert-danger" role="alert">{this.state.addRepairResultMsg}</div>
       }
     }
 


### PR DESCRIPTION
This PR adds a "force" option to the add repair schedule API to allow for creating overlapping schedules, even though it's not recommended (and broken for earlier versions of Cassandra).

Fixes #1078 

