### PR TITLE
Add adaptive segment timeouts

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -180,8 +180,6 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     context.repairManager = RepairManager.create(
         context,
         environment.lifecycle().scheduledExecutorService("RepairRunner").threads(repairThreads).build(),
-        config.getHangingRepairTimeoutMins(),
-        TimeUnit.MINUTES,
         config.getRepairManagerSchedulingIntervalSeconds(),
         TimeUnit.SECONDS,
         maxParallelRepairs);
@@ -476,7 +474,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
   }
 
   private void tryInitializeStorage(ReaperApplicationConfiguration config, Environment environment)
-    throws ReaperException, InterruptedException {
+      throws ReaperException, InterruptedException {
     if (context.storage == null) {
       LOG.info("initializing storage of type: {}", config.getStorageType());
       int storageFailures = 0;

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -561,6 +561,9 @@ public final class ReaperApplicationConfiguration extends Configuration {
     @JsonProperty
     private List<String> excludedClusters = Collections.emptyList();
 
+    @JsonProperty
+    private Boolean adaptive;
+
     public Boolean isEnabled() {
       return enabled;
     }
@@ -621,6 +624,14 @@ public final class ReaperApplicationConfiguration extends Configuration {
       return excludedClusters;
     }
 
+    public Boolean isAdaptive() {
+      return adaptive == null ? false : adaptive;
+    }
+
+    public void setAdaptive(Boolean adaptive) {
+      this.adaptive = adaptive;
+    }
+
     @Override
     public String toString() {
       return "AutoSchedulingConfiguration{"
@@ -634,6 +645,8 @@ public final class ReaperApplicationConfiguration extends Configuration {
           + timeBeforeFirstSchedule
           + ", scheduleSpreadPeriod="
           + scheduleSpreadPeriod
+          + ", adaptive="
+          + adaptive
           + '}';
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
@@ -48,6 +48,7 @@ public final class RepairRun implements Comparable<RepairRun> {
   private final int segmentCount;
   private final RepairParallelism repairParallelism;
   private final Set<String> tables;
+  private final boolean adaptiveSchedule;
 
   private RepairRun(Builder builder, UUID id) {
     this.id = id;
@@ -65,6 +66,7 @@ public final class RepairRun implements Comparable<RepairRun> {
     this.segmentCount = builder.segmentCount;
     this.repairParallelism = builder.repairParallelism;
     this.tables = builder.tables;
+    this.adaptiveSchedule = builder.adaptiveSchedule;
   }
 
   public static Builder builder(String clusterName, UUID repairUnitId) {
@@ -129,6 +131,10 @@ public final class RepairRun implements Comparable<RepairRun> {
 
   public Set<String> getTables() {
     return tables;
+  }
+
+  public Boolean getAdaptiveSchedule() {
+    return adaptiveSchedule;
   }
 
   public Builder with() {
@@ -208,6 +214,8 @@ public final class RepairRun implements Comparable<RepairRun> {
     private Integer segmentCount;
     private RepairParallelism repairParallelism;
     private Set<String> tables;
+    private boolean adaptiveSchedule;
+
 
     private Builder(String clusterName, UUID repairUnitId) {
       this.clusterName = clusterName;
@@ -229,6 +237,7 @@ public final class RepairRun implements Comparable<RepairRun> {
       segmentCount = original.segmentCount;
       repairParallelism = original.repairParallelism;
       tables = original.tables;
+      adaptiveSchedule = original.adaptiveSchedule;
     }
 
     public Builder runState(RunState runState) {
@@ -291,6 +300,11 @@ public final class RepairRun implements Comparable<RepairRun> {
 
     public Builder tables(Set<String> tables) {
       this.tables = Collections.unmodifiableSet(tables);
+      return this;
+    }
+
+    public Builder adaptiveSchedule(boolean adaptive) {
+      this.adaptiveSchedule = adaptive;
       return this;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
@@ -36,9 +36,12 @@ public final class RepairSchedule extends EditableRepairSchedule {
   private final State state;
   private final DateTime nextActivation;
   private final ImmutableList<UUID> runHistory;
-  @Deprecated private final int segmentCount;
+  private final RepairParallelism repairParallelism;
+  private final double intensity;
   private final DateTime creationTime;
   private final DateTime pauseTime;
+  private final int segmentCountPerNode;
+  private final boolean adaptive;
 
   private RepairSchedule(Builder builder, UUID id) {
     this.id = id;
@@ -47,13 +50,13 @@ public final class RepairSchedule extends EditableRepairSchedule {
     this.daysBetween = builder.daysBetween;
     this.nextActivation = builder.nextActivation;
     this.runHistory = builder.runHistory;
-    this.segmentCount = builder.segmentCount;
     this.repairParallelism = builder.repairParallelism;
     this.intensity = builder.intensity;
     this.creationTime = builder.creationTime;
     this.owner = builder.owner;
     this.pauseTime = builder.pauseTime;
     this.segmentCountPerNode = builder.segmentCountPerNode;
+    this.adaptive = builder.adaptive;
   }
 
   public static Builder builder(UUID repairUnitId) {
@@ -92,8 +95,16 @@ public final class RepairSchedule extends EditableRepairSchedule {
     return new LongCollectionSqlType(list);
   }
 
-  public int getSegmentCount() {
-    return segmentCount;
+  public Integer getSegmentCountPerNode() {
+    return segmentCountPerNode;
+  }
+
+  public RepairParallelism getRepairParallelism() {
+    return repairParallelism;
+  }
+
+  public Double getIntensity() {
+    return intensity;
   }
 
   public DateTime getCreationTime() {
@@ -106,6 +117,10 @@ public final class RepairSchedule extends EditableRepairSchedule {
 
   public DateTime getPauseTime() {
     return pauseTime;
+  }
+
+  public boolean getAdaptive() {
+    return adaptive;
   }
 
   public Builder with() {
@@ -130,14 +145,13 @@ public final class RepairSchedule extends EditableRepairSchedule {
     private Integer daysBetween;
     private DateTime nextActivation;
     private ImmutableList<UUID> runHistory = ImmutableList.<UUID>of();
-    @Deprecated private int segmentCount = 0;
     private RepairParallelism repairParallelism;
     private Double intensity;
     private DateTime creationTime = DateTime.now();
     private String owner = "";
     private DateTime pauseTime;
     private Integer segmentCountPerNode;
-    private boolean majorCompaction = false;
+    private boolean adaptive = false;
 
     private Builder(UUID repairUnitId) {
       this.repairUnitId = repairUnitId;
@@ -149,7 +163,6 @@ public final class RepairSchedule extends EditableRepairSchedule {
       daysBetween = original.daysBetween;
       nextActivation = original.nextActivation;
       runHistory = original.runHistory;
-      segmentCount = original.segmentCount;
       repairParallelism = original.repairParallelism;
       intensity = original.intensity;
       creationTime = original.creationTime;
@@ -157,6 +170,7 @@ public final class RepairSchedule extends EditableRepairSchedule {
       pauseTime = original.pauseTime;
       intensity = original.intensity;
       segmentCountPerNode = original.segmentCountPerNode;
+      adaptive = original.adaptive;
     }
 
     public Builder state(State state) {
@@ -176,11 +190,6 @@ public final class RepairSchedule extends EditableRepairSchedule {
 
     public Builder runHistory(ImmutableList<UUID> runHistory) {
       this.runHistory = runHistory;
-      return this;
-    }
-
-    public Builder segmentCount(int segmentCount) {
-      this.segmentCount = segmentCount;
       return this;
     }
 
@@ -211,6 +220,11 @@ public final class RepairSchedule extends EditableRepairSchedule {
 
     public Builder segmentCountPerNode(int segmentCountPerNode) {
       this.segmentCountPerNode = segmentCountPerNode;
+      return this;
+    }
+
+    public Builder adaptive(boolean adaptive) {
+      this.adaptive = adaptive;
       return this;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairUnit.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairUnit.java
@@ -35,6 +35,7 @@ public final class RepairUnit {
   private final Set<String> datacenters;
   private final Set<String> blacklistedTables;
   private final int repairThreadCount;
+  private final int timeout;
 
   private RepairUnit(Builder builder, UUID id) {
     this.id = id;
@@ -46,6 +47,7 @@ public final class RepairUnit {
     this.datacenters = builder.datacenters;
     this.blacklistedTables = builder.blacklistedTables;
     this.repairThreadCount = builder.repairThreadCount;
+    this.timeout = builder.timeout;
   }
 
   public static Builder builder() {
@@ -88,6 +90,10 @@ public final class RepairUnit {
     return repairThreadCount;
   }
 
+  public int getTimeout() {
+    return timeout;
+  }
+
   public Builder with() {
     return new Builder(this);
   }
@@ -102,6 +108,7 @@ public final class RepairUnit {
     public Set<String> datacenters = Collections.emptySet();
     public Set<String> blacklistedTables = Collections.emptySet();
     public Integer repairThreadCount;
+    public Integer timeout;
 
     private Builder() {}
 
@@ -114,6 +121,7 @@ public final class RepairUnit {
       datacenters = original.datacenters;
       blacklistedTables = original.blacklistedTables;
       repairThreadCount = original.repairThreadCount;
+      timeout = original.timeout;
     }
 
     public Builder clusterName(String clusterName) {
@@ -156,11 +164,17 @@ public final class RepairUnit {
       return this;
     }
 
+    public Builder timeout(int timeout) {
+      this.timeout = timeout;
+      return this;
+    }
+
     public RepairUnit build(UUID id) {
       Preconditions.checkState(null != clusterName, "clusterName(..) must be called before build(..)");
       Preconditions.checkState(null != keyspaceName, "keyspaceName(..) must be called before build(..)");
       Preconditions.checkState(null != incrementalRepair, "incrementalRepair(..) must be called before build(..)");
       Preconditions.checkState(null != repairThreadCount, "repairThreadCount(..) must be called before build(..)");
+      Preconditions.checkState(null != timeout, "timeout(..) must be called before build(..)");
       return new RepairUnit(this, id);
     }
 
@@ -181,6 +195,10 @@ public final class RepairUnit {
       hash +=  Objects.hashCode(this.datacenters);
       hash *= 59;
       hash +=  Objects.hashCode(this.blacklistedTables);
+      hash *= 59;
+      hash +=  Objects.hashCode(this.repairThreadCount);
+      hash *= 59;
+      hash +=  Objects.hashCode(this.timeout);
       return hash;
     }
 
@@ -200,7 +218,8 @@ public final class RepairUnit {
           && Objects.equals(this.nodes, ((Builder) obj).nodes)
           && Objects.equals(this.datacenters, ((Builder) obj).datacenters)
           && Objects.equals(this.blacklistedTables, ((Builder) obj).blacklistedTables)
-          && Objects.equals(this.repairThreadCount, ((Builder) obj).repairThreadCount);
+          && Objects.equals(this.repairThreadCount, ((Builder) obj).repairThreadCount)
+          && Objects.equals(this.timeout, ((Builder) obj).timeout);
     }
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -199,7 +199,6 @@ public final class RepairRunResource {
         LOG.error(ex.getMessage(), ex);
         return Response.status(Response.Status.NOT_FOUND).entity(ex.getMessage()).build();
       }
-
       int timeout = timeoutParam.orElse(context.config.getHangingRepairTimeoutMins());
       boolean force = (forceParam.isPresent() ? Boolean.parseBoolean(forceParam.get()) : false);
 
@@ -245,10 +244,10 @@ public final class RepairRunResource {
               theRepairUnit,
               cause,
               owner.get(),
-              0,
               segments,
               parallelism,
-              intensity);
+              intensity,
+              false);
 
       return Response.created(buildRepairRunUri(uriInfo, newRepairRun))
           .entity(new RepairRunStatus(newRepairRun, theRepairUnit, 0))

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -165,7 +165,8 @@ public final class RepairScheduleResource {
       @QueryParam("datacenters") Optional<String> datacentersToRepairParam,
       @QueryParam("blacklistedTables") Optional<String> blacklistedTableNamesParam,
       @QueryParam("repairThreadCount") Optional<Integer> repairThreadCountParam,
-      @QueryParam("force") Optional<String> forceParam) {
+      @QueryParam("force") Optional<String> forceParam,
+      @QueryParam("timeout") Optional<Integer> timeoutParam) {
 
     try {
       Response possibleFailResponse = RepairRunResource.checkRequestForAddRepair(
@@ -182,7 +183,8 @@ public final class RepairScheduleResource {
           datacentersToRepairParam,
           blacklistedTableNamesParam,
           repairThreadCountParam,
-          forceParam);
+          forceParam,
+          timeoutParam);
 
       if (null != possibleFailResponse) {
         return possibleFailResponse;
@@ -264,6 +266,8 @@ public final class RepairScheduleResource {
       // explicitly force a schedule even if the schedule conflicts
       boolean force = (forceParam.isPresent() ? Boolean.parseBoolean(forceParam.get()) : false);
 
+      int timeout = timeoutParam.orElse(context.config.getHangingRepairTimeoutMins());
+
       RepairUnit.Builder unitBuilder = RepairUnit.builder()
           .clusterName(cluster.getName())
           .keyspaceName(keyspace.get())
@@ -272,7 +276,8 @@ public final class RepairScheduleResource {
           .nodes(nodesToRepair)
           .datacenters(datacentersToRepair)
           .blacklistedTables(blacklistedTableNames)
-          .repairThreadCount(repairThreadCountParam.orElse(context.config.getRepairThreadCount()));
+          .repairThreadCount(repairThreadCountParam.orElse(context.config.getRepairThreadCount()))
+          .timeout(timeout);
 
       return addRepairSchedule(
           cluster,

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -166,7 +166,8 @@ public final class RepairScheduleResource {
       @QueryParam("blacklistedTables") Optional<String> blacklistedTableNamesParam,
       @QueryParam("repairThreadCount") Optional<Integer> repairThreadCountParam,
       @QueryParam("force") Optional<String> forceParam,
-      @QueryParam("timeout") Optional<Integer> timeoutParam) {
+      @QueryParam("timeout") Optional<Integer> timeoutParam,
+      @QueryParam("adaptive") Optional<String> adaptiveParam) {
 
     try {
       Response possibleFailResponse = RepairRunResource.checkRequestForAddRepair(
@@ -267,6 +268,7 @@ public final class RepairScheduleResource {
       boolean force = (forceParam.isPresent() ? Boolean.parseBoolean(forceParam.get()) : false);
 
       int timeout = timeoutParam.orElse(context.config.getHangingRepairTimeoutMins());
+      boolean adaptive = (adaptiveParam.isPresent() ? Boolean.parseBoolean(adaptiveParam.get()) : false);
 
       RepairUnit.Builder unitBuilder = RepairUnit.builder()
           .clusterName(cluster.getName())
@@ -290,7 +292,8 @@ public final class RepairScheduleResource {
           nextActivation,
           getSegmentCount(segmentCountPerNode),
           getIntensity(intensityStr),
-          force);
+          force,
+          adaptive);
 
     } catch (ReaperException e) {
       LOG.error(e.getMessage(), e);
@@ -309,7 +312,8 @@ public final class RepairScheduleResource {
       DateTime next,
       int segments,
       Double intensity,
-      boolean force) {
+      boolean force,
+      boolean adaptive) {
 
     Optional<RepairSchedule> conflictingRepairSchedule
         = repairScheduleService.identicalRepairUnit(cluster, unitBuilder);
@@ -351,7 +355,7 @@ public final class RepairScheduleResource {
         .checkState(unit.getIncrementalRepair() == incremental, "%s!=%s", unit.getIncrementalRepair(), incremental);
 
     RepairSchedule newRepairSchedule = repairScheduleService
-        .storeNewRepairSchedule(cluster, unit, days, next, owner, segments, parallel, intensity, force);
+        .storeNewRepairSchedule(cluster, unit, days, next, owner, segments, parallel, intensity, force, adaptive);
 
     return Response.created(buildRepairScheduleUri(uriInfo, newRepairSchedule)).build();
   }

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
@@ -112,6 +112,9 @@ public final class RepairRunStatus {
   @JsonProperty("repair_unit_id")
   private UUID repairUnitId;
 
+  @JsonProperty("segment_timeout")
+  private int segmentTimeout;
+
 
   /**
    * Default public constructor Required for Jackson JSON parsing.
@@ -141,7 +144,8 @@ public final class RepairRunStatus {
       Collection<String> datacenters,
       Collection<String> blacklistedTables,
       int repairThreadCount,
-      UUID repairUnitId) {
+      UUID repairUnitId,
+      int segmentTimeout) {
 
     this.id = runId;
     this.cause = cause;
@@ -166,6 +170,7 @@ public final class RepairRunStatus {
     this.datacenters = datacenters;
     this.blacklistedTables = blacklistedTables;
     this.repairThreadCount = repairThreadCount;
+    this.segmentTimeout = segmentTimeout;
 
     if (startTime == null) {
       duration = null;
@@ -226,7 +231,8 @@ public final class RepairRunStatus {
         repairUnit.getDatacenters(),
         repairUnit.getBlacklistedTables(),
         repairUnit.getRepairThreadCount(),
-        repairRun.getRepairUnitId());
+        repairRun.getRepairUnitId(),
+        repairUnit.getTimeout());
   }
 
   @JsonProperty("creation_time")

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
@@ -115,6 +115,9 @@ public final class RepairRunStatus {
   @JsonProperty("segment_timeout")
   private int segmentTimeout;
 
+  @JsonProperty("adaptive_schedule")
+  private boolean adaptiveSchedule;
+
 
   /**
    * Default public constructor Required for Jackson JSON parsing.
@@ -145,7 +148,8 @@ public final class RepairRunStatus {
       Collection<String> blacklistedTables,
       int repairThreadCount,
       UUID repairUnitId,
-      int segmentTimeout) {
+      int segmentTimeout,
+      boolean adaptiveSchedule) {
 
     this.id = runId;
     this.cause = cause;
@@ -171,6 +175,7 @@ public final class RepairRunStatus {
     this.blacklistedTables = blacklistedTables;
     this.repairThreadCount = repairThreadCount;
     this.segmentTimeout = segmentTimeout;
+    this.adaptiveSchedule = adaptiveSchedule;
 
     if (startTime == null) {
       duration = null;
@@ -232,7 +237,8 @@ public final class RepairRunStatus {
         repairUnit.getBlacklistedTables(),
         repairUnit.getRepairThreadCount(),
         repairRun.getRepairUnitId(),
-        repairUnit.getTimeout());
+        repairUnit.getTimeout(),
+        repairRun.getAdaptiveSchedule());
   }
 
   @JsonProperty("creation_time")
@@ -510,4 +516,11 @@ public final class RepairRunStatus {
     this.repairUnitId = repairUnitId;
   }
 
+  public boolean getAdaptiveSchedule() {
+    return adaptiveSchedule;
+  }
+
+  public void setAdaptiveSchedule(boolean adaptiveSchedule) {
+    this.adaptiveSchedule = adaptiveSchedule;
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
@@ -64,9 +64,6 @@ public final class RepairScheduleStatus {
   @JsonProperty("incremental_repair")
   private boolean incrementalRepair;
 
-  @JsonProperty("segment_count")
-  private int segmentCount;
-
   @JsonProperty("repair_parallelism")
   private RepairParallelism repairParallelism;
 
@@ -94,6 +91,9 @@ public final class RepairScheduleStatus {
   @JsonProperty("segment_timeout")
   private int segmentTimeout;
 
+  @JsonProperty("adaptive")
+  private boolean adaptive;
+
   /**
    * Default public constructor Required for Jackson JSON parsing.
    */
@@ -112,7 +112,6 @@ public final class RepairScheduleStatus {
       DateTime pauseTime,
       double intensity,
       boolean incrementalRepair,
-      int segmentCount,
       RepairParallelism repairParallelism,
       int daysBetween,
       Collection<String> nodes,
@@ -121,7 +120,8 @@ public final class RepairScheduleStatus {
       int segmentCountPerNode,
       int repairThreadCount,
       UUID repairUnitId,
-      int segmentTimeout) {
+      int segmentTimeout,
+      boolean adaptive) {
 
     this.id = id;
     this.owner = owner;
@@ -134,7 +134,6 @@ public final class RepairScheduleStatus {
     this.pauseTime = pauseTime;
     this.intensity = RepairRunStatus.roundDoubleNicely(intensity);
     this.incrementalRepair = incrementalRepair;
-    this.segmentCount = segmentCount;
     this.repairParallelism = repairParallelism;
     this.daysBetween = daysBetween;
     this.nodes = nodes;
@@ -144,7 +143,7 @@ public final class RepairScheduleStatus {
     this.repairThreadCount = repairThreadCount;
     this.repairUnitId = repairUnitId;
     this.segmentTimeout = segmentTimeout;
-
+    this.adaptive = adaptive;
   }
 
   public RepairScheduleStatus(RepairSchedule repairSchedule, RepairUnit repairUnit) {
@@ -160,7 +159,6 @@ public final class RepairScheduleStatus {
         repairSchedule.getPauseTime(),
         repairSchedule.getIntensity(),
         repairUnit.getIncrementalRepair(),
-        repairSchedule.getSegmentCount(),
         repairSchedule.getRepairParallelism(),
         repairSchedule.getDaysBetween(),
         repairUnit.getNodes(),
@@ -169,7 +167,8 @@ public final class RepairScheduleStatus {
         repairSchedule.getSegmentCountPerNode(),
         repairUnit.getRepairThreadCount(),
         repairUnit.getId(),
-        repairUnit.getTimeout());
+        repairUnit.getTimeout(),
+        repairSchedule.getAdaptive());
   }
 
   public UUID getId() {
@@ -252,20 +251,12 @@ public final class RepairScheduleStatus {
     this.intensity = intensity;
   }
 
-  public int getSegmentCount() {
-    return segmentCount;
-  }
-
   public boolean getIncrementalRepair() {
     return incrementalRepair;
   }
 
   public void setIncrementalRepair(boolean incrementalRepair) {
     this.incrementalRepair = incrementalRepair;
-  }
-
-  public void setSegmentCount(int segmentCount) {
-    this.segmentCount = segmentCount;
   }
 
   public RepairParallelism getRepairParallelism() {
@@ -374,5 +365,13 @@ public final class RepairScheduleStatus {
 
   public void setRepairUnitId(UUID repairUnitId) {
     this.repairUnitId = repairUnitId;
+  }
+
+  public boolean getAdaptive() {
+    return adaptive;
+  }
+
+  public void setAdaptive(boolean adaptive) {
+    this.adaptive = adaptive;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
@@ -91,6 +91,9 @@ public final class RepairScheduleStatus {
   @JsonProperty("repair_unit_id")
   private UUID repairUnitId;
 
+  @JsonProperty("segment_timeout")
+  private int segmentTimeout;
+
   /**
    * Default public constructor Required for Jackson JSON parsing.
    */
@@ -117,7 +120,8 @@ public final class RepairScheduleStatus {
       Collection<String> blacklistedTables,
       int segmentCountPerNode,
       int repairThreadCount,
-      UUID repairUnitId) {
+      UUID repairUnitId,
+      int segmentTimeout) {
 
     this.id = id;
     this.owner = owner;
@@ -139,6 +143,7 @@ public final class RepairScheduleStatus {
     this.segmentCountPerNode = segmentCountPerNode;
     this.repairThreadCount = repairThreadCount;
     this.repairUnitId = repairUnitId;
+    this.segmentTimeout = segmentTimeout;
 
   }
 
@@ -163,7 +168,8 @@ public final class RepairScheduleStatus {
         repairUnit.getBlacklistedTables(),
         repairSchedule.getSegmentCountPerNode(),
         repairUnit.getRepairThreadCount(),
-        repairUnit.getId());
+        repairUnit.getId(),
+        repairUnit.getTimeout());
   }
 
   public UUID getId() {

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -125,7 +125,8 @@ public final class ClusterRepairScheduler {
         .clusterName(cluster.getName())
         .keyspaceName(keyspace)
         .incrementalRepair(incrementalRepair)
-        .repairThreadCount(context.config.getRepairThreadCount());
+        .repairThreadCount(context.config.getRepairThreadCount())
+        .timeout(context.config.getHangingRepairTimeoutMins());
 
     RepairSchedule repairSchedule = repairScheduleService.storeNewRepairSchedule(
             cluster,

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -22,7 +22,6 @@ import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
-import io.cassandrareaper.core.Table;
 import io.cassandrareaper.jmx.ClusterFacade;
 
 import java.util.Collection;
@@ -31,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
@@ -137,24 +135,10 @@ public final class ClusterRepairScheduler {
             context.config.getSegmentCountPerNode(),
             context.config.getRepairParallelism(),
             context.config.getRepairIntensity(),
-            false);
+            false,
+            context.config.getAutoScheduling().isAdaptive());
 
     LOG.info("Scheduled repair created: {}", repairSchedule);
-  }
-
-  private boolean keyspaceHasNoTable(AppContext context, Cluster cluster, String keyspace) {
-    try {
-      Set<String> tables
-          = ClusterFacade
-              .create(context)
-              .getTablesForKeyspace(cluster, keyspace)
-              .stream()
-              .map(Table::getName)
-              .collect(Collectors.toSet());
-      return tables.isEmpty();
-    } catch (ReaperException e) {
-      throw Throwables.propagate(e);
-    }
   }
 
   private static class ScheduledRepairDiffView {

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -63,7 +63,6 @@ public final class RepairManager implements AutoCloseable {
   private final AppContext context;
   private final ClusterFacade clusterFacade;
   private final ListeningScheduledExecutorService executor;
-  private final long repairTimeoutMillis;
   private final long retryDelayMillis;
   private final int maxParallelRepairs;
 
@@ -71,8 +70,6 @@ public final class RepairManager implements AutoCloseable {
       AppContext context,
       ClusterFacade clusterFacade,
       ScheduledExecutorService executor,
-      long repairTimeout,
-      TimeUnit repairTimeoutTimeUnit,
       long retryDelay,
       TimeUnit retryDelayTimeUnit,
       int maxParallelRepairs
@@ -80,7 +77,6 @@ public final class RepairManager implements AutoCloseable {
 
     this.context = context;
     this.clusterFacade = clusterFacade;
-    this.repairTimeoutMillis = repairTimeoutTimeUnit.toMillis(repairTimeout);
     this.retryDelayMillis = retryDelayTimeUnit.toMillis(retryDelay);
 
     this.executor = MoreExecutors.listeningDecorator(
@@ -93,8 +89,6 @@ public final class RepairManager implements AutoCloseable {
       AppContext context,
       ClusterFacade clusterFacadeSupplier,
       ScheduledExecutorService executor,
-      long repairTimeout,
-      TimeUnit repairTimeoutTimeUnit,
       long retryDelay,
       TimeUnit retryDelayTimeUnit,
       int maxParallelRepairs
@@ -104,8 +98,6 @@ public final class RepairManager implements AutoCloseable {
         context,
         clusterFacadeSupplier,
         executor,
-        repairTimeout,
-        repairTimeoutTimeUnit,
         retryDelay,
         retryDelayTimeUnit,
         maxParallelRepairs);
@@ -114,8 +106,6 @@ public final class RepairManager implements AutoCloseable {
   public static RepairManager create(
       AppContext context,
       ScheduledExecutorService executor,
-      long repairTimeout,
-      TimeUnit repairTimeoutTimeUnit,
       long retryDelay,
       TimeUnit retryDelayTimeUnit,
       int maxParallelRepairs
@@ -125,15 +115,9 @@ public final class RepairManager implements AutoCloseable {
         context,
         ClusterFacade.create(context),
         executor,
-        repairTimeout,
-        repairTimeoutTimeUnit,
         retryDelay,
         retryDelayTimeUnit,
         maxParallelRepairs);
-  }
-
-  long getRepairTimeoutMillis() {
-    return repairTimeoutMillis;
   }
 
   /**

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -317,7 +317,8 @@ public final class RepairRunService {
       RepairUnit repairUnit) {
 
     List<RepairSegment.Builder> repairSegmentBuilders = Lists.newArrayList();
-    tokenSegments.forEach(range -> repairSegmentBuilders.add(RepairSegment.builder(range, repairUnit.getId())));
+    tokenSegments.forEach(
+        range -> repairSegmentBuilders.add(RepairSegment.builder(range, repairUnit.getId())));
     return repairSegmentBuilders;
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.codahale.metrics.Gauge;
@@ -548,7 +549,7 @@ final class RepairRunner implements Runnable {
           clusterFacade,
           segmentId,
           potentialCoordinators,
-          context.repairManager.getRepairTimeoutMillis(),
+          TimeUnit.MINUTES.toMillis(repairUnit.getTimeout()),
           intensity,
           validationParallelism,
           clusterName,

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -24,6 +24,7 @@ import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.CompactionStats;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.core.RepairRun;
+import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Segment;
@@ -37,6 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -51,6 +53,8 @@ import java.util.stream.Collectors;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -68,6 +72,12 @@ final class RepairRunner implements Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(RepairRunner.class);
   private static final ExecutorService METRICS_GRABBER_EXECUTOR = Executors.newFixedThreadPool(10);
+  // Threshold over which adaptive schedules will get tuned for more segments.
+  private static final int PERCENT_EXTENDED_THRESHOLD = 20;
+  // Minimun number of segments per nodes for adaptive schedule auto-tune.
+  private static final int MIN_SEGMENTS_PER_NODE_REDUCTION = 16;
+  // Segment duration under which adaptive schedules will get a reduction in segments per node.
+  private static final int SEGMENT_DURATION_FOR_REDUCTION_THRESHOLD = 5;
 
   private final AppContext context;
   private final ClusterFacade clusterFacade;
@@ -273,8 +283,106 @@ final class RepairRunner implements Runnable {
 
         context.metricRegistry.counter(
           MetricRegistry.name(RepairManager.class, "repairDone", RepairRun.RunState.DONE.toString())).inc();
+
+        maybeAdaptRepairSchedule();
       }
     }
+  }
+
+  /**
+   * Tune segment timeout and number of segments for adaptive schedules.
+   * Checks that the run was triggered by an adaptive schedule and gathers info on the run to apply tunings.
+   */
+  @VisibleForTesting
+  public void maybeAdaptRepairSchedule() {
+    Optional<RepairRun> repairRun = context.storage.getRepairRun(repairRunId);
+    if (repairRun.isPresent() && Boolean.TRUE.equals(repairRun.get().getAdaptiveSchedule())) {
+      Collection<RepairSegment> segments
+          = context.storage.getSegmentsWithState(repairRunId, RepairSegment.State.DONE);
+      int maxSegmentDurationInMins = segments.stream()
+          .mapToInt(repairSegment
+              -> (int) (repairSegment.getEndTime().getMillis() - repairSegment.getStartTime().getMillis()) / 60_000)
+          .max()
+          .orElseThrow(NoSuchElementException::new);
+      int extendedSegments = (int) segments.stream().filter(segment -> segment.getFailCount() > 0).count();
+      double percentExtendedSegments
+          = ((float) extendedSegments / (float) repairRun.get().getSegmentCount()) * 100.0;
+      LOG.info("extendedSegments = {}, total segments = {}, percent extended = {}",
+          extendedSegments,
+          repairRun.get().getSegmentCount(),
+          percentExtendedSegments);
+      tuneAdaptiveRepair(percentExtendedSegments, maxSegmentDurationInMins);
+    }
+  }
+
+  @VisibleForTesting
+  void tuneAdaptiveRepair(double percentExtendedSegments, int maxSegmentDuration) {
+    LOG.info("Percent extended segments: {}", percentExtendedSegments);
+    if (percentExtendedSegments > PERCENT_EXTENDED_THRESHOLD) {
+      // Too many segments were extended, meaning that the number of segments is too low
+      addSegmentsPerNodeToScheduleForUnit();
+    } else if ((int) percentExtendedSegments <= PERCENT_EXTENDED_THRESHOLD && percentExtendedSegments >= 1) {
+      // The number of extended segments is moderate and timeout should be extended
+      raiseTimeoutOfUnit();
+    } else if (percentExtendedSegments == 0 && maxSegmentDuration < SEGMENT_DURATION_FOR_REDUCTION_THRESHOLD) {
+      // Segments are being executed very fast so segment count could be lowered
+      reduceSegmentsPerNodeToScheduleForUnit();
+    }
+  }
+
+  @VisibleForTesting
+  void reduceSegmentsPerNodeToScheduleForUnit() {
+    LOG.debug("Reducing segments per node for adaptive schedule on repair unit {}", repairUnit.getId());
+    RepairSchedule scheduleToTune = getScheduleForRun();
+
+    // Reduce segments by decrements of 10%
+    int newSegmentCountPerNode
+        = (int) Math.max(MIN_SEGMENTS_PER_NODE_REDUCTION, scheduleToTune.getSegmentCountPerNode() / 1.1);
+
+    // update schedule with new segment per node value
+    RepairSchedule newSchedule
+        = scheduleToTune.with().segmentCountPerNode(newSegmentCountPerNode).build(scheduleToTune.getId());
+    context.storage.updateRepairSchedule(newSchedule);
+
+  }
+
+  @VisibleForTesting
+  void raiseTimeoutOfUnit() {
+    // Build updated repair unit
+    RepairUnit updatedUnit = repairUnit.with().timeout(repairUnit.getTimeout() * 2).build(repairUnit.getId());
+
+    // update unit with new timeout
+    context.storage.updateRepairUnit(updatedUnit);
+  }
+
+  @VisibleForTesting
+  void addSegmentsPerNodeToScheduleForUnit() {
+    LOG.debug("Adding segments per node for adaptive schedule on repair unit {}", repairUnit.getId());
+    RepairSchedule scheduleToTune = getScheduleForRun();
+
+    // Reduce segments by increments of 20%
+    int newSegmentCountPerNode
+        = (int) Math.max(MIN_SEGMENTS_PER_NODE_REDUCTION, scheduleToTune.getSegmentCountPerNode() * 1.2);
+
+    // update schedule with new segment per node value
+    RepairSchedule newSchedule
+        = scheduleToTune.with().segmentCountPerNode(newSegmentCountPerNode).build(scheduleToTune.getId());
+    context.storage.updateRepairSchedule(newSchedule);
+  }
+
+  private RepairSchedule getScheduleForRun() {
+    // find schedule
+    Collection<RepairSchedule> schedulesForKeyspace
+        = context.storage.getRepairSchedulesForClusterAndKeyspace(clusterName, repairUnit.getKeyspaceName());
+    List<RepairSchedule> schedulesToTune = schedulesForKeyspace.stream()
+        .filter(schedule -> schedule.getRepairUnitId().equals(repairUnit.getId()))
+        .collect(Collectors.toList());
+
+    // Set precondition that only a single schedule should match
+    Preconditions.checkArgument(schedulesToTune.size() == 1, String.format("Update for repair run %s and unit %s "
+        + "should impact a single schedule. %d were found", repairRunId, repairUnit.getId(), schedulesToTune.size()));
+
+    return schedulesToTune.get(0);
   }
 
   /**

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -96,7 +96,8 @@ public final class RepairScheduleService {
       int segmentCountPerNode,
       RepairParallelism repairParallelism,
       Double intensity,
-      boolean force) {
+      boolean force,
+      boolean adaptive) {
 
     Preconditions.checkArgument(
         force || !conflictingRepairSchedule(cluster, repairUnit.with()).isPresent(),
@@ -111,7 +112,8 @@ public final class RepairScheduleService {
         .repairParallelism(repairParallelism)
         .intensity(intensity)
         .segmentCountPerNode(segmentCountPerNode)
-        .owner(owner);
+        .owner(owner)
+        .adaptive(adaptive);
 
     return context.storage.addRepairSchedule(scheduleBuilder);
   }

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -303,10 +303,10 @@ public final class SchedulingManager extends TimerTask {
         repairUnit,
         Optional.of(getCauseName(schedule)),
         schedule.getOwner(),
-        schedule.getSegmentCount(),
         schedule.getSegmentCountPerNode(),
         schedule.getRepairParallelism(),
-        schedule.getIntensity());
+        schedule.getIntensity(),
+        schedule.getAdaptive());
   }
 
   private static String getCauseName(RepairSchedule schedule) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -89,6 +89,8 @@ public interface IStorage {
 
   Optional<RepairUnit> getRepairUnit(RepairUnit.Builder repairUnit);
 
+  void updateRepairUnit(RepairUnit updatedRepairUnit);
+
   boolean updateRepairSegment(RepairSegment newRepairSegment);
 
   Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId);

--- a/src/server/src/main/java/io/cassandrareaper/storage/InitializeStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/InitializeStorage.java
@@ -56,7 +56,7 @@ public final class InitializeStorage {
   }
 
   public IStorage initializeStorageBackend()
-    throws ReaperException {
+      throws ReaperException {
     IStorage storage;
     LOG.info("Initializing the database and performing schema migrations");
 
@@ -82,7 +82,8 @@ public final class InitializeStorage {
       // instantiate store
       storage = new PostgresStorage(
           reaperInstanceId,
-          factory.build(environment, config.getDataSourceFactory(), "postgresql")
+          factory.build(environment, config.getDataSourceFactory(), "postgresql"),
+          config.getHangingRepairTimeoutMins()
       );
       initDatabase(config);
     } else {

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -502,7 +502,8 @@ public final class MemoryStorage implements IStorage {
               unit.getDatacenters(),
               unit.getBlacklistedTables(),
               unit.getRepairThreadCount(),
-              unit.getId()));
+              unit.getId(),
+              unit.getTimeout()));
     }
     return runStatuses;
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -287,6 +287,12 @@ public final class MemoryStorage implements IStorage {
   }
 
   @Override
+  public void updateRepairUnit(RepairUnit updatedRepairUnit) {
+    repairUnits.put(updatedRepairUnit.getId(), updatedRepairUnit);
+    repairUnitsByKey.put(updatedRepairUnit.with(), updatedRepairUnit);
+  }
+
+  @Override
   public RepairUnit getRepairUnit(UUID id) {
     RepairUnit unit = repairUnits.get(id);
     Preconditions.checkArgument(null != unit);
@@ -503,7 +509,8 @@ public final class MemoryStorage implements IStorage {
               unit.getBlacklistedTables(),
               unit.getRepairThreadCount(),
               unit.getId(),
-              unit.getTimeout()));
+              unit.getTimeout(),
+              run.getAdaptiveSchedule()));
     }
     return runStatuses;
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -376,6 +376,13 @@ public class PostgresStorage implements IStorage, IDistributedStorage {
   }
 
   @Override
+  public void updateRepairUnit(RepairUnit updatedRepairUnit) {
+    try (Handle h = jdbi.open()) {
+      getPostgresStorage(h).updateRepairUnit(updatedRepairUnit);
+    }
+  }
+
+  @Override
   public RepairUnit getRepairUnit(UUID id) {
     RepairUnit result;
     try (Handle h = jdbi.open()) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -75,18 +75,19 @@ public interface IStoragePostgreSql {
   //
   String SQL_REPAIR_RUN_ALL_FIELDS_NO_ID = "cluster_name, repair_unit_id, cause, owner, state, creation_time, "
       + "start_time, end_time, pause_time, intensity, last_event, "
-      + "segment_count, repair_parallelism, tables";
+      + "segment_count, repair_parallelism, tables, adaptive_schedule";
   String SQL_REPAIR_RUN_ALL_FIELDS = "repair_run.id, " + SQL_REPAIR_RUN_ALL_FIELDS_NO_ID;
   String SQL_INSERT_REPAIR_RUN = "INSERT INTO repair_run ("
       + SQL_REPAIR_RUN_ALL_FIELDS_NO_ID
       + ") VALUES "
       + "(:clusterName, :repairUnitId, :cause, :owner, :runState, :creationTime, "
       + ":startTime, :endTime, :pauseTime, :intensity, :lastEvent, :segmentCount, "
-      + ":repairParallelism, :tables)";
+      + ":repairParallelism, :tables, :adaptiveSchedule)";
   String SQL_UPDATE_REPAIR_RUN = "UPDATE repair_run SET cause = :cause, owner = :owner, state = :runState, "
       + "start_time = :startTime, end_time = :endTime, pause_time = :pauseTime, "
       + "intensity = :intensity, last_event = :lastEvent, segment_count = :segmentCount, "
-      + "repair_parallelism = :repairParallelism, tables = :tables WHERE id = :id";
+      + "repair_parallelism = :repairParallelism, tables = :tables, adaptive_schedule = :adaptiveSchedule "
+      + "WHERE id = :id";
   String SQL_GET_REPAIR_RUN = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS + " FROM repair_run WHERE id = :id";
   String SQL_GET_REPAIR_RUNS_FOR_CLUSTER = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS
       + " FROM repair_run WHERE cluster_name = :clusterName ORDER BY id desc LIMIT :limit";
@@ -106,6 +107,12 @@ public interface IStoragePostgreSql {
           + ") VALUES "
           + "(:clusterName, :keyspaceName, :columnFamilies, "
           + ":incrementalRepair, :nodes, :datacenters, :blacklistedTables, :repairThreadCount, :timeout)";
+  String SQL_UPDATE_REPAIR_UNIT = "UPDATE repair_unit "
+          + "SET cluster_name = :clusterName, keyspace_name = :keyspaceName, "
+          + "column_families = :columnFamilies, incremental_repair = :incrementalRepair, nodes = :nodes, "
+          + "datacenters = :datacenters, blacklisted_tables = :blacklistedTables, "
+          + "repair_thread_count = :repairThreadCount, timeout = :timeout "
+          + "WHERE id = :id";
   String SQL_GET_REPAIR_UNIT = "SELECT " + SQL_REPAIR_UNIT_ALL_FIELDS + " FROM repair_unit WHERE id = :id";
 
   String SQL_GET_REPAIR_UNIT_BY_CLUSTER_AND_TABLES = "SELECT "
@@ -168,22 +175,22 @@ public interface IStoragePostgreSql {
   // RepairSchedule
   //
   String SQL_REPAIR_SCHEDULE_ALL_FIELDS_NO_ID
-      = "repair_unit_id, state, days_between, next_activation, run_history, segment_count, "
-          + "repair_parallelism, intensity, creation_time, owner, pause_time, segment_count_per_node ";
+      = "repair_unit_id, state, days_between, next_activation, run_history, "
+          + "repair_parallelism, intensity, creation_time, owner, pause_time, segment_count_per_node, adaptive ";
   String SQL_REPAIR_SCHEDULE_ALL_FIELDS = "repair_schedule.id, " + SQL_REPAIR_SCHEDULE_ALL_FIELDS_NO_ID;
   String SQL_INSERT_REPAIR_SCHEDULE
       = "INSERT INTO repair_schedule ("
           + SQL_REPAIR_SCHEDULE_ALL_FIELDS_NO_ID
           + ") VALUES "
-          + "(:repairUnitId, :state, :daysBetween, :nextActivation, :runHistorySql, :segmentCount, "
-          + ":repairParallelism, :intensity, :creationTime, :owner, :pauseTime, :segmentCountPerNode)";
+          + "(:repairUnitId, :state, :daysBetween, :nextActivation, :runHistorySql, "
+          + ":repairParallelism, :intensity, :creationTime, :owner, :pauseTime, :segmentCountPerNode, :adaptive)";
   String SQL_UPDATE_REPAIR_SCHEDULE
       = "UPDATE repair_schedule SET repair_unit_id = :repairUnitId, state = :state, "
           + "days_between = :daysBetween, next_activation = :nextActivation, "
-          + "run_history = :runHistorySql, segment_count = :segmentCount, "
+          + "run_history = :runHistorySql, "
           + "segment_count_per_node = :segmentCountPerNode, "
           + "repair_parallelism = :repairParallelism, creation_time = :creationTime, owner = :owner, "
-          + "pause_time = :pauseTime WHERE id = :id";
+          + "pause_time = :pauseTime, adaptive = :adaptive WHERE id = :id";
   String SQL_GET_REPAIR_SCHEDULE = "SELECT " + SQL_REPAIR_SCHEDULE_ALL_FIELDS + " FROM repair_schedule WHERE id = :id";
   String SQL_GET_REPAIR_SCHEDULES_FOR_CLUSTER = "SELECT "
       + SQL_REPAIR_SCHEDULE_ALL_FIELDS
@@ -228,10 +235,10 @@ public interface IStoragePostgreSql {
 
   String SQL_CLUSTER_SCHEDULE_OVERVIEW
       = "SELECT repair_schedule.id, owner, cluster_name, keyspace_name, column_families, state, "
-          + "creation_time, next_activation, pause_time, intensity, segment_count, "
+          + "creation_time, next_activation, pause_time, intensity,  "
           + "repair_parallelism, days_between, incremental_repair, nodes, "
           + "datacenters, blacklisted_tables, segment_count_per_node, repair_thread_count,"
-          + "repair_unit_id, repair_unit.timeout "
+          + "repair_unit_id, repair_unit.timeout, adaptive "
           + "FROM repair_schedule "
           + "JOIN repair_unit ON repair_unit_id = repair_unit.id "
           + "WHERE cluster_name = :clusterName";
@@ -549,6 +556,10 @@ public interface IStoragePostgreSql {
   @GetGeneratedKeys
   long insertRepairUnit(
       @BindBean RepairUnit newRepairUnit);
+
+  @SqlUpdate(SQL_UPDATE_REPAIR_UNIT)
+  void updateRepairUnit(
+      @BindBean RepairUnit updatedRepairUnit);
 
   @SqlUpdate(SQL_DELETE_REPAIR_UNIT)
   int deleteRepairUnit(

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -99,13 +99,13 @@ public interface IStoragePostgreSql {
   // RepairUni
   //
   String SQL_REPAIR_UNIT_ALL_FIELDS_NO_ID = "cluster_name, keyspace_name, column_families, "
-          + "incremental_repair, nodes, datacenters, blacklisted_tables, repair_thread_count";
+          + "incremental_repair, nodes, datacenters, blacklisted_tables, repair_thread_count, timeout";
   String SQL_REPAIR_UNIT_ALL_FIELDS = "repair_unit.id, " + SQL_REPAIR_UNIT_ALL_FIELDS_NO_ID;
   String SQL_INSERT_REPAIR_UNIT = "INSERT INTO repair_unit ("
           + SQL_REPAIR_UNIT_ALL_FIELDS_NO_ID
           + ") VALUES "
           + "(:clusterName, :keyspaceName, :columnFamilies, "
-          + ":incrementalRepair, :nodes, :datacenters, :blacklistedTables, :repairThreadCount)";
+          + ":incrementalRepair, :nodes, :datacenters, :blacklistedTables, :repairThreadCount, :timeout)";
   String SQL_GET_REPAIR_UNIT = "SELECT " + SQL_REPAIR_UNIT_ALL_FIELDS + " FROM repair_unit WHERE id = :id";
 
   String SQL_GET_REPAIR_UNIT_BY_CLUSTER_AND_TABLES = "SELECT "
@@ -230,7 +230,8 @@ public interface IStoragePostgreSql {
       = "SELECT repair_schedule.id, owner, cluster_name, keyspace_name, column_families, state, "
           + "creation_time, next_activation, pause_time, intensity, segment_count, "
           + "repair_parallelism, days_between, incremental_repair, nodes, "
-          + "datacenters, blacklisted_tables, segment_count_per_node, repair_thread_count, repair_unit_id "
+          + "datacenters, blacklisted_tables, segment_count_per_node, repair_thread_count,"
+          + "repair_unit_id, repair_unit.timeout "
           + "FROM repair_schedule "
           + "JOIN repair_unit ON repair_unit_id = repair_unit.id "
           + "WHERE cluster_name = :clusterName";
@@ -541,7 +542,8 @@ public interface IStoragePostgreSql {
       @Bind("nodes") Collection<String> nodes,
       @Bind("datacenters") Collection<String> datacenters,
       @Bind("blacklisted_tables") Collection<String> blacklistedTables,
-      @Bind("repairThreadCount") int repairThreadCount);
+      @Bind("repairThreadCount") int repairThreadCount,
+      @Bind("timeout") int timeout);
 
   @SqlUpdate(SQL_INSERT_REPAIR_UNIT)
   @GetGeneratedKeys

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunMapper.java
@@ -63,6 +63,7 @@ public final class RepairRunMapper implements ResultSetMapper<RepairRun> {
         .endTime(getDateTimeOrNull(rs, "end_time"))
         .pauseTime(getDateTimeOrNull(rs, "pause_time"))
         .lastEvent(rs.getString("last_event"))
+        .adaptiveSchedule(rs.getBoolean("adaptive_schedule"))
         .build(UuidUtil.fromSequenceId(rs.getLong("id")));
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
@@ -78,6 +78,7 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
 
     int repairThreadCount = rs.getInt("repair_thread_count");
     int timeout = rs.getInt("timeout");
+    boolean adaptiveSchedule = rs.getBoolean("adaptive_schedule");
 
     return new RepairRunStatus(
         UuidUtil.fromSequenceId(runId),
@@ -102,7 +103,8 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
         blacklistedTables,
         repairThreadCount,
         UuidUtil.fromSequenceId(unitId),
-        timeout
+        timeout,
+        adaptiveSchedule
         );
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
@@ -77,6 +77,7 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
                     : rs.getArray("blacklisted_tables").getArray()));
 
     int repairThreadCount = rs.getInt("repair_thread_count");
+    int timeout = rs.getInt("timeout");
 
     return new RepairRunStatus(
         UuidUtil.fromSequenceId(runId),
@@ -100,6 +101,8 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
         datacenters,
         blacklistedTables,
         repairThreadCount,
-        UuidUtil.fromSequenceId(unitId));
+        UuidUtil.fromSequenceId(unitId),
+        timeout
+        );
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleMapper.java
@@ -70,13 +70,13 @@ public final class RepairScheduleMapper implements ResultSetMapper<RepairSchedul
         .daysBetween(rs.getInt("days_between"))
         .nextActivation(RepairRunMapper.getDateTimeOrNull(rs, "next_activation"))
         .runHistory(ImmutableList.copyOf(runHistoryUuids))
-        .segmentCount(rs.getInt("segment_count"))
         .repairParallelism(RepairParallelism.fromName(parallelism))
         .intensity(rs.getDouble("intensity"))
         .creationTime(RepairRunMapper.getDateTimeOrNull(rs, "creation_time"))
         .segmentCountPerNode(rs.getInt("segment_count_per_node"))
         .owner(rs.getString("owner"))
         .pauseTime(RepairRunMapper.getDateTimeOrNull(rs, "pause_time"))
+        .adaptive(rs.getBoolean("adaptive"))
         .build(UuidUtil.fromSequenceId(rs.getLong("id")));
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -67,7 +67,8 @@ public final class RepairScheduleStatusMapper implements ResultSetMapper<RepairS
                 : getStringArray(rs.getArray("blacklisted_tables").getArray())),
         rs.getInt("segment_count_per_node"),
         rs.getInt("repair_thread_count"),
-        UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")));
+        UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")),
+        rs.getInt("timeout"));
   }
 
   private String[] getStringArray(Object array) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -47,7 +47,6 @@ public final class RepairScheduleStatusMapper implements ResultSetMapper<RepairS
         RepairRunMapper.getDateTimeOrNull(rs, "pause_time"),
         rs.getDouble("intensity"),
         rs.getBoolean("incremental_repair"),
-        rs.getInt("segment_count"),
         RepairParallelism.fromName(
             rs.getString("repair_parallelism")
                 .toLowerCase()
@@ -68,7 +67,8 @@ public final class RepairScheduleStatusMapper implements ResultSetMapper<RepairS
         rs.getInt("segment_count_per_node"),
         rs.getInt("repair_thread_count"),
         UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")),
-        rs.getInt("timeout"));
+        rs.getInt("timeout"),
+        rs.getBoolean("adaptive"));
   }
 
   private String[] getStringArray(Object array) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairUnitMapper.java
@@ -45,6 +45,10 @@ public final class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
             ? new String[] {}
             : IStoragePostgreSql.parseStringArray(rs.getArray("blacklisted_tables").getArray());
 
+    int segmentTimeout = rs.getInt("timeout") == 0
+            ? 30
+            : rs.getInt("timeout");
+
     RepairUnit.Builder builder = RepairUnit.builder()
             .clusterName(rs.getString("cluster_name"))
             .keyspaceName(rs.getString("keyspace_name"))
@@ -53,7 +57,8 @@ public final class RepairUnitMapper implements ResultSetMapper<RepairUnit> {
             .nodes(Sets.newHashSet(nodes))
             .datacenters(Sets.newHashSet(datacenters))
             .blacklistedTables(Sets.newHashSet(blacklistedTables))
-            .repairThreadCount(rs.getInt("repair_thread_count"));
+            .repairThreadCount(rs.getInt("repair_thread_count"))
+            .timeout(segmentTimeout);
 
     return builder.build(UuidUtil.fromSequenceId(rs.getLong("id")));
   }

--- a/src/server/src/main/resources/db/astra/005_adaptive_repairs.cql
+++ b/src/server/src/main/resources/db/astra/005_adaptive_repairs.cql
@@ -16,3 +16,5 @@
 -- Store the repair segment timeout in the repair unit
 
 ALTER TABLE repair_unit_v1 ADD timeout int;
+ALTER TABLE repair_schedule_v1 ADD adaptive boolean;
+ALTER TABLE repair_run ADD adaptive_schedule boolean static;

--- a/src/server/src/main/resources/db/astra/005_adaptive_repairs.cql
+++ b/src/server/src/main/resources/db/astra/005_adaptive_repairs.cql
@@ -1,0 +1,18 @@
+--
+--  Copyright 2021-2021 Datastax inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Store the repair segment timeout in the repair unit
+
+ALTER TABLE repair_unit_v1 ADD timeout int;

--- a/src/server/src/main/resources/db/cassandra/029_adaptive_repairs.cql
+++ b/src/server/src/main/resources/db/cassandra/029_adaptive_repairs.cql
@@ -16,3 +16,5 @@
 -- Store the repair segment timeout in the repair unit
 
 ALTER TABLE repair_unit_v1 ADD timeout int;
+ALTER TABLE repair_schedule_v1 ADD adaptive boolean;
+ALTER TABLE repair_run ADD adaptive_schedule boolean static;

--- a/src/server/src/main/resources/db/cassandra/029_adaptive_repairs.cql
+++ b/src/server/src/main/resources/db/cassandra/029_adaptive_repairs.cql
@@ -1,0 +1,18 @@
+--
+--  Copyright 2021-2021 Datastax inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Store the repair segment timeout in the repair unit
+
+ALTER TABLE repair_unit_v1 ADD timeout int;

--- a/src/server/src/main/resources/db/h2/V22_0_0__adaptive_repairs.sql
+++ b/src/server/src/main/resources/db/h2/V22_0_0__adaptive_repairs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repair_unit
+ADD timeout INT NOT NULL DEFAULT 0;

--- a/src/server/src/main/resources/db/h2/V22_0_0__adaptive_repairs.sql
+++ b/src/server/src/main/resources/db/h2/V22_0_0__adaptive_repairs.sql
@@ -1,2 +1,11 @@
 ALTER TABLE repair_unit
 ADD timeout INT NOT NULL DEFAULT 0;
+
+ALTER TABLE repair_schedule
+ADD adaptive BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE repair_run
+ADD adaptive_schedule BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE repair_schedule
+DROP segment_count;

--- a/src/server/src/main/resources/db/postgres/V22_0_0__adaptive_repairs.sql
+++ b/src/server/src/main/resources/db/postgres/V22_0_0__adaptive_repairs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "repair_unit" 
+ADD "timeout" INT NOT NULL DEFAULT 0;

--- a/src/server/src/main/resources/db/postgres/V22_0_0__adaptive_repairs.sql
+++ b/src/server/src/main/resources/db/postgres/V22_0_0__adaptive_repairs.sql
@@ -1,2 +1,11 @@
 ALTER TABLE "repair_unit" 
 ADD "timeout" INT NOT NULL DEFAULT 0;
+
+ALTER TABLE "repair_schedule"
+ADD "adaptive" BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE "repair_run"
+ADD "adaptive_schedule" BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE "repair_schedule"
+DROP "segment_count";

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -417,6 +417,7 @@ public final class BasicSteps {
       params.put("scheduleDaysBetween", "1");
       params.put("repairParallelism", repairType.equals("incremental") ? "parallel" : "sequential");
       params.put("incrementalRepair", repairType.equals("incremental") ? "True" : "False");
+      params.put("adaptive", "False");
       Response response = runner.callReaper("POST", "/repair_schedule", Optional.of(params));
       int responseStatus = response.getStatus();
       String responseEntity = response.readEntity(String.class);

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -98,6 +98,7 @@ public final class RepairRunResourceTest {
   private static final double REPAIR_INTENSITY = 0.5f;
   private static final RepairParallelism REPAIR_PARALLELISM = RepairParallelism.SEQUENTIAL;
   private static final String STCS = "SizeTieredCompactionStrategy";
+  private static final int SEGMENT_TIMEOUT = 30;
 
   private static final List<BigInteger> TOKENS = Lists.newArrayList(
       BigInteger.valueOf(0L),
@@ -118,8 +119,6 @@ public final class RepairRunResourceTest {
     context.repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(THREAD_CNT),
-        REPAIR_TIMEOUT_S,
-        TimeUnit.SECONDS,
         RETRY_DELAY_S,
         TimeUnit.SECONDS,
         1);
@@ -138,6 +137,7 @@ public final class RepairRunResourceTest {
     context.config = new ReaperApplicationConfiguration();
     context.config.setSegmentCount(SEGMENT_CNT);
     context.config.setRepairIntensity(REPAIR_INTENSITY);
+    context.config.setHangingRepairTimeoutMins(SEGMENT_TIMEOUT);
 
     uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(SAMPLE_URI));
@@ -190,7 +190,8 @@ public final class RepairRunResourceTest {
             .nodes(NODES)
             .datacenters(DATACENTERS)
             .blacklistedTables(BLACKLISTED_TABLES)
-            .repairThreadCount(REPAIR_THREAD_COUNT);
+            .repairThreadCount(REPAIR_THREAD_COUNT)
+            .timeout(SEGMENT_TIMEOUT);
 
     context.storage.addRepairUnit(repairUnitBuilder);
   }
@@ -237,7 +238,8 @@ public final class RepairRunResourceTest {
         Optional.<String>empty(),
         blacklistedTables.isEmpty() ? Optional.empty() : Optional.of(StringUtils.join(blacklistedTables, ',')),
         Optional.of(repairThreadCount),
-        Optional.<String>empty());
+        Optional.<String>empty(),
+        Optional.of(30));
   }
 
   @Test
@@ -293,6 +295,7 @@ public final class RepairRunResourceTest {
   @Test
   public void doesNotDisplayBlacklistedCompactionStrategies() throws Exception {
     context.config.setBlacklistTwcsTables(true);
+    context.config.setHangingRepairTimeoutMins(30);
     when(proxy.getKeyspaces()).thenReturn(Lists.newArrayList(keyspace));
 
     when(proxy.getTablesForKeyspace(keyspace)).thenReturn(
@@ -539,7 +542,8 @@ public final class RepairRunResourceTest {
       Set<String> nodes,
       Set<String> blacklistedTables,
       Integer repairThreadCount,
-      String force) {
+      String force,
+      Integer segmentTimeout) {
 
     return resource.addRepairRun(
         uriInfo,
@@ -556,7 +560,8 @@ public final class RepairRunResourceTest {
         Optional.<String>empty(),
         blacklistedTables.isEmpty() ? Optional.empty() : Optional.of(StringUtils.join(blacklistedTables, ',')),
         Optional.of(repairThreadCount),
-        Optional.of(force));
+        Optional.of(force),
+        Optional.of(segmentTimeout));
   }
 
   @Test
@@ -575,7 +580,8 @@ public final class RepairRunResourceTest {
             NODES,
             BLACKLISTED_TABLES,
             REPAIR_THREAD_COUNT,
-            "foo");
+            "foo",
+            30);
 
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     assertTrue(response.getEntity() instanceof String);

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
@@ -180,9 +180,6 @@ public class RepairScheduleResourceTest {
     // repairUnitId
     assertThat(patchedRepairSchedule.getRepairUnitId()).isNotNull();
     assertThat(patchedRepairSchedule.getRepairUnitId()).isEqualTo(mockRepairSchedule.getRepairUnitId());
-    // segmentCount
-    assertThat(patchedRepairSchedule.getSegmentCount()).isNotNull();
-    assertThat(patchedRepairSchedule.getSegmentCount()).isEqualTo(mockRepairSchedule.getSegmentCount());
     // creationTime
     assertThat(patchedRepairSchedule.getCreationTime()).isNotNull();
     assertThat(patchedRepairSchedule.getCreationTime()).isEqualTo(mockRepairSchedule.getCreationTime());
@@ -301,7 +298,8 @@ public class RepairScheduleResourceTest {
         .incrementalRepair(false)
         .repairThreadCount(1)
         .clusterName("cluster-test")
-        .keyspaceName("keyspace-test");
+        .keyspaceName("keyspace-test")
+        .timeout(30);
     RepairUnit repairUnit = context.storage.addRepairUnit(mockRepairUnitBuilder);
     mockObjects.setRepairUnit(repairUnit);
 

--- a/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
@@ -79,7 +79,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1,
             UUID.randomUUID(),
-            30); // repair thread count
+            30,
+            false); // repair thread count
 
     assertEquals("1 minute 0 seconds", repairStatus.getDuration());
   }
@@ -109,7 +110,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1,
             UUID.randomUUID(),
-            30); // repair thread count
+            30,
+            false); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }
@@ -139,7 +141,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1,
             UUID.randomUUID(),
-            30); // repair thread count
+            30,
+            false); // repair thread count
 
     assertEquals("1 minute 50 seconds", repairStatus.getDuration());
   }
@@ -169,7 +172,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1,
             UUID.randomUUID(),
-            30); // repair thread count
+            30,
+            false); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }

--- a/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
@@ -17,7 +17,6 @@
 
 package io.cassandrareaper.resources.view;
 
-
 import io.cassandrareaper.core.RepairRun;
 
 import java.util.Collections;
@@ -49,7 +48,7 @@ public final class RepairRunStatusTest {
   }
 
   @Test
-  public void testDateTimeToISO8601() {
+  public void testDateTimeToIso8601() {
     DateTime dateTime = new DateTime(2015, 2, 20, 15, 24, 45, DateTimeZone.UTC);
     assertEquals("2015-02-20T15:24:45Z", RepairRunStatus.dateTimeToIso8601(dateTime));
   }
@@ -79,7 +78,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // datacenters
             Collections.EMPTY_LIST, // blacklist
             1,
-            UUID.randomUUID()); // repair thread count
+            UUID.randomUUID(),
+            30); // repair thread count
 
     assertEquals("1 minute 0 seconds", repairStatus.getDuration());
   }
@@ -108,7 +108,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // datacenters
             Collections.EMPTY_LIST, // blacklist
             1,
-            UUID.randomUUID()); // repair thread count
+            UUID.randomUUID(),
+            30); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }
@@ -137,7 +138,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // datacenters
             Collections.EMPTY_LIST, // blacklist
             1,
-            UUID.randomUUID()); // repair thread count
+            UUID.randomUUID(),
+            30); // repair thread count
 
     assertEquals("1 minute 50 seconds", repairStatus.getDuration());
   }
@@ -166,7 +168,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // datacenters
             Collections.EMPTY_LIST, // blacklist
             1,
-            UUID.randomUUID()); // repair thread count
+            UUID.randomUUID(),
+            30); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -117,8 +117,8 @@ public final class ClusterRepairSchedulerTest {
   @Test
   public void removeSchedulesForKeyspaceThatNoLongerExists() throws Exception {
     context.storage.addCluster(cluster);
-    context.storage.addRepairSchedule(aRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
-    context.storage.addRepairSchedule(aRepairSchedule(cluster, "keyspace2", TWO_HOURS_AGO));
+    context.storage.addRepairSchedule(oneRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
+    context.storage.addRepairSchedule(oneRepairSchedule(cluster, "keyspace2", TWO_HOURS_AGO));
     when(jmxProxy.getKeyspaces()).thenReturn(Lists.newArrayList("keyspace1"));
     clusterRepairAuto.scheduleRepairs(cluster);
     assertThat(context.storage.getAllRepairSchedules()).hasSize(1);
@@ -131,7 +131,7 @@ public final class ClusterRepairSchedulerTest {
   @Test
   public void addSchedulesForNewKeyspace() throws Exception {
     context.storage.addCluster(cluster);
-    context.storage.addRepairSchedule(aRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
+    context.storage.addRepairSchedule(oneRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
 
     when(jmxProxy.getKeyspaces()).thenReturn(Lists.newArrayList("keyspace1", "keyspace2"));
 
@@ -228,7 +228,7 @@ public final class ClusterRepairSchedulerTest {
         Arrays.asList(cluster.getName() + "-1", cluster.getName() + "-2")
     );
     context.storage.addCluster(cluster);
-    context.storage.addRepairSchedule(aRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
+    context.storage.addRepairSchedule(oneRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
     when(jmxProxy.getKeyspaces()).thenReturn(Lists.newArrayList("keyspace1"));
 
     clusterRepairAuto.scheduleRepairs(cluster);
@@ -243,8 +243,8 @@ public final class ClusterRepairSchedulerTest {
     return DateTime.now().plus(DELAY_BEFORE_SCHEDULE.toMillis());
   }
 
-  private RepairSchedule.Builder aRepairSchedule(Cluster cluster, String keyspace, DateTime creationTime) {
-    RepairUnit repairUnit = context.storage.addRepairUnit(aRepair(cluster, keyspace));
+  private RepairSchedule.Builder oneRepairSchedule(Cluster cluster, String keyspace, DateTime creationTime) {
+    RepairUnit repairUnit = context.storage.addRepairUnit(oneRepair(cluster, keyspace));
 
     return RepairSchedule.builder(repairUnit.getId())
         .creationTime(creationTime)
@@ -252,12 +252,11 @@ public final class ClusterRepairSchedulerTest {
         .nextActivation(DateTime.now())
         .repairParallelism(RepairParallelism.DATACENTER_AWARE)
         .intensity(0.9)
-        .segmentCount(10)
-        .segmentCountPerNode(0);
+        .segmentCountPerNode(3);
 
   }
 
-  private RepairUnit.Builder aRepair(Cluster cluster, String keyspace) {
+  private RepairUnit.Builder oneRepair(Cluster cluster, String keyspace) {
     return RepairUnit.builder()
         .clusterName(cluster.getName())
         .keyspaceName(keyspace)
@@ -304,7 +303,6 @@ public final class ClusterRepairSchedulerTest {
 
         assertThat(repairSchedule.getDaysBetween()).isEqualTo(config.getScheduleDaysBetween());
         assertThat(repairSchedule.getIntensity()).isEqualTo(config.getRepairIntensity());
-        assertThat(repairSchedule.getSegmentCount()).isEqualTo(0);
         assertThat(repairSchedule.getSegmentCountPerNode())
             .isEqualTo(config.getSegmentCountPerNode());
         assertThat(repairSchedule.getRepairParallelism()).isEqualTo(config.getRepairParallelism());

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -262,7 +262,8 @@ public final class ClusterRepairSchedulerTest {
         .clusterName(cluster.getName())
         .keyspaceName(keyspace)
         .incrementalRepair(Boolean.FALSE)
-        .repairThreadCount(1);
+        .repairThreadCount(1)
+        .timeout(30);
   }
 
   private ClusterRepairScheduleAssertion assertThatClusterRepairSchedules(Collection<RepairSchedule> repairSchedules) {

--- a/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
@@ -172,8 +172,6 @@ public final class HeartTest {
     context.repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        REPAIR_TIMEOUT_S,
-        TimeUnit.SECONDS,
         RETRY_DELAY_S,
         TimeUnit.SECONDS,
         1);
@@ -203,8 +201,6 @@ public final class HeartTest {
     context.repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        REPAIR_TIMEOUT_S,
-        TimeUnit.SECONDS,
         RETRY_DELAY_S,
         TimeUnit.SECONDS,
         1);
@@ -237,8 +233,6 @@ public final class HeartTest {
     context.repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        REPAIR_TIMEOUT_S,
-        TimeUnit.SECONDS,
         RETRY_DELAY_S,
         TimeUnit.SECONDS,
         1);
@@ -275,8 +269,6 @@ public final class HeartTest {
     context.repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        REPAIR_TIMEOUT_S,
-        TimeUnit.SECONDS,
         RETRY_DELAY_S,
         TimeUnit.SECONDS,
         1);

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -82,6 +82,7 @@ public final class RepairManagerTest {
     final Set<String> datacenters = Collections.emptySet();
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
 
     // use CassandraStorage so we get both IStorage and IDistributedStorage
     final IStorage storage = mock(CassandraStorage.class);
@@ -95,8 +96,6 @@ public final class RepairManagerTest {
     RepairManager repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        500,
-        TimeUnit.MILLISECONDS,
         1,
         TimeUnit.MILLISECONDS,
         1);
@@ -112,6 +111,7 @@ public final class RepairManagerTest {
         .nodes(nodes)
         .datacenters(datacenters)
         .repairThreadCount(repairThreadCount)
+        .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
 
     final RepairRun run = RepairRun.builder(clusterName, cf.getId())
@@ -159,6 +159,7 @@ public final class RepairManagerTest {
     final Set<String> datacenters = Collections.emptySet();
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
 
     // use CassandraStorage so we get both IStorage and IDistributedStorage
     final IStorage storage = mock(CassandraStorage.class);
@@ -172,8 +173,6 @@ public final class RepairManagerTest {
     RepairManager repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        500,
-        TimeUnit.MILLISECONDS,
         1,
         TimeUnit.MILLISECONDS,
         1);
@@ -189,6 +188,7 @@ public final class RepairManagerTest {
         .nodes(nodes)
         .datacenters(datacenters)
         .repairThreadCount(repairThreadCount)
+        .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
 
     final RepairRun run = RepairRun.builder(clusterName, cf.getId())
@@ -240,6 +240,7 @@ public final class RepairManagerTest {
     final Set<String> datacenters = Collections.emptySet();
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
 
     final IStorage storage = mock(IStorage.class);
 
@@ -252,8 +253,6 @@ public final class RepairManagerTest {
     RepairManager repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        500,
-        TimeUnit.MILLISECONDS,
         1,
         TimeUnit.MILLISECONDS,
         1);
@@ -269,6 +268,7 @@ public final class RepairManagerTest {
         .nodes(nodes)
         .datacenters(datacenters)
         .repairThreadCount(repairThreadCount)
+        .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
 
     final RepairRun run = RepairRun.builder(clusterName, cf.getId())
@@ -317,6 +317,7 @@ public final class RepairManagerTest {
     final Set<String> datacenters = Collections.emptySet();
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
 
     final IStorage storage = mock(IStorage.class);
 
@@ -329,8 +330,6 @@ public final class RepairManagerTest {
     RepairManager repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        500,
-        TimeUnit.MILLISECONDS,
         1,
         TimeUnit.MILLISECONDS,
         1);
@@ -346,6 +345,7 @@ public final class RepairManagerTest {
         .nodes(nodes)
         .datacenters(datacenters)
         .repairThreadCount(repairThreadCount)
+        .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
 
     final RepairRun run = RepairRun.builder(clusterName, cf.getId())
@@ -388,8 +388,6 @@ public final class RepairManagerTest {
     context.repairManager = RepairManager.create(
         context,
         Executors.newScheduledThreadPool(1),
-        500,
-        TimeUnit.MILLISECONDS,
         1,
         TimeUnit.MILLISECONDS,
         1);
@@ -400,6 +398,7 @@ public final class RepairManagerTest {
     final Set<String> nodes = Sets.newHashSet("127.0.0.1");
     final Set<String> datacenters = Collections.emptySet();
     final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
 
     final RepairUnit cf = RepairUnit.builder()
         .clusterName(clusterName)
@@ -409,6 +408,7 @@ public final class RepairManagerTest {
         .nodes(nodes)
         .datacenters(datacenters)
         .repairThreadCount(repairThreadCount)
+        .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
 
     double intensity = 0.5f;
@@ -436,14 +436,6 @@ public final class RepairManagerTest {
     context.config = new ReaperApplicationConfiguration();
     context.storage = mock(CassandraStorage.class);
     doReturn(true).when(context.storage).updateRepairRun(any());
-    RepairManager repairManager = RepairManager.create(
-        context,
-        Executors.newScheduledThreadPool(1),
-        500,
-        TimeUnit.MILLISECONDS,
-        1,
-        TimeUnit.MILLISECONDS,
-        100);
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     String cluster1 = "cluster1";
     String cluster2 = "cluster2";
@@ -489,7 +481,12 @@ public final class RepairManagerTest {
             return Optional.of(repairRuns.get(invocation.getArgument(0)));
           }
         });
-
+    RepairManager repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        1,
+        TimeUnit.MILLISECONDS,
+        100);
     repairRuns.entrySet().stream().forEach(run -> {
       try {
         repairManager.startRepairRun(run.getValue());
@@ -509,14 +506,6 @@ public final class RepairManagerTest {
     context.config = new ReaperApplicationConfiguration();
     context.storage = mock(CassandraStorage.class);
     doReturn(true).when(context.storage).updateRepairRun(any());
-    RepairManager repairManager = RepairManager.create(
-        context,
-        Executors.newScheduledThreadPool(1),
-        500,
-        TimeUnit.MILLISECONDS,
-        1,
-        TimeUnit.MILLISECONDS,
-        2);
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     String cluster1 = "cluster1";
     String cluster2 = "cluster2";
@@ -562,7 +551,12 @@ public final class RepairManagerTest {
             return Optional.of(repairRuns.get(invocation.getArgument(0)));
           }
         });
-
+    RepairManager repairManager = RepairManager.create(
+        context,
+        Executors.newScheduledThreadPool(1),
+        1,
+        TimeUnit.MILLISECONDS,
+        2);
     repairRuns.entrySet().stream().forEach(run -> {
       try {
         repairManager.startRepairRun(run.getValue());
@@ -583,6 +577,7 @@ public final class RepairManagerTest {
     final Set<String> nodes = Sets.newHashSet("127.0.0.1");
     final Set<String> datacenters = Collections.emptySet();
     final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
 
     final RepairUnit repairUnit = RepairUnit.builder()
         .clusterName(clusterName)
@@ -592,6 +587,7 @@ public final class RepairManagerTest {
         .nodes(nodes)
         .datacenters(datacenters)
         .repairThreadCount(repairThreadCount)
+        .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
 
     return repairUnit;

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -294,8 +294,8 @@ public final class RepairRunServiceTest {
         .repairThreadCount(4)
         .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
-    List<Segment> segments = repairRunService.generateSegments(cluster, 10, 10, unit);
-    assertEquals(12, segments.size());
+    List<Segment> segments = repairRunService.generateSegments(cluster, 10, unit);
+    assertEquals(32, segments.size());
     assertEquals(3, segments.get(0).getReplicas().keySet().size());
     assertEquals("dc1", segments.get(0).getReplicas().get("127.0.0.1"));
   }

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -228,6 +228,7 @@ public final class RepairRunServiceTest {
     final long TIME_RUN = 41L;
     final double INTENSITY = 0.5f;
     final int REPAIR_THREAD_COUNT = 1;
+    final int segmentTimeout = 30;
     final List<BigInteger> TOKENS = Lists.newArrayList(
         BigInteger.valueOf(0L),
         BigInteger.valueOf(100L),
@@ -245,7 +246,8 @@ public final class RepairRunServiceTest {
             .nodes(NODES)
             .datacenters(DATACENTERS)
             .blacklistedTables(BLACKLISTED_TABLES)
-            .repairThreadCount(REPAIR_THREAD_COUNT));
+            .repairThreadCount(REPAIR_THREAD_COUNT)
+            .timeout(segmentTimeout));
     DateTimeUtils.setCurrentMillisFixed(TIME_RUN);
 
     AppContext context = new AppContext();
@@ -290,6 +292,7 @@ public final class RepairRunServiceTest {
         .blacklistedTables(Sets.newHashSet("table1"))
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
     List<Segment> segments = repairRunService.generateSegments(cluster, 10, 10, unit);
     assertEquals(12, segments.size());

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
@@ -85,6 +85,7 @@ public final class RepairUnitServiceTest {
         .blacklistedTables(Sets.newHashSet("table1"))
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(30)
         .build(UUIDs.timeBased());
 
     assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(cluster, unit));
@@ -108,6 +109,7 @@ public final class RepairUnitServiceTest {
           .blacklistedTables(Sets.newHashSet("table1"))
           .incrementalRepair(false)
           .repairThreadCount(4)
+          .timeout(30)
           .build(UUIDs.timeBased());
 
     assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(cluster, unit));
@@ -130,6 +132,7 @@ public final class RepairUnitServiceTest {
         .keyspaceName("test")
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(30)
         .build(UUIDs.timeBased());
 
     assertEquals(Sets.newHashSet("table2", "table3"), service.getTablesToRepair(cluster, unit));
@@ -153,6 +156,7 @@ public final class RepairUnitServiceTest {
         .blacklistedTables(Sets.newHashSet("table1", "table3"))
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(30)
         .build(UUIDs.timeBased());
 
     assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(cluster, unit));
@@ -176,6 +180,7 @@ public final class RepairUnitServiceTest {
         .blacklistedTables(Sets.newHashSet("table1"))
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(30)
         .build(UUIDs.timeBased());
 
     assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(cluster, unit));
@@ -200,6 +205,7 @@ public final class RepairUnitServiceTest {
         .blacklistedTables(Sets.newHashSet("table1"))
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(30)
         .build(UUIDs.timeBased());
 
     assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(cluster, unit));
@@ -224,6 +230,7 @@ public final class RepairUnitServiceTest {
         .blacklistedTables(Sets.newHashSet("table1"))
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(30)
         .build(UUIDs.timeBased());
 
     assertEquals(Sets.newHashSet("table2"), service.getTablesToRepair(cluster, unit));
@@ -247,6 +254,7 @@ public final class RepairUnitServiceTest {
         .blacklistedTables(Sets.newHashSet("table1", "table2", "table3"))
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(30)
         .build(UUIDs.timeBased());
 
     service.getTablesToRepair(cluster, unit);
@@ -272,6 +280,7 @@ public final class RepairUnitServiceTest {
         .blacklistedTables(Sets.newHashSet("table1", "table2", "table3"))
         .incrementalRepair(false)
         .repairThreadCount(4)
+        .timeout(30)
         .build(UUIDs.timeBased());
 
     service.getTablesToRepair(cluster, unit);

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -87,8 +87,9 @@ public final class SegmentRunnerTest {
 
   @Test
   public void timeoutTest() throws InterruptedException, ReaperException, ExecutionException,
-    MalformedObjectNameException, ReflectionException, IOException {
+        MalformedObjectNameException, ReflectionException, IOException {
     final AppContext context = new AppContext();
+    final int segmentTimeout = 30;
     context.config = Mockito.mock(ReaperApplicationConfiguration.class);
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
@@ -101,7 +102,8 @@ public final class SegmentRunnerTest {
                 .columnFamilies(Sets.newHashSet("reaper"))
                 .incrementalRepair(false)
                 .nodes(Sets.newHashSet("127.0.0.1"))
-                .repairThreadCount(1));
+                .repairThreadCount(1)
+                .timeout(segmentTimeout));
 
     Map<String, String> replicas = Maps.newHashMap();
     replicas.put("127.0.0.1", "dc1");
@@ -211,8 +213,9 @@ public final class SegmentRunnerTest {
 
   @Test
   public void successTest() throws InterruptedException, ReaperException, ExecutionException,
-    MalformedObjectNameException, ReflectionException, IOException {
+        MalformedObjectNameException, ReflectionException, IOException {
     final IStorage storage = new MemoryStorage();
+    final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -221,7 +224,8 @@ public final class SegmentRunnerTest {
                 .columnFamilies(Sets.newHashSet("reaper"))
                 .incrementalRepair(false)
                 .nodes(Sets.newHashSet("127.0.0.1"))
-                .repairThreadCount(1));
+                .repairThreadCount(1)
+                .timeout(segmentTimeout));
 
     Map<String, String> replicas = Maps.newHashMap();
     replicas.put("127.0.0.1", "dc1");
@@ -362,8 +366,9 @@ public final class SegmentRunnerTest {
 
   @Test
   public void failureTest() throws InterruptedException, ReaperException, ExecutionException,
-    MalformedObjectNameException, ReflectionException, IOException {
+        MalformedObjectNameException, ReflectionException, IOException {
     final IStorage storage = new MemoryStorage();
+    final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -372,7 +377,8 @@ public final class SegmentRunnerTest {
                 .columnFamilies(Sets.newHashSet("reaper"))
                 .incrementalRepair(false)
                 .nodes(Sets.newHashSet("127.0.0.1"))
-                .repairThreadCount(1));
+                .repairThreadCount(1)
+                .timeout(segmentTimeout));
 
     Map<String, String> replicas = Maps.newHashMap();
     replicas.put("127.0.0.1", "dc1");
@@ -518,7 +524,8 @@ public final class SegmentRunnerTest {
                 .columnFamilies(Sets.newHashSet("reaper"))
                 .incrementalRepair(false)
                 .nodes(Sets.newHashSet("127.0.0.1"))
-                .repairThreadCount(1));
+                .repairThreadCount(1)
+                .timeout(30));
 
     Map<String, String> replicas = Maps.newHashMap();
     replicas.put("127.0.0.1", "dc1");
@@ -660,7 +667,8 @@ public final class SegmentRunnerTest {
                 .columnFamilies(Sets.newHashSet("reaper"))
                 .incrementalRepair(false)
                 .nodes(Sets.newHashSet("127.0.0.1"))
-                .repairThreadCount(1));
+                .repairThreadCount(1)
+                .timeout(30));
 
     Map<String, String> replicas = Maps.newHashMap();
     replicas.put("127.0.0.1", "dc1");
@@ -795,6 +803,7 @@ public final class SegmentRunnerTest {
       throws InterruptedException, ReaperException, ExecutionException,
       MalformedObjectNameException, ReflectionException, IOException {
     final IStorage storage = new MemoryStorage();
+    final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -803,7 +812,8 @@ public final class SegmentRunnerTest {
                 .columnFamilies(Sets.newHashSet("reaper"))
                 .incrementalRepair(false)
                 .nodes(Sets.newHashSet("127.0.0.1"))
-                .repairThreadCount(1));
+                .repairThreadCount(1)
+                .timeout(30));
 
     Map<String, String> replicas = Maps.newHashMap();
     replicas.put("127.0.0.1", "dc1");
@@ -939,6 +949,7 @@ public final class SegmentRunnerTest {
       throws InterruptedException, ReaperException, ExecutionException,
       MalformedObjectNameException, ReflectionException, IOException {
     final IStorage storage = new MemoryStorage();
+    final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -947,7 +958,8 @@ public final class SegmentRunnerTest {
                 .columnFamilies(Sets.newHashSet("reaper"))
                 .incrementalRepair(false)
                 .nodes(Sets.newHashSet("127.0.0.1"))
-                .repairThreadCount(1));
+                .repairThreadCount(1)
+                .timeout(30));
 
     Map<String, String> replicas = Maps.newHashMap();
     replicas.put("127.0.0.1", "dc1");

--- a/src/server/src/test/java/io/cassandrareaper/storage/PostgresStorageTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/storage/PostgresStorageTest.java
@@ -50,6 +50,7 @@ public class PostgresStorageTest {
 
   private static final String DB_URL = "jdbc:h2:mem:test_mem;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;"
       + "DATABASE_TO_UPPER=FALSE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
+  private static final int SEGMENT_TIMEOUT = 30;
 
   @Before
   public void setUp() throws SQLException, IOException {
@@ -75,7 +76,7 @@ public class PostgresStorageTest {
   public void testTakeLead() {
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();
@@ -105,7 +106,7 @@ public class PostgresStorageTest {
   public void testNoLeaders() {
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();
@@ -119,7 +120,7 @@ public class PostgresStorageTest {
   public void testRenewLead() throws InterruptedException {
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();
@@ -148,7 +149,7 @@ public class PostgresStorageTest {
   public void testReleaseLead() {
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();
@@ -182,7 +183,7 @@ public class PostgresStorageTest {
   public void testSaveHeartbeat() {
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();
@@ -197,7 +198,7 @@ public class PostgresStorageTest {
   public void testNodeOperations() {
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();
@@ -216,7 +217,7 @@ public class PostgresStorageTest {
   public void testGenericMetricsByHostandCluster() {
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();
@@ -283,7 +284,7 @@ public class PostgresStorageTest {
   public void testGenericMetricExpiration() {
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();
@@ -345,7 +346,7 @@ public class PostgresStorageTest {
     System.out.println("Testing leader timeout (this will take a minute)...");
     DBI dbi = new DBI(DB_URL);
     UUID reaperInstanceId = UUID.randomUUID();
-    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, 1, 1, 1, 1);
+    PostgresStorage storage = new PostgresStorage(reaperInstanceId, dbi, 1, 1, 1, 1, SEGMENT_TIMEOUT);
     Assertions.assertThat(storage.isStorageConnected()).isTrue();
 
     Handle handle = dbi.open();

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -88,6 +88,7 @@ const repairForm = CreateReactClass({
       datacentersSelectDisabled: false,
       showModal: false,
       force: "false",
+      adaptive: false,
     };
   },
 
@@ -206,6 +207,9 @@ const repairForm = CreateReactClass({
     if (this.state.cause) repair.cause = this.state.cause;
     if (this.state.incrementalRepair) {
       repair.incrementalRepair = this.state.incrementalRepair;
+      if (repair.incrementalRepair == "true") {
+        repair.repairParallelism = "PARALLEL";
+      }
     }
     else {
       repair.incrementalRepair = "false";
@@ -222,6 +226,12 @@ const repairForm = CreateReactClass({
     }
     if (this.state.timeout) {
       repair.timeout = this.state.timeout;
+    }
+    if (this.state.adaptive) {
+      repair.adaptive = this.state.adaptive;
+    }
+    else {
+      repair.adaptive = "false";
     }
 
     this.props.addRepairSubject.onNext({
@@ -487,32 +497,44 @@ const repairForm = CreateReactClass({
     else if (this.state.formType === "schedule") {
       customInput = (
         <div>
-        <div className="form-group">
-          <label htmlFor="in_startTime" className="col-sm-3 control-label">Start time*</label>
-          <div className="col-sm-9 col-md-7 col-lg-5">
-            <DatePicker
-              selected={this.state.startTime}
-              onChange={value => this.setState({startTime: value})}
-              showTimeSelect
-              timeFormat="HH:mm"
-              timeIntervals={15}
-              timeCaption="Time"
-              dateFormat="d MMMM yyyy HH:mm"
-            />
+          <div className="form-group">
+            <label htmlFor="in_startTime" className="col-sm-3 control-label">Start time*</label>
+            <div className="col-sm-9 col-md-7 col-lg-5">
+              <DatePicker
+                selected={this.state.startTime}
+                onChange={value => this.setState({startTime: value})}
+                showTimeSelect
+                timeFormat="HH:mm"
+                timeIntervals={15}
+                timeCaption="Time"
+                dateFormat="d MMMM yyyy HH:mm"
+              />
+            </div>
+          </div>
+          <div className="form-group">
+            <label htmlFor="in_intervalDays" className="col-sm-3 control-label">Interval in days*</label>
+            <div className="col-sm-9 col-md-7 col-lg-5">
+              <input type="number" required className="form-control" value={this.state.intervalDays}
+                onChange={this._handleChange} id="in_intervalDays" placeholder="amount of days to wait between scheduling new repairs, (e.g. 7 for weekly)"/>
+            </div>
+          </div>
+          <div className="form-group">
+            <label htmlFor="in_adaptive" className="col-sm-3 control-label">Adaptive</label>
+            <div className="col-sm-9 col-md-7 col-lg-5">
+              <Select
+                id="in_adaptive"
+                name="in_adaptive"
+                classNamePrefix="select"
+                options={[{label: "true", value: "true"}, {label: "false", value: "false"}]}
+                placeholder="false"
+                onChange={this._handleSelectOnChange}
+              />
+            </div>
           </div>
         </div>
-        <div className="form-group">
-          <label htmlFor="in_intervalDays" className="col-sm-3 control-label">Interval in days*</label>
-          <div className="col-sm-9 col-md-7 col-lg-5">
-            <input type="number" required className="form-control" value={this.state.intervalDays}
-              onChange={this._handleChange} id="in_intervalDays" placeholder="amount of days to wait between scheduling new repairs, (e.g. 7 for weekly)"/>
-          </div>
-        </div>
-        </div>
+        
       );
     }
-
-    const keyspaceInputStyle = this.state.keyspaceList.length > 0 ? 'form-control-hidden':'form-control';
 
     const advancedSettingsHeader = (
       <div className="panel-title" >

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -62,6 +62,7 @@ const repairForm = CreateReactClass({
       intervalDays: "",
       incrementalRepair: "false",
       repairThreadCount: 1,
+      timeout: null,
       formCollapsed: true,
       advancedFormCollapsed: true,
       clusterStatus: {},
@@ -218,6 +219,9 @@ const repairForm = CreateReactClass({
     }
     else {
       repair.force = "false";
+    }
+    if (this.state.timeout) {
+      repair.timeout = this.state.timeout;
     }
 
     this.props.addRepairSubject.onNext({
@@ -693,6 +697,13 @@ const repairForm = CreateReactClass({
                         <input type="number" className="form-control" value={this.state.repairThreadCount}
                           min="1" max="4"
                           onChange={this._handleChange} id="in_repairThreadCount" placeholder="repair threads"/>
+                      </div>
+                    </div>
+                    <div className="form-group">
+                      <label htmlFor="in_timeout" className="col-sm-3 control-label">Segment timeout</label>
+                      <div className="col-sm-14 col-md-12 col-lg-9">
+                      <input type="number" className="form-control" value={this.state.timeout}
+                          onChange={this._handleChange} id="in_timeout" placeholder="Segment timeout in minutes before it gets killed and rescheduled."/>
                       </div>
                     </div>
                   </div>

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -167,12 +167,14 @@ const TableRowDetails = CreateReactClass({
 
     var metrics = ["io.cassandrareaper.service.RepairRunner.repairProgress", "io.cassandrareaper.service.RepairRunner.segmentsDone",
                    "io.cassandrareaper.service.RepairRunner.segmentsTotal", "io.cassandrareaper.service.RepairRunner.millisSinceLastRepair"];
-  let cleanupRegex = /[^A-Za-z0-9]/mg
-  let availableMetrics = metrics.map(metric => <div key={metric + this.props.row.repair_unit_id}>
-      {metric + "." 
-        + this.props.row.cluster_name.replace(cleanupRegex, "") + "." 
-        + this.props.row.keyspace_name.replace(cleanupRegex, "") + "." 
-        + this.props.row.repair_unit_id.replace(cleanupRegex, "")}</div>)
+    let cleanupRegex = /[^A-Za-z0-9]/mg
+    let availableMetrics = metrics.map(metric => <div key={metric + this.props.row.repair_unit_id}>
+        {metric + "." 
+          + this.props.row.cluster_name.replace(cleanupRegex, "") + "." 
+          + this.props.row.keyspace_name.replace(cleanupRegex, "") + "." 
+          + this.props.row.repair_unit_id.replace(cleanupRegex, "")}</div>);
+
+    const adaptiveSchedule = this.props.row.adaptive_schedule == true ? "true" : "false";
     return (
       <tr id={rowID} className="collapse out">
         <td colSpan="7">
@@ -257,6 +259,10 @@ const TableRowDetails = CreateReactClass({
                 <tr>
                     <td>Available metrics<br/><i>(can require a full run before appearing)</i></td>
                     <td>{availableMetrics}</td>
+                </tr>
+                <tr>
+                    <td>Adaptive Schedule</td>
+                    <td>{adaptiveSchedule}</td>
                 </tr>
             </tbody>
           </table>

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -235,6 +235,10 @@ const TableRowDetails = CreateReactClass({
                     <td>{this.props.row.repair_thread_count}</td>
                 </tr>
                 <tr>
+                    <td>Segment timeout (mins)</td>
+                    <td>{this.props.row.segment_timeout}</td>
+                </tr>
+                <tr>
                     <td>Nodes</td>
                     <td><CFsListRender list={this.props.row.nodes} /></td>
                 </tr>

--- a/src/ui/app/jsx/schedule-list.jsx
+++ b/src/ui/app/jsx/schedule-list.jsx
@@ -280,6 +280,10 @@ const TableRowDetails = CreateReactClass({
                     <td>{this.props.row.repair_thread_count}</td>
                 </tr>
                 <tr>
+                    <td>Segment timeout (mins)</td>
+                    <td>{this.props.row.segment_timeout}</td>
+                </tr>
+                <tr>
                     <td>Repair parallelism</td>
                     <td>{this.props.row.repair_parallelism}</td>
                 </tr>

--- a/src/ui/app/jsx/schedule-list.jsx
+++ b/src/ui/app/jsx/schedule-list.jsx
@@ -228,6 +228,7 @@ const TableRowDetails = CreateReactClass({
     const nextAt = moment(this.props.row.next_activation).format("LLL");
     const rowID = `details_${this.props.row.id}`;
     const incremental = this.props.row.incremental_repair == true ? "true" : "false";
+    const adaptive = this.props.row.adaptive == true ? "true" : "false";
 
     let segmentCount = <tr>
                         <td>Segment count per node</td>
@@ -294,6 +295,10 @@ const TableRowDetails = CreateReactClass({
                 <tr>
                     <td>Creation time</td>
                     <td>{createdAt}</td>
+                </tr>
+                <tr>
+                    <td>Adaptive</td>
+                    <td>{adaptive}</td>
                 </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Fixes #1059 
Fixes #1060 

As a first step towards adaptive repairs, this commit adds the segment timeout in the repair units using the configuration timeout as default.
This timeout can be set differently for each repair run or schedule.
Segments failing will get an extended timeout at each attempt to avoid blocking misconfigured repairs and heavy segments.

Unlike imagined in #1059 and #1060, timeouts don't need to be stored on the segments since we can compute the extended timeouts using the fail count. Also the timeout extensions do not double each time but rather apply the following formula: `timeout = segmentTimeout * failCount`
