### PR TITLE
Add 4.0.0 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,11 +125,13 @@ jobs:
     name: H2 and Memory backends
     needs: build
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [1.2.19, 2.0.17, 2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [1.2.19, 2.0.17, 2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [local]
         test-type: [ccm]
+        experimental: [false]
         include:
           # don't run against the following C* versions when using cassandra storage type
           - cassandra-version: 1.2.19
@@ -140,10 +142,12 @@ jobs:
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+          - cassandra-version: 'github:apache/trunk'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -210,7 +214,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        cassandra-version: [3.11.10]
+        cassandra-version: [3.11.11]
         storage-type: [postgresql]
         test-type: [ccm]
         grim-max: [1, 2, 4]
@@ -303,20 +307,24 @@ jobs:
     needs: build
     name: Cassandra backend
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra]
         test-type: [ccm]
+        experimental: [false]
         include:
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+          - cassandra-version: 'github:apache/trunk'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -451,33 +459,40 @@ jobs:
     needs: [docker-tests, its-ccm-local, its-pgsql, its-ccm-cass, its-elassandra]
     name: Sidecar
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra, postgresql]
         test-type: [sidecar]
         grim-max: [1]
         grim-min: [1]
+        experimental: [false]
         # all versions but trunk have the same cucumber options, but we can't declare that more effectively (yet)
         include:
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar'
+          - cassandra-version: 4.0.0
+            cucumber-options: '--tags @sidecar'
           - cassandra-version: 'github:apache/trunk'
             cucumber-options: '--tags @sidecar'
-        # sidecar test including postgres should only run with C* 3.11.10, so we exclude all other
+            experimental: true
+        # sidecar test including postgres should only run with C* 3.11.11, so we exclude all other
         exclude:
           - storage-type: postgresql
             cassandra-version: 2.1.22
           - storage-type: postgresql
             cassandra-version: 2.2.19
           - storage-type: postgresql
-            cassandra-version: 3.0.24
+            cassandra-version: 3.0.25
+          - storage-type: postgresql
+            cassandra-version: 3.11.11
           - storage-type: postgresql
             cassandra-version: 'github:apache/trunk'
     steps:
@@ -556,20 +571,23 @@ jobs:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [3.11.10, 'github:apache/trunk']
+        cassandra-version: [4.0.0, 'github:apache/trunk']
         storage-type: [cassandra, postgresql]
         test-type: [each]
         grim-max: [1]
         grim-min: [1]
-        # Reducing the scope to 3.11 and trunk to shorten the integration test times
+        experimental: [false]
+        # Reduced scope to shorten the integration test times
         include:
-          - cassandra-version: 3.11.10
-            cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar'
+          - cassandra-version: 4.0.0
+            cucumber-options: '--tags @sidecar'
           - cassandra-version: 'github:apache/trunk'
             cucumber-options: '--tags @sidecar'
-        # sidecar test including postgres should only run with C* 3.11.10, so we exclude all other
+            experimental: true
+        # sidecar test including postgres should only run with C* 3.11.11, so we exclude all other
         exclude:
           - storage-type: postgresql
             cassandra-version: 'github:apache/trunk'
@@ -633,23 +651,27 @@ jobs:
     needs: [docker-tests, its-ccm-local, its-pgsql, its-ccm-cass, its-elassandra]
     name: Distributed tests
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra]
         test-type: [ccm]
         grim-max: [2]
         grim-min: [2]
+        experimental: [false]
         include:
           # all versions but trunk need to exclude trunk tests
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+          - cassandra-version: 'github:apache/trunk'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -712,23 +734,27 @@ jobs:
     needs: [docker-tests, its-ccm-local, its-pgsql, its-ccm-cass, its-elassandra]
     name: Flapping reapers
     runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [2.1.22, 2.2.19, 3.0.24, 3.11.10, 'github:apache/trunk']
+        cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra]
         test-type: [ccm]
         grim-max: [4]
         grim-min: [2]
+        experimental: [false]
         include:
           # all versions but trunk need to exclude trunk tests
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.0.24
+          - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-          - cassandra-version: 3.11.10
+          - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+          - cassandra-version: 'github:apache/trunk'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,21 +131,28 @@ jobs:
         cassandra-version: [1.2.19, 2.0.17, 2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [local]
         test-type: [ccm]
-        experimental: [false]
         include:
           # don't run against the following C* versions when using cassandra storage type
           - cassandra-version: 1.2.19
             cucumber-options: '--tags ~@cassandra_2_1_onwards --tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 2.0.17
             cucumber-options: '--tags ~@cassandra_2_1_onwards --tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+            experimental: false
+          - cassandra-version: 4.0.0
+            experimental: false
           - cassandra-version: 'github:apache/trunk'
             experimental: true
     steps:
@@ -313,16 +320,21 @@ jobs:
         cassandra-version: [2.1.22, 2.2.19, 3.0.25, 3.11.11, 4.0.0, 'github:apache/trunk']
         storage-type: [cassandra]
         test-type: [ccm]
-        experimental: [false]
         include:
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+            experimental: false
+          - cassandra-version: 4.0.0
+            experimental: false
           - cassandra-version: 'github:apache/trunk'
             experimental: true
     steps:
@@ -467,19 +479,23 @@ jobs:
         test-type: [sidecar]
         grim-max: [1]
         grim-min: [1]
-        experimental: [false]
         # all versions but trunk have the same cucumber options, but we can't declare that more effectively (yet)
         include:
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @sidecar'
+            experimental: false
           - cassandra-version: 4.0.0
             cucumber-options: '--tags @sidecar'
+            experimental: false
           - cassandra-version: 'github:apache/trunk'
             cucumber-options: '--tags @sidecar'
             experimental: true
@@ -579,11 +595,11 @@ jobs:
         test-type: [each]
         grim-max: [1]
         grim-min: [1]
-        experimental: [false]
         # Reduced scope to shorten the integration test times
         include:
           - cassandra-version: 4.0.0
             cucumber-options: '--tags @sidecar'
+            experimental: false
           - cassandra-version: 'github:apache/trunk'
             cucumber-options: '--tags @sidecar'
             experimental: true
@@ -659,17 +675,22 @@ jobs:
         test-type: [ccm]
         grim-max: [2]
         grim-min: [2]
-        experimental: [false]
         include:
           # all versions but trunk need to exclude trunk tests
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+            experimental: false
+          - cassandra-version: 4.0.0
+            experimental: false
           - cassandra-version: 'github:apache/trunk'
             experimental: true
     steps:
@@ -742,17 +763,22 @@ jobs:
         test-type: [ccm]
         grim-max: [4]
         grim-min: [2]
-        experimental: [false]
         include:
           # all versions but trunk need to exclude trunk tests
           - cassandra-version: 2.1.22
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 2.2.19
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.0.25
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
+            experimental: false
           - cassandra-version: 3.11.11
             cucumber-options: '--tags ~@cassandra_4_0_onwards'
+            experimental: false
+          - cassandra-version: 4.0.0
+            experimental: false
           - cassandra-version: 'github:apache/trunk'
             experimental: true
     steps:

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -1286,26 +1286,25 @@ public final class BasicSteps {
       String keyspace) throws Throwable {
 
     synchronized (BasicSteps.class) {
-      RUNNERS.parallelStream().forEach(runner -> {
-        Map<String, String> params = Maps.newHashMap();
-        params.put("clusterName", clusterName);
-        params.put("keyspace", keyspace);
-        params.put("owner", TestContext.TEST_USER);
-        params.put("intensity", "0.9");
-        params.put("scheduleDaysBetween", "1");
-        params.put("repairParallelism", repairType.equals("incremental") ? "parallel" : "sequential");
-        params.put("incrementalRepair", repairType.equals("incremental") ? "True" : "False");
-        params.put("force", "true");
-        Response response = runner.callReaper("POST", "/repair_schedule", Optional.of(params));
+      ReaperTestJettyRunner runner = RUNNERS.get(RAND.nextInt(RUNNERS.size()));
+      Map<String, String> params = Maps.newHashMap();
+      params.put("clusterName", clusterName);
+      params.put("keyspace", keyspace);
+      params.put("owner", TestContext.TEST_USER);
+      params.put("intensity", "0.9");
+      params.put("scheduleDaysBetween", "1");
+      params.put("repairParallelism", repairType.equals("incremental") ? "parallel" : "sequential");
+      params.put("incrementalRepair", repairType.equals("incremental") ? "True" : "False");
+      params.put("force", "true");
+      Response response = runner.callReaper("POST", "/repair_schedule", Optional.of(params));
 
-        int status = response.getStatus();
-        String responseEntity = response.readEntity(String.class);
+      int status = response.getStatus();
+      String responseEntity = response.readEntity(String.class);
 
-        Assertions.assertThat(
-              ImmutableList.of(Response.Status.NO_CONTENT.getStatusCode(), Response.Status.CREATED.getStatusCode()))
-            .withFailMessage(responseEntity)
-            .contains(status);
-      });
+      Assertions.assertThat(
+            ImmutableList.of(Response.Status.CREATED.getStatusCode()))
+          .withFailMessage(responseEntity)
+          .contains(status);
     }
   }
 


### PR DESCRIPTION
Trunk can now be unstable with possible breaking changes again which means we have to make trunk tests optional and add 4.0.0 explicitly to the test matrix.