### PR TITLE
Update CI following 4.0.0 GA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,11 +125,13 @@ jobs:
     name: H2 and Memory backends
     needs: build
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [1.2.19, 2.0.17, 2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [1.2.19, 2.0.17, 2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [local]
         test-type: [ccm]
+        experimental: [false]
         include:
           # don't run against the following C* versions when using cassandra storage type
           - cassandra-version: 1.2.19
@@ -140,10 +142,12 @@ jobs:
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+          - cassandra-version: 'github:apache/trunk'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -210,7 +214,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        cassandra-version: [3.11.10]
+        cassandra-version: [3.11.11]
         storage-type: [postgresql]
         test-type: [ccm]
         grim-max: [1, 2, 4]
@@ -303,20 +307,24 @@ jobs:
     needs: build
     name: Cassandra backend
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra]
         test-type: [ccm]
+        experimental: [false]
         include:
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+          - cassandra-version: 'github:apache/trunk'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -451,33 +459,40 @@ jobs:
     needs: [docker-tests, its-ccm-local, its-pgsql, its-ccm-cass, its-elassandra]
     name: Sidecar
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra, postgresql]
         test-type: [sidecar]
         grim-max: [1]
         grim-min: [1]
+        experimental: [false]
         # all versions but trunk have the same cucumber options, but we can't declare that more effectively (yet)
         include:
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar'
+          - cassandra-version: 4.0.0
+            cucumber-options: '--tags @sidecar'
           - cassandra-version: 'github:apache/trunk'
             cucumber-options: '--tags @sidecar'
-        # sidecar test including postgres should only run with C* 3.11.10, so we exclude all other
+            experimental: true
+        # sidecar test including postgres should only run with C* 3.11.11, so we exclude all other
         exclude:
           - storage-type: postgresql
             cassandra-version: 2.1.22
           - storage-type: postgresql
             cassandra-version: 2.2.19
           - storage-type: postgresql
-            cassandra-version: 3.0.24
+            cassandra-version: 3.0.25
+          - storage-type: postgresql
+            cassandra-version: 3.11.11
           - storage-type: postgresql
             cassandra-version: 'github:apache/trunk'
     steps:
@@ -556,20 +571,23 @@ jobs:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [3.11.10, 'github:apache/trunk']
+        cassandra-version: [4.0.0, 'github:apache/trunk']
         storage-type: [cassandra, postgresql]
         test-type: [each]
         grim-max: [1]
         grim-min: [1]
-        # Reducing the scope to 3.11 and trunk to shorten the integration test times
+        experimental: [false]
+        # Reduced scope to shorten the integration test times
         include:
-          - cassandra-version: 3.11.10
-            cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar'
+          - cassandra-version: 4.0.0
+            cucumber-options: '--tags @sidecar'
           - cassandra-version: 'github:apache/trunk'
             cucumber-options: '--tags @sidecar'
-        # sidecar test including postgres should only run with C* 3.11.10, so we exclude all other
+            experimental: true
+        # sidecar test including postgres should only run with C* 3.11.11, so we exclude all other
         exclude:
           - storage-type: postgresql
             cassandra-version: 'github:apache/trunk'
@@ -633,23 +651,27 @@ jobs:
     needs: [docker-tests, its-ccm-local, its-pgsql, its-ccm-cass, its-elassandra]
     name: Distributed tests
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra]
         test-type: [ccm]
         grim-max: [2]
         grim-min: [2]
+        experimental: [false]
         include:
           # all versions but trunk need to exclude trunk tests
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+          - cassandra-version: 'github:apache/trunk'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -712,23 +734,27 @@ jobs:
     needs: [docker-tests, its-ccm-local, its-pgsql, its-ccm-cass, its-elassandra]
     name: Flapping reapers
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra]
         test-type: [ccm]
         grim-max: [4]
         grim-min: [2]
+        experimental: [false]
         include:
           # all versions but trunk need to exclude trunk tests
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+          - cassandra-version: 'github:apache/trunk'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Fossa CLI
         run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b .
       - name: Scan for dependencies and licenses
         run: |
-          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} fossa analyze
+          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} ./fossa analyze

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -107,7 +107,8 @@ public final class RepairRunResource {
       @QueryParam("nodes") Optional<String> nodesToRepairParam,
       @QueryParam("datacenters") Optional<String> datacentersToRepairParam,
       @QueryParam("blacklistedTables") Optional<String> blacklistedTableNamesParam,
-      @QueryParam("repairThreadCount") Optional<Integer> repairThreadCountParam) {
+      @QueryParam("repairThreadCount") Optional<Integer> repairThreadCountParam,
+      @QueryParam("force") Optional<String> forceParam) {
 
     try {
       final Response possibleFailedResponse
@@ -124,7 +125,8 @@ public final class RepairRunResource {
           nodesToRepairParam,
           datacentersToRepairParam,
           blacklistedTableNamesParam,
-          repairThreadCountParam);
+          repairThreadCountParam,
+          forceParam);
 
       if (null != possibleFailedResponse) {
         return possibleFailedResponse;
@@ -272,7 +274,8 @@ public final class RepairRunResource {
       Optional<String> nodesStr,
       Optional<String> datacentersStr,
       Optional<String> blacklistedTableNamesParam,
-      Optional<Integer> repairThreadCountStr) throws ReaperException {
+      Optional<Integer> repairThreadCountStr,
+      Optional<String> forceParam) throws ReaperException {
 
     if (!clusterName.isPresent()) {
       return createMissingArgumentResponse("clusterName");
@@ -346,6 +349,15 @@ public final class RepairRunResource {
     if (tableNamesParam.isPresent() && blacklistedTableNamesParam.isPresent()) {
       return Response.status(Response.Status.BAD_REQUEST)
           .entity("invalid to specify a table list and a blacklist")
+          .build();
+    }
+
+    if (forceParam.isPresent()
+        && (!forceParam.get().toUpperCase().contentEquals("TRUE")
+        && !forceParam.get().toUpperCase().contentEquals("FALSE"))) {
+
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("invalid query parameter \"force\", expecting [True,False]")
           .build();
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -135,7 +135,8 @@ public final class ClusterRepairScheduler {
             REPAIR_OWNER,
             context.config.getSegmentCountPerNode(),
             context.config.getRepairParallelism(),
-            context.config.getRepairIntensity());
+            context.config.getRepairIntensity(),
+            false);
 
     LOG.info("Scheduled repair created: {}", repairSchedule);
   }

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -61,6 +61,24 @@ public final class RepairScheduleService {
     return Optional.empty();
   }
 
+  public Optional<RepairSchedule> identicalRepairUnit(Cluster cluster, RepairUnit.Builder repairUnit) {
+
+    Collection<RepairSchedule> repairSchedules = context.storage
+        .getRepairSchedulesForClusterAndKeyspace(repairUnit.clusterName, repairUnit.keyspaceName);
+
+    for (RepairSchedule sched : repairSchedules) {
+      RepairUnit repairUnitForSched = context.storage.getRepairUnit(sched.getRepairUnitId());
+      Preconditions.checkState(repairUnitForSched.getClusterName().equals(repairUnit.clusterName));
+      Preconditions.checkState(repairUnitForSched.getKeyspaceName().equals(repairUnit.keyspaceName));
+
+      // if the schedule is identical, return immediately
+      if (repairUnitService.identicalUnits(cluster, repairUnitForSched, repairUnit)) {
+        return Optional.of(sched);
+      }
+    }
+    return Optional.empty();
+  }
+
   /**
    * Instantiates a RepairSchedule and stores it in the storage backend.
    *
@@ -77,10 +95,11 @@ public final class RepairScheduleService {
       String owner,
       int segmentCountPerNode,
       RepairParallelism repairParallelism,
-      Double intensity) {
+      Double intensity,
+      boolean force) {
 
     Preconditions.checkArgument(
-        !conflictingRepairSchedule(cluster, repairUnit.with()).isPresent(),
+        force || !conflictingRepairSchedule(cluster, repairUnit.with()).isPresent(),
         "A repair schedule already exists for cluster \"%s\", keyspace \"%s\", and column families: %s",
         cluster.getName(),
         repairUnit.getKeyspaceName(),

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -146,6 +146,26 @@ Feature: Using Reaper
 
   @sidecar
   @all_nodes_reachable
+  @cassandra_2_1_onwards
+  Scenario Outline: Adding a scheduled full repair and a scheduled incremental repair for the same keyspace with force option
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new daily "incremental" repair schedule is added for "test" and keyspace "test_keyspace3"
+    And a new daily "full" repair schedule is added that already exists for "test" and keyspace "test_keyspace3" with force option
+    Then reaper has 2 scheduled repairs for cluster called "test"
+    When reaper is upgraded to latest
+    Then reaper has 2 scheduled repairs for cluster called "test"
+    And deleting cluster called "test" fails
+    When all added schedules are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @all_nodes_reachable
   @cassandra_3_11_onwards
   Scenario Outline: Add a scheduled incremental repair and collect percent repaired metrics
     Given that reaper <version> is running

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -23,6 +23,8 @@ import $ from "jquery";
 import DatePicker from "react-datepicker";
 import Moment from 'moment';
 import moment from "moment";
+import Modal from 'react-bootstrap/lib/Modal';
+import Button from 'react-bootstrap/lib/Button';
 
 Moment.locale(navigator.language);
 
@@ -42,6 +44,7 @@ const repairForm = CreateReactClass({
     return {
       formType: this.props.formType,
       addRepairResultMsg: null,
+      addRepairResultStatus: null,
       clusterNames: [],
       submitEnabled: false,
       clusterName: this.props.currentCluster === "all" ? this.props.clusterNames[0] : this.props.currentCluster,
@@ -82,14 +85,25 @@ const repairForm = CreateReactClass({
       datacentersList: [],
       datacentersSelectValues: [],
       datacentersSelectDisabled: false,
+      showModal: false,
+      force: "false",
     };
   },
 
   UNSAFE_componentWillMount: function() {
     this._repairResultSubscription = this.props.addRepairResult.subscribeOnNext(obs =>
       obs.subscribe(
-        r => this.setState({addRepairResultMsg: null}),
-        r => this.setState({addRepairResultMsg: r.responseText})
+        r => this.setState({
+          addRepairResultMsg: null,
+          addRepairResultStatus: null,
+          showModal: false,
+          force: "false",
+        }),
+        r => this.setState({
+          addRepairResultMsg: r.responseText,
+          addRepairResultStatus: r.status,
+          showModal: true,
+        })
       )
     );
 
@@ -199,6 +213,12 @@ const repairForm = CreateReactClass({
     if (this.state.datacenters) repair.datacenters = this.state.datacenters;
     if (this.state.blacklistedTables) repair.blacklistedTables = this.state.blacklistedTables;
     if (this.state.repairThreadCount && this.state.repairThreadCount > 0) repair.repairThreadCount = this.state.repairThreadCount;
+    if (this.state.force) {
+      repair.force = this.state.force;
+    }
+    else {
+      repair.force = "false";
+    }
 
     this.props.addRepairSubject.onNext({
       type: this.state.formType,
@@ -360,11 +380,48 @@ const repairForm = CreateReactClass({
     return uuid;
   },
 
+  _onForce(e){
+    this.setState({
+      force: "true",
+      addRepairResultMsg: null,
+      showModal: false }, () => this._onAdd(e));
+  },
+
+  _onClose(e){
+    this.setState({
+      force: "false",
+      addRepairResultMsg: null,
+      showModal: false
+    });
+  },
+
   render: function() {
 
     let addMsg = null;
     if(this.state.addRepairResultMsg) {
-      addMsg = <div className="alert alert-danger" role="alert">{this.state.addRepairResultMsg}</div>
+      if(this.state.addRepairResultStatus && this.state.addRepairResultStatus === 409) {
+        addMsg = (
+                <span>
+                <Modal show={this.state.showModal} onHide={this._onClose}>
+                  <Modal.Header closeButton>
+                    <Modal.Title>Scheduling conflict detected</Modal.Title>
+                  </Modal.Header>
+                  <Modal.Body>
+                    <p>{this.state.addRepairResultMsg}</p>
+                    <p>It is not reccommended to create overlapping repair schedules.</p>
+                    <p>For Cassandra 4.0 and later, you can force creating this schedule by clicking the "Force" button below.</p>
+                  </Modal.Body>
+                  <Modal.Footer>
+                    <Button variant="secondary" onClick={this._onClose}>Cancel</Button>
+                    <Button variant="primary" onClick={this._onForce}>Force</Button>
+                  </Modal.Footer>
+                </Modal>
+              </span>
+        );
+      }
+      else {
+        addMsg = <div className="alert alert-danger" role="alert">{this.state.addRepairResultMsg}</div>
+      }
     }
 
     const clusterNameOptions = this.state.clusterNames.sort().map(name => {


### PR DESCRIPTION
Trunk can now be unstable with possible breaking changes again which means we have to make trunk tests optional and add 4.0.0 explicitly to the test matrix.