### PR TITLE
Fix the Base64-decoder failing if JWT_SECRET is not provided

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java
@@ -22,7 +22,9 @@ import io.cassandrareaper.storage.CassandraStorage;
 import io.cassandrareaper.storage.PostgresStorage;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Base64;
 
 import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.http.HttpServletRequest;
@@ -30,7 +32,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.DatatypeConverter;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -55,6 +56,7 @@ public final class ShiroJwtProvider {
   }
 
   private static Key getSigningKey(AppContext cxt) {
+    byte[] key;
     String txt = System.getenv("JWT_SECRET");
     if (null == txt) {
       if (cxt.storage instanceof CassandraStorage) {
@@ -64,7 +66,10 @@ public final class ShiroJwtProvider {
       } else {
         txt = AppContext.REAPER_INSTANCE_ADDRESS;
       }
+      key = txt.getBytes(StandardCharsets.UTF_8);
+    } else {
+      key = Base64.getDecoder().decode(txt);
     }
-    return new SecretKeySpec(DatatypeConverter.parseBase64Binary(txt), SIG_ALG.getJcaName());
+    return new SecretKeySpec(key, SIG_ALG.getJcaName());
   }
 }


### PR DESCRIPTION
If the JWT_SECRET is not specified, rest of the signing options are expected to be in Base64-format (which they're not). This modification requires only the JWT_SECRET to be in Base64-format, rest are not decoded anymore.

This should also fix #767 since the shortest Base64 string is 4 characters. 

The Base64.getDecoder() is more strict and as such, this will test if those inputs are really Base64 or not (and current tests are enough to test this new behavior).