### PR TITLE
Allow repair schedules to be adaptive

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -561,6 +561,9 @@ public final class ReaperApplicationConfiguration extends Configuration {
     @JsonProperty
     private List<String> excludedClusters = Collections.emptyList();
 
+    @JsonProperty
+    private Boolean adaptive;
+
     public Boolean isEnabled() {
       return enabled;
     }
@@ -621,6 +624,14 @@ public final class ReaperApplicationConfiguration extends Configuration {
       return excludedClusters;
     }
 
+    public Boolean isAdaptive() {
+      return adaptive == null ? false : adaptive;
+    }
+
+    public void setAdaptive(Boolean adaptive) {
+      this.adaptive = adaptive;
+    }
+
     @Override
     public String toString() {
       return "AutoSchedulingConfiguration{"
@@ -634,6 +645,8 @@ public final class ReaperApplicationConfiguration extends Configuration {
           + timeBeforeFirstSchedule
           + ", scheduleSpreadPeriod="
           + scheduleSpreadPeriod
+          + ", adaptive="
+          + adaptive
           + '}';
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairRun.java
@@ -48,6 +48,7 @@ public final class RepairRun implements Comparable<RepairRun> {
   private final int segmentCount;
   private final RepairParallelism repairParallelism;
   private final Set<String> tables;
+  private final boolean adaptiveSchedule;
 
   private RepairRun(Builder builder, UUID id) {
     this.id = id;
@@ -65,6 +66,7 @@ public final class RepairRun implements Comparable<RepairRun> {
     this.segmentCount = builder.segmentCount;
     this.repairParallelism = builder.repairParallelism;
     this.tables = builder.tables;
+    this.adaptiveSchedule = builder.adaptiveSchedule;
   }
 
   public static Builder builder(String clusterName, UUID repairUnitId) {
@@ -129,6 +131,10 @@ public final class RepairRun implements Comparable<RepairRun> {
 
   public Set<String> getTables() {
     return tables;
+  }
+
+  public Boolean getAdaptiveSchedule() {
+    return adaptiveSchedule;
   }
 
   public Builder with() {
@@ -208,6 +214,8 @@ public final class RepairRun implements Comparable<RepairRun> {
     private Integer segmentCount;
     private RepairParallelism repairParallelism;
     private Set<String> tables;
+    private boolean adaptiveSchedule;
+
 
     private Builder(String clusterName, UUID repairUnitId) {
       this.clusterName = clusterName;
@@ -229,6 +237,7 @@ public final class RepairRun implements Comparable<RepairRun> {
       segmentCount = original.segmentCount;
       repairParallelism = original.repairParallelism;
       tables = original.tables;
+      adaptiveSchedule = original.adaptiveSchedule;
     }
 
     public Builder runState(RunState runState) {
@@ -291,6 +300,11 @@ public final class RepairRun implements Comparable<RepairRun> {
 
     public Builder tables(Set<String> tables) {
       this.tables = Collections.unmodifiableSet(tables);
+      return this;
+    }
+
+    public Builder adaptiveSchedule(boolean adaptive) {
+      this.adaptiveSchedule = adaptive;
       return this;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
@@ -37,13 +37,13 @@ public final class RepairSchedule {
   private final int daysBetween;
   private final DateTime nextActivation;
   private final ImmutableList<UUID> runHistory;
-  @Deprecated private final int segmentCount;
   private final RepairParallelism repairParallelism;
   private final double intensity;
   private final DateTime creationTime;
   private final String owner;
   private final DateTime pauseTime;
   private final int segmentCountPerNode;
+  private final boolean adaptive;
 
   private RepairSchedule(Builder builder, UUID id) {
     this.id = id;
@@ -52,13 +52,13 @@ public final class RepairSchedule {
     this.daysBetween = builder.daysBetween;
     this.nextActivation = builder.nextActivation;
     this.runHistory = builder.runHistory;
-    this.segmentCount = builder.segmentCount;
     this.repairParallelism = builder.repairParallelism;
     this.intensity = builder.intensity;
     this.creationTime = builder.creationTime;
     this.owner = builder.owner;
     this.pauseTime = builder.pauseTime;
     this.segmentCountPerNode = builder.segmentCountPerNode;
+    this.adaptive = builder.adaptive;
   }
 
   public static Builder builder(UUID repairUnitId) {
@@ -101,10 +101,6 @@ public final class RepairSchedule {
     return new LongCollectionSqlType(list);
   }
 
-  public int getSegmentCount() {
-    return segmentCount;
-  }
-
   public int getSegmentCountPerNode() {
     return segmentCountPerNode;
   }
@@ -129,6 +125,10 @@ public final class RepairSchedule {
     return pauseTime;
   }
 
+  public boolean getAdaptive() {
+    return adaptive;
+  }
+
   public Builder with() {
     return new Builder(this);
   }
@@ -151,14 +151,13 @@ public final class RepairSchedule {
     private Integer daysBetween;
     private DateTime nextActivation;
     private ImmutableList<UUID> runHistory = ImmutableList.<UUID>of();
-    @Deprecated private int segmentCount = 0;
     private RepairParallelism repairParallelism;
     private Double intensity;
     private DateTime creationTime = DateTime.now();
     private String owner = "";
     private DateTime pauseTime;
     private Integer segmentCountPerNode;
-    private boolean majorCompaction = false;
+    private boolean adaptive = false;
 
     private Builder(UUID repairUnitId) {
       this.repairUnitId = repairUnitId;
@@ -170,7 +169,6 @@ public final class RepairSchedule {
       daysBetween = original.daysBetween;
       nextActivation = original.nextActivation;
       runHistory = original.runHistory;
-      segmentCount = original.segmentCount;
       repairParallelism = original.repairParallelism;
       intensity = original.intensity;
       creationTime = original.creationTime;
@@ -178,6 +176,7 @@ public final class RepairSchedule {
       pauseTime = original.pauseTime;
       intensity = original.intensity;
       segmentCountPerNode = original.segmentCountPerNode;
+      adaptive = original.adaptive;
     }
 
     public Builder state(State state) {
@@ -197,11 +196,6 @@ public final class RepairSchedule {
 
     public Builder runHistory(ImmutableList<UUID> runHistory) {
       this.runHistory = runHistory;
-      return this;
-    }
-
-    public Builder segmentCount(int segmentCount) {
-      this.segmentCount = segmentCount;
       return this;
     }
 
@@ -232,6 +226,11 @@ public final class RepairSchedule {
 
     public Builder segmentCountPerNode(int segmentCountPerNode) {
       this.segmentCountPerNode = segmentCountPerNode;
+      return this;
+    }
+
+    public Builder adaptive(boolean adaptive) {
+      this.adaptive = adaptive;
       return this;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -199,7 +199,6 @@ public final class RepairRunResource {
         LOG.error(ex.getMessage(), ex);
         return Response.status(Response.Status.NOT_FOUND).entity(ex.getMessage()).build();
       }
-
       int timeout = timeoutParam.orElse(context.config.getHangingRepairTimeoutMins());
       boolean force = (forceParam.isPresent() ? Boolean.parseBoolean(forceParam.get()) : false);
 
@@ -245,10 +244,10 @@ public final class RepairRunResource {
               theRepairUnit,
               cause,
               owner.get(),
-              0,
               segments,
               parallelism,
-              intensity);
+              intensity,
+              false);
 
       return Response.created(buildRepairRunUri(uriInfo, newRepairRun))
           .entity(new RepairRunStatus(newRepairRun, theRepairUnit, 0))

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairRunStatus.java
@@ -115,6 +115,9 @@ public final class RepairRunStatus {
   @JsonProperty("segment_timeout")
   private int segmentTimeout;
 
+  @JsonProperty("adaptive_schedule")
+  private boolean adaptiveSchedule;
+
 
   /**
    * Default public constructor Required for Jackson JSON parsing.
@@ -145,7 +148,8 @@ public final class RepairRunStatus {
       Collection<String> blacklistedTables,
       int repairThreadCount,
       UUID repairUnitId,
-      int segmentTimeout) {
+      int segmentTimeout,
+      boolean adaptiveSchedule) {
 
     this.id = runId;
     this.cause = cause;
@@ -171,6 +175,7 @@ public final class RepairRunStatus {
     this.blacklistedTables = blacklistedTables;
     this.repairThreadCount = repairThreadCount;
     this.segmentTimeout = segmentTimeout;
+    this.adaptiveSchedule = adaptiveSchedule;
 
     if (startTime == null) {
       duration = null;
@@ -232,7 +237,8 @@ public final class RepairRunStatus {
         repairUnit.getBlacklistedTables(),
         repairUnit.getRepairThreadCount(),
         repairRun.getRepairUnitId(),
-        repairUnit.getTimeout());
+        repairUnit.getTimeout(),
+        repairRun.getAdaptiveSchedule());
   }
 
   @JsonProperty("creation_time")
@@ -510,4 +516,11 @@ public final class RepairRunStatus {
     this.repairUnitId = repairUnitId;
   }
 
+  public boolean getAdaptiveSchedule() {
+    return adaptiveSchedule;
+  }
+
+  public void setAdaptiveSchedule(boolean adaptiveSchedule) {
+    this.adaptiveSchedule = adaptiveSchedule;
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/RepairScheduleStatus.java
@@ -64,9 +64,6 @@ public final class RepairScheduleStatus {
   @JsonProperty("incremental_repair")
   private boolean incrementalRepair;
 
-  @JsonProperty("segment_count")
-  private int segmentCount;
-
   @JsonProperty("repair_parallelism")
   private RepairParallelism repairParallelism;
 
@@ -94,6 +91,9 @@ public final class RepairScheduleStatus {
   @JsonProperty("segment_timeout")
   private int segmentTimeout;
 
+  @JsonProperty("adaptive")
+  private boolean adaptive;
+
   /**
    * Default public constructor Required for Jackson JSON parsing.
    */
@@ -112,7 +112,6 @@ public final class RepairScheduleStatus {
       DateTime pauseTime,
       double intensity,
       boolean incrementalRepair,
-      int segmentCount,
       RepairParallelism repairParallelism,
       int daysBetween,
       Collection<String> nodes,
@@ -121,7 +120,8 @@ public final class RepairScheduleStatus {
       int segmentCountPerNode,
       int repairThreadCount,
       UUID repairUnitId,
-      int segmentTimeout) {
+      int segmentTimeout,
+      boolean adaptive) {
 
     this.id = id;
     this.owner = owner;
@@ -134,7 +134,6 @@ public final class RepairScheduleStatus {
     this.pauseTime = pauseTime;
     this.intensity = RepairRunStatus.roundDoubleNicely(intensity);
     this.incrementalRepair = incrementalRepair;
-    this.segmentCount = segmentCount;
     this.repairParallelism = repairParallelism;
     this.daysBetween = daysBetween;
     this.nodes = nodes;
@@ -144,7 +143,7 @@ public final class RepairScheduleStatus {
     this.repairThreadCount = repairThreadCount;
     this.repairUnitId = repairUnitId;
     this.segmentTimeout = segmentTimeout;
-
+    this.adaptive = adaptive;
   }
 
   public RepairScheduleStatus(RepairSchedule repairSchedule, RepairUnit repairUnit) {
@@ -160,7 +159,6 @@ public final class RepairScheduleStatus {
         repairSchedule.getPauseTime(),
         repairSchedule.getIntensity(),
         repairUnit.getIncrementalRepair(),
-        repairSchedule.getSegmentCount(),
         repairSchedule.getRepairParallelism(),
         repairSchedule.getDaysBetween(),
         repairUnit.getNodes(),
@@ -169,7 +167,8 @@ public final class RepairScheduleStatus {
         repairSchedule.getSegmentCountPerNode(),
         repairUnit.getRepairThreadCount(),
         repairUnit.getId(),
-        repairUnit.getTimeout());
+        repairUnit.getTimeout(),
+        repairSchedule.getAdaptive());
   }
 
   public UUID getId() {
@@ -252,20 +251,12 @@ public final class RepairScheduleStatus {
     this.intensity = intensity;
   }
 
-  public int getSegmentCount() {
-    return segmentCount;
-  }
-
   public boolean getIncrementalRepair() {
     return incrementalRepair;
   }
 
   public void setIncrementalRepair(boolean incrementalRepair) {
     this.incrementalRepair = incrementalRepair;
-  }
-
-  public void setSegmentCount(int segmentCount) {
-    this.segmentCount = segmentCount;
   }
 
   public RepairParallelism getRepairParallelism() {
@@ -374,5 +365,13 @@ public final class RepairScheduleStatus {
 
   public void setRepairUnitId(UUID repairUnitId) {
     this.repairUnitId = repairUnitId;
+  }
+
+  public boolean getAdaptive() {
+    return adaptive;
+  }
+
+  public void setAdaptive(boolean adaptive) {
+    this.adaptive = adaptive;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -22,7 +22,6 @@ import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
-import io.cassandrareaper.core.Table;
 import io.cassandrareaper.jmx.ClusterFacade;
 
 import java.util.Collection;
@@ -31,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
@@ -137,24 +135,10 @@ public final class ClusterRepairScheduler {
             context.config.getSegmentCountPerNode(),
             context.config.getRepairParallelism(),
             context.config.getRepairIntensity(),
-            false);
+            false,
+            context.config.getAutoScheduling().isAdaptive());
 
     LOG.info("Scheduled repair created: {}", repairSchedule);
-  }
-
-  private boolean keyspaceHasNoTable(AppContext context, Cluster cluster, String keyspace) {
-    try {
-      Set<String> tables
-          = ClusterFacade
-              .create(context)
-              .getTablesForKeyspace(cluster, keyspace)
-              .stream()
-              .map(Table::getName)
-              .collect(Collectors.toSet());
-      return tables.isEmpty();
-    } catch (ReaperException e) {
-      throw Throwables.propagate(e);
-    }
   }
 
   private static class ScheduledRepairDiffView {

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -96,7 +96,8 @@ public final class RepairScheduleService {
       int segmentCountPerNode,
       RepairParallelism repairParallelism,
       Double intensity,
-      boolean force) {
+      boolean force,
+      boolean adaptive) {
 
     Preconditions.checkArgument(
         force || !conflictingRepairSchedule(cluster, repairUnit.with()).isPresent(),
@@ -111,7 +112,8 @@ public final class RepairScheduleService {
         .repairParallelism(repairParallelism)
         .intensity(intensity)
         .segmentCountPerNode(segmentCountPerNode)
-        .owner(owner);
+        .owner(owner)
+        .adaptive(adaptive);
 
     return context.storage.addRepairSchedule(scheduleBuilder);
   }

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -303,10 +303,10 @@ public final class SchedulingManager extends TimerTask {
         repairUnit,
         Optional.of(getCauseName(schedule)),
         schedule.getOwner(),
-        schedule.getSegmentCount(),
         schedule.getSegmentCountPerNode(),
         schedule.getRepairParallelism(),
-        schedule.getIntensity());
+        schedule.getIntensity(),
+        schedule.getAdaptive());
   }
 
   private static String getCauseName(RepairSchedule schedule) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -89,6 +89,8 @@ public interface IStorage {
 
   Optional<RepairUnit> getRepairUnit(RepairUnit.Builder repairUnit);
 
+  void updateRepairUnit(RepairUnit updatedRepairUnit);
+
   boolean updateRepairSegment(RepairSegment newRepairSegment);
 
   Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId);

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorage.java
@@ -287,6 +287,12 @@ public final class MemoryStorage implements IStorage {
   }
 
   @Override
+  public void updateRepairUnit(RepairUnit updatedRepairUnit) {
+    repairUnits.put(updatedRepairUnit.getId(), updatedRepairUnit);
+    repairUnitsByKey.put(updatedRepairUnit.with(), updatedRepairUnit);
+  }
+
+  @Override
   public RepairUnit getRepairUnit(UUID id) {
     RepairUnit unit = repairUnits.get(id);
     Preconditions.checkArgument(null != unit);
@@ -503,7 +509,8 @@ public final class MemoryStorage implements IStorage {
               unit.getBlacklistedTables(),
               unit.getRepairThreadCount(),
               unit.getId(),
-              unit.getTimeout()));
+              unit.getTimeout(),
+              run.getAdaptiveSchedule()));
     }
     return runStatuses;
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/PostgresStorage.java
@@ -376,6 +376,13 @@ public class PostgresStorage implements IStorage, IDistributedStorage {
   }
 
   @Override
+  public void updateRepairUnit(RepairUnit updatedRepairUnit) {
+    try (Handle h = jdbi.open()) {
+      getPostgresStorage(h).updateRepairUnit(updatedRepairUnit);
+    }
+  }
+
+  @Override
   public RepairUnit getRepairUnit(UUID id) {
     RepairUnit result;
     try (Handle h = jdbi.open()) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/IStoragePostgreSql.java
@@ -75,18 +75,19 @@ public interface IStoragePostgreSql {
   //
   String SQL_REPAIR_RUN_ALL_FIELDS_NO_ID = "cluster_name, repair_unit_id, cause, owner, state, creation_time, "
       + "start_time, end_time, pause_time, intensity, last_event, "
-      + "segment_count, repair_parallelism, tables";
+      + "segment_count, repair_parallelism, tables, adaptive_schedule";
   String SQL_REPAIR_RUN_ALL_FIELDS = "repair_run.id, " + SQL_REPAIR_RUN_ALL_FIELDS_NO_ID;
   String SQL_INSERT_REPAIR_RUN = "INSERT INTO repair_run ("
       + SQL_REPAIR_RUN_ALL_FIELDS_NO_ID
       + ") VALUES "
       + "(:clusterName, :repairUnitId, :cause, :owner, :runState, :creationTime, "
       + ":startTime, :endTime, :pauseTime, :intensity, :lastEvent, :segmentCount, "
-      + ":repairParallelism, :tables)";
+      + ":repairParallelism, :tables, :adaptiveSchedule)";
   String SQL_UPDATE_REPAIR_RUN = "UPDATE repair_run SET cause = :cause, owner = :owner, state = :runState, "
       + "start_time = :startTime, end_time = :endTime, pause_time = :pauseTime, "
       + "intensity = :intensity, last_event = :lastEvent, segment_count = :segmentCount, "
-      + "repair_parallelism = :repairParallelism, tables = :tables WHERE id = :id";
+      + "repair_parallelism = :repairParallelism, tables = :tables, adaptive_schedule = :adaptiveSchedule "
+      + "WHERE id = :id";
   String SQL_GET_REPAIR_RUN = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS + " FROM repair_run WHERE id = :id";
   String SQL_GET_REPAIR_RUNS_FOR_CLUSTER = "SELECT " + SQL_REPAIR_RUN_ALL_FIELDS
       + " FROM repair_run WHERE cluster_name = :clusterName ORDER BY id desc LIMIT :limit";
@@ -106,6 +107,12 @@ public interface IStoragePostgreSql {
           + ") VALUES "
           + "(:clusterName, :keyspaceName, :columnFamilies, "
           + ":incrementalRepair, :nodes, :datacenters, :blacklistedTables, :repairThreadCount, :timeout)";
+  String SQL_UPDATE_REPAIR_UNIT = "UPDATE repair_unit "
+          + "SET cluster_name = :clusterName, keyspace_name = :keyspaceName, "
+          + "column_families = :columnFamilies, incremental_repair = :incrementalRepair, nodes = :nodes, "
+          + "datacenters = :datacenters, blacklisted_tables = :blacklistedTables, "
+          + "repair_thread_count = :repairThreadCount, timeout = :timeout "
+          + "WHERE id = :id";
   String SQL_GET_REPAIR_UNIT = "SELECT " + SQL_REPAIR_UNIT_ALL_FIELDS + " FROM repair_unit WHERE id = :id";
 
   String SQL_GET_REPAIR_UNIT_BY_CLUSTER_AND_TABLES = "SELECT "
@@ -168,22 +175,22 @@ public interface IStoragePostgreSql {
   // RepairSchedule
   //
   String SQL_REPAIR_SCHEDULE_ALL_FIELDS_NO_ID
-      = "repair_unit_id, state, days_between, next_activation, run_history, segment_count, "
-          + "repair_parallelism, intensity, creation_time, owner, pause_time, segment_count_per_node ";
+      = "repair_unit_id, state, days_between, next_activation, run_history, "
+          + "repair_parallelism, intensity, creation_time, owner, pause_time, segment_count_per_node, adaptive ";
   String SQL_REPAIR_SCHEDULE_ALL_FIELDS = "repair_schedule.id, " + SQL_REPAIR_SCHEDULE_ALL_FIELDS_NO_ID;
   String SQL_INSERT_REPAIR_SCHEDULE
       = "INSERT INTO repair_schedule ("
           + SQL_REPAIR_SCHEDULE_ALL_FIELDS_NO_ID
           + ") VALUES "
-          + "(:repairUnitId, :state, :daysBetween, :nextActivation, :runHistorySql, :segmentCount, "
-          + ":repairParallelism, :intensity, :creationTime, :owner, :pauseTime, :segmentCountPerNode)";
+          + "(:repairUnitId, :state, :daysBetween, :nextActivation, :runHistorySql, "
+          + ":repairParallelism, :intensity, :creationTime, :owner, :pauseTime, :segmentCountPerNode, :adaptive)";
   String SQL_UPDATE_REPAIR_SCHEDULE
       = "UPDATE repair_schedule SET repair_unit_id = :repairUnitId, state = :state, "
           + "days_between = :daysBetween, next_activation = :nextActivation, "
-          + "run_history = :runHistorySql, segment_count = :segmentCount, "
+          + "run_history = :runHistorySql, "
           + "segment_count_per_node = :segmentCountPerNode, "
           + "repair_parallelism = :repairParallelism, creation_time = :creationTime, owner = :owner, "
-          + "pause_time = :pauseTime WHERE id = :id";
+          + "pause_time = :pauseTime, adaptive = :adaptive WHERE id = :id";
   String SQL_GET_REPAIR_SCHEDULE = "SELECT " + SQL_REPAIR_SCHEDULE_ALL_FIELDS + " FROM repair_schedule WHERE id = :id";
   String SQL_GET_REPAIR_SCHEDULES_FOR_CLUSTER = "SELECT "
       + SQL_REPAIR_SCHEDULE_ALL_FIELDS
@@ -228,10 +235,10 @@ public interface IStoragePostgreSql {
 
   String SQL_CLUSTER_SCHEDULE_OVERVIEW
       = "SELECT repair_schedule.id, owner, cluster_name, keyspace_name, column_families, state, "
-          + "creation_time, next_activation, pause_time, intensity, segment_count, "
+          + "creation_time, next_activation, pause_time, intensity,  "
           + "repair_parallelism, days_between, incremental_repair, nodes, "
           + "datacenters, blacklisted_tables, segment_count_per_node, repair_thread_count,"
-          + "repair_unit_id, repair_unit.timeout "
+          + "repair_unit_id, repair_unit.timeout, adaptive "
           + "FROM repair_schedule "
           + "JOIN repair_unit ON repair_unit_id = repair_unit.id "
           + "WHERE cluster_name = :clusterName";
@@ -549,6 +556,10 @@ public interface IStoragePostgreSql {
   @GetGeneratedKeys
   long insertRepairUnit(
       @BindBean RepairUnit newRepairUnit);
+
+  @SqlUpdate(SQL_UPDATE_REPAIR_UNIT)
+  void updateRepairUnit(
+      @BindBean RepairUnit updatedRepairUnit);
 
   @SqlUpdate(SQL_DELETE_REPAIR_UNIT)
   int deleteRepairUnit(

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunMapper.java
@@ -63,6 +63,7 @@ public final class RepairRunMapper implements ResultSetMapper<RepairRun> {
         .endTime(getDateTimeOrNull(rs, "end_time"))
         .pauseTime(getDateTimeOrNull(rs, "pause_time"))
         .lastEvent(rs.getString("last_event"))
+        .adaptiveSchedule(rs.getBoolean("adaptive_schedule"))
         .build(UuidUtil.fromSequenceId(rs.getLong("id")));
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairRunStatusMapper.java
@@ -78,6 +78,7 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
 
     int repairThreadCount = rs.getInt("repair_thread_count");
     int timeout = rs.getInt("timeout");
+    boolean adaptiveSchedule = rs.getBoolean("adaptive_schedule");
 
     return new RepairRunStatus(
         UuidUtil.fromSequenceId(runId),
@@ -102,7 +103,8 @@ public final class RepairRunStatusMapper implements ResultSetMapper<RepairRunSta
         blacklistedTables,
         repairThreadCount,
         UuidUtil.fromSequenceId(unitId),
-        timeout
+        timeout,
+        adaptiveSchedule
         );
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleMapper.java
@@ -70,13 +70,13 @@ public final class RepairScheduleMapper implements ResultSetMapper<RepairSchedul
         .daysBetween(rs.getInt("days_between"))
         .nextActivation(RepairRunMapper.getDateTimeOrNull(rs, "next_activation"))
         .runHistory(ImmutableList.copyOf(runHistoryUuids))
-        .segmentCount(rs.getInt("segment_count"))
         .repairParallelism(RepairParallelism.fromName(parallelism))
         .intensity(rs.getDouble("intensity"))
         .creationTime(RepairRunMapper.getDateTimeOrNull(rs, "creation_time"))
         .segmentCountPerNode(rs.getInt("segment_count_per_node"))
         .owner(rs.getString("owner"))
         .pauseTime(RepairRunMapper.getDateTimeOrNull(rs, "pause_time"))
+        .adaptive(rs.getBoolean("adaptive"))
         .build(UuidUtil.fromSequenceId(rs.getLong("id")));
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/postgresql/RepairScheduleStatusMapper.java
@@ -47,7 +47,6 @@ public final class RepairScheduleStatusMapper implements ResultSetMapper<RepairS
         RepairRunMapper.getDateTimeOrNull(rs, "pause_time"),
         rs.getDouble("intensity"),
         rs.getBoolean("incremental_repair"),
-        rs.getInt("segment_count"),
         RepairParallelism.fromName(
             rs.getString("repair_parallelism")
                 .toLowerCase()
@@ -68,7 +67,8 @@ public final class RepairScheduleStatusMapper implements ResultSetMapper<RepairS
         rs.getInt("segment_count_per_node"),
         rs.getInt("repair_thread_count"),
         UuidUtil.fromSequenceId(rs.getLong("repair_unit_id")),
-        rs.getInt("timeout"));
+        rs.getInt("timeout"),
+        rs.getBoolean("adaptive"));
   }
 
   private String[] getStringArray(Object array) {

--- a/src/server/src/main/resources/db/astra/005_adaptive_repairs.cql
+++ b/src/server/src/main/resources/db/astra/005_adaptive_repairs.cql
@@ -16,3 +16,5 @@
 -- Store the repair segment timeout in the repair unit
 
 ALTER TABLE repair_unit_v1 ADD timeout int;
+ALTER TABLE repair_schedule_v1 ADD adaptive boolean;
+ALTER TABLE repair_run ADD adaptive_schedule boolean static;

--- a/src/server/src/main/resources/db/cassandra/029_adaptive_repairs.cql
+++ b/src/server/src/main/resources/db/cassandra/029_adaptive_repairs.cql
@@ -16,3 +16,5 @@
 -- Store the repair segment timeout in the repair unit
 
 ALTER TABLE repair_unit_v1 ADD timeout int;
+ALTER TABLE repair_schedule_v1 ADD adaptive boolean;
+ALTER TABLE repair_run ADD adaptive_schedule boolean static;

--- a/src/server/src/main/resources/db/h2/V22_0_0__adaptive_repairs.sql
+++ b/src/server/src/main/resources/db/h2/V22_0_0__adaptive_repairs.sql
@@ -1,2 +1,11 @@
 ALTER TABLE repair_unit
 ADD timeout INT NOT NULL DEFAULT 0;
+
+ALTER TABLE repair_schedule
+ADD adaptive BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE repair_run
+ADD adaptive_schedule BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE repair_schedule
+DROP segment_count;

--- a/src/server/src/main/resources/db/postgres/V22_0_0__adaptive_repairs.sql
+++ b/src/server/src/main/resources/db/postgres/V22_0_0__adaptive_repairs.sql
@@ -1,2 +1,11 @@
 ALTER TABLE "repair_unit" 
 ADD "timeout" INT NOT NULL DEFAULT 0;
+
+ALTER TABLE "repair_schedule"
+ADD "adaptive" BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE "repair_run"
+ADD "adaptive_schedule" BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE "repair_schedule"
+DROP "segment_count";

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -417,6 +417,7 @@ public final class BasicSteps {
       params.put("scheduleDaysBetween", "1");
       params.put("repairParallelism", repairType.equals("incremental") ? "parallel" : "sequential");
       params.put("incrementalRepair", repairType.equals("incremental") ? "True" : "False");
+      params.put("adaptive", "False");
       Response response = runner.callReaper("POST", "/repair_schedule", Optional.of(params));
       int responseStatus = response.getStatus();
       String responseEntity = response.readEntity(String.class);

--- a/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/view/RepairRunStatusTest.java
@@ -79,7 +79,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1,
             UUID.randomUUID(),
-            30); // repair thread count
+            30,
+            false); // repair thread count
 
     assertEquals("1 minute 0 seconds", repairStatus.getDuration());
   }
@@ -109,7 +110,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1,
             UUID.randomUUID(),
-            30); // repair thread count
+            30,
+            false); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }
@@ -139,7 +141,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1,
             UUID.randomUUID(),
-            30); // repair thread count
+            30,
+            false); // repair thread count
 
     assertEquals("1 minute 50 seconds", repairStatus.getDuration());
   }
@@ -169,7 +172,8 @@ public final class RepairRunStatusTest {
             Collections.EMPTY_LIST, // blacklist
             1,
             UUID.randomUUID(),
-            30); // repair thread count
+            30,
+            false); // repair thread count
 
     assertEquals("1 minute 30 seconds", repairStatus.getDuration());
   }

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -117,8 +117,8 @@ public final class ClusterRepairSchedulerTest {
   @Test
   public void removeSchedulesForKeyspaceThatNoLongerExists() throws Exception {
     context.storage.addCluster(cluster);
-    context.storage.addRepairSchedule(aRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
-    context.storage.addRepairSchedule(aRepairSchedule(cluster, "keyspace2", TWO_HOURS_AGO));
+    context.storage.addRepairSchedule(oneRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
+    context.storage.addRepairSchedule(oneRepairSchedule(cluster, "keyspace2", TWO_HOURS_AGO));
     when(jmxProxy.getKeyspaces()).thenReturn(Lists.newArrayList("keyspace1"));
     clusterRepairAuto.scheduleRepairs(cluster);
     assertThat(context.storage.getAllRepairSchedules()).hasSize(1);
@@ -131,7 +131,7 @@ public final class ClusterRepairSchedulerTest {
   @Test
   public void addSchedulesForNewKeyspace() throws Exception {
     context.storage.addCluster(cluster);
-    context.storage.addRepairSchedule(aRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
+    context.storage.addRepairSchedule(oneRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
 
     when(jmxProxy.getKeyspaces()).thenReturn(Lists.newArrayList("keyspace1", "keyspace2"));
 
@@ -228,7 +228,7 @@ public final class ClusterRepairSchedulerTest {
         Arrays.asList(cluster.getName() + "-1", cluster.getName() + "-2")
     );
     context.storage.addCluster(cluster);
-    context.storage.addRepairSchedule(aRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
+    context.storage.addRepairSchedule(oneRepairSchedule(cluster, "keyspace1", TWO_HOURS_AGO));
     when(jmxProxy.getKeyspaces()).thenReturn(Lists.newArrayList("keyspace1"));
 
     clusterRepairAuto.scheduleRepairs(cluster);
@@ -243,8 +243,8 @@ public final class ClusterRepairSchedulerTest {
     return DateTime.now().plus(DELAY_BEFORE_SCHEDULE.toMillis());
   }
 
-  private RepairSchedule.Builder aRepairSchedule(Cluster cluster, String keyspace, DateTime creationTime) {
-    RepairUnit repairUnit = context.storage.addRepairUnit(aRepair(cluster, keyspace));
+  private RepairSchedule.Builder oneRepairSchedule(Cluster cluster, String keyspace, DateTime creationTime) {
+    RepairUnit repairUnit = context.storage.addRepairUnit(oneRepair(cluster, keyspace));
 
     return RepairSchedule.builder(repairUnit.getId())
         .creationTime(creationTime)
@@ -252,12 +252,11 @@ public final class ClusterRepairSchedulerTest {
         .nextActivation(DateTime.now())
         .repairParallelism(RepairParallelism.DATACENTER_AWARE)
         .intensity(0.9)
-        .segmentCount(10)
-        .segmentCountPerNode(0);
+        .segmentCountPerNode(3);
 
   }
 
-  private RepairUnit.Builder aRepair(Cluster cluster, String keyspace) {
+  private RepairUnit.Builder oneRepair(Cluster cluster, String keyspace) {
     return RepairUnit.builder()
         .clusterName(cluster.getName())
         .keyspaceName(keyspace)
@@ -304,7 +303,6 @@ public final class ClusterRepairSchedulerTest {
 
         assertThat(repairSchedule.getDaysBetween()).isEqualTo(config.getScheduleDaysBetween());
         assertThat(repairSchedule.getIntensity()).isEqualTo(config.getRepairIntensity());
-        assertThat(repairSchedule.getSegmentCount()).isEqualTo(0);
         assertThat(repairSchedule.getSegmentCountPerNode())
             .isEqualTo(config.getSegmentCountPerNode());
         assertThat(repairSchedule.getRepairParallelism()).isEqualTo(config.getRepairParallelism());

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -294,8 +294,8 @@ public final class RepairRunServiceTest {
         .repairThreadCount(4)
         .timeout(segmentTimeout)
         .build(UUIDs.timeBased());
-    List<Segment> segments = repairRunService.generateSegments(cluster, 10, 10, unit);
-    assertEquals(12, segments.size());
+    List<Segment> segments = repairRunService.generateSegments(cluster, 10, unit);
+    assertEquals(32, segments.size());
     assertEquals(3, segments.get(0).getReplicas().keySet().size());
     assertEquals("dc1", segments.get(0).getReplicas().get("127.0.0.1"));
   }

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -88,6 +88,7 @@ const repairForm = CreateReactClass({
       datacentersSelectDisabled: false,
       showModal: false,
       force: "false",
+      adaptive: false,
     };
   },
 
@@ -206,6 +207,9 @@ const repairForm = CreateReactClass({
     if (this.state.cause) repair.cause = this.state.cause;
     if (this.state.incrementalRepair) {
       repair.incrementalRepair = this.state.incrementalRepair;
+      if (repair.incrementalRepair == "true") {
+        repair.repairParallelism = "PARALLEL";
+      }
     }
     else {
       repair.incrementalRepair = "false";
@@ -222,6 +226,12 @@ const repairForm = CreateReactClass({
     }
     if (this.state.timeout) {
       repair.timeout = this.state.timeout;
+    }
+    if (this.state.adaptive) {
+      repair.adaptive = this.state.adaptive;
+    }
+    else {
+      repair.adaptive = "false";
     }
 
     this.props.addRepairSubject.onNext({
@@ -487,32 +497,44 @@ const repairForm = CreateReactClass({
     else if (this.state.formType === "schedule") {
       customInput = (
         <div>
-        <div className="form-group">
-          <label htmlFor="in_startTime" className="col-sm-3 control-label">Start time*</label>
-          <div className="col-sm-9 col-md-7 col-lg-5">
-            <DatePicker
-              selected={this.state.startTime}
-              onChange={value => this.setState({startTime: value})}
-              showTimeSelect
-              timeFormat="HH:mm"
-              timeIntervals={15}
-              timeCaption="Time"
-              dateFormat="d MMMM yyyy HH:mm"
-            />
+          <div className="form-group">
+            <label htmlFor="in_startTime" className="col-sm-3 control-label">Start time*</label>
+            <div className="col-sm-9 col-md-7 col-lg-5">
+              <DatePicker
+                selected={this.state.startTime}
+                onChange={value => this.setState({startTime: value})}
+                showTimeSelect
+                timeFormat="HH:mm"
+                timeIntervals={15}
+                timeCaption="Time"
+                dateFormat="d MMMM yyyy HH:mm"
+              />
+            </div>
+          </div>
+          <div className="form-group">
+            <label htmlFor="in_intervalDays" className="col-sm-3 control-label">Interval in days*</label>
+            <div className="col-sm-9 col-md-7 col-lg-5">
+              <input type="number" required className="form-control" value={this.state.intervalDays}
+                onChange={this._handleChange} id="in_intervalDays" placeholder="amount of days to wait between scheduling new repairs, (e.g. 7 for weekly)"/>
+            </div>
+          </div>
+          <div className="form-group">
+            <label htmlFor="in_adaptive" className="col-sm-3 control-label">Adaptive</label>
+            <div className="col-sm-9 col-md-7 col-lg-5">
+              <Select
+                id="in_adaptive"
+                name="in_adaptive"
+                classNamePrefix="select"
+                options={[{label: "true", value: "true"}, {label: "false", value: "false"}]}
+                placeholder="false"
+                onChange={this._handleSelectOnChange}
+              />
+            </div>
           </div>
         </div>
-        <div className="form-group">
-          <label htmlFor="in_intervalDays" className="col-sm-3 control-label">Interval in days*</label>
-          <div className="col-sm-9 col-md-7 col-lg-5">
-            <input type="number" required className="form-control" value={this.state.intervalDays}
-              onChange={this._handleChange} id="in_intervalDays" placeholder="amount of days to wait between scheduling new repairs, (e.g. 7 for weekly)"/>
-          </div>
-        </div>
-        </div>
+        
       );
     }
-
-    const keyspaceInputStyle = this.state.keyspaceList.length > 0 ? 'form-control-hidden':'form-control';
 
     const advancedSettingsHeader = (
       <div className="panel-title" >

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -167,12 +167,14 @@ const TableRowDetails = CreateReactClass({
 
     var metrics = ["io.cassandrareaper.service.RepairRunner.repairProgress", "io.cassandrareaper.service.RepairRunner.segmentsDone",
                    "io.cassandrareaper.service.RepairRunner.segmentsTotal", "io.cassandrareaper.service.RepairRunner.millisSinceLastRepair"];
-  let cleanupRegex = /[^A-Za-z0-9]/mg
-  let availableMetrics = metrics.map(metric => <div key={metric + this.props.row.repair_unit_id}>
-      {metric + "." 
-        + this.props.row.cluster_name.replace(cleanupRegex, "") + "." 
-        + this.props.row.keyspace_name.replace(cleanupRegex, "") + "." 
-        + this.props.row.repair_unit_id.replace(cleanupRegex, "")}</div>)
+    let cleanupRegex = /[^A-Za-z0-9]/mg
+    let availableMetrics = metrics.map(metric => <div key={metric + this.props.row.repair_unit_id}>
+        {metric + "." 
+          + this.props.row.cluster_name.replace(cleanupRegex, "") + "." 
+          + this.props.row.keyspace_name.replace(cleanupRegex, "") + "." 
+          + this.props.row.repair_unit_id.replace(cleanupRegex, "")}</div>);
+
+    const adaptiveSchedule = this.props.row.adaptive_schedule == true ? "true" : "false";
     return (
       <tr id={rowID} className="collapse out">
         <td colSpan="7">
@@ -257,6 +259,10 @@ const TableRowDetails = CreateReactClass({
                 <tr>
                     <td>Available metrics<br/><i>(can require a full run before appearing)</i></td>
                     <td>{availableMetrics}</td>
+                </tr>
+                <tr>
+                    <td>Adaptive Schedule</td>
+                    <td>{adaptiveSchedule}</td>
                 </tr>
             </tbody>
           </table>

--- a/src/ui/app/jsx/schedule-list.jsx
+++ b/src/ui/app/jsx/schedule-list.jsx
@@ -78,6 +78,7 @@ const TableRowDetails = CreateReactClass({
     const nextAt = moment(this.props.row.next_activation).format("LLL");
     const rowID = `details_${this.props.row.id}`;
     const incremental = this.props.row.incremental_repair == true ? "true" : "false";
+    const adaptive = this.props.row.adaptive == true ? "true" : "false";
 
     let segmentCount = <tr>
                         <td>Segment count per node</td>
@@ -144,6 +145,10 @@ const TableRowDetails = CreateReactClass({
                 <tr>
                     <td>Creation time</td>
                     <td>{createdAt}</td>
+                </tr>
+                <tr>
+                    <td>Adaptive</td>
+                    <td>{adaptive}</td>
                 </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Fixes #1061

Adaptive schedules will be updated at the end of each repair if the run metrics require it. The schedule can get a higher/lower number of segments or a higher segment timeout depending on the latest run.
The applied rules are the following: 

- if more than 20% segments were extended, the number of segments will be raised by 20% on the schedule
- if less than 20% segments were extended (and at least one), the timeout will be set to twice the current timeout
- if no segment was extended and the maximum duration of segments is below 5 minutes, the number of segments will be reduced by 10% with a minimum of 16 segments per node.

The changes above are not aggressive on purpose (10% to 20% changes in numbers of segments and a minimum of 16 segments per node) to apply gradual changes and generate safe automated changes.