### PR TITLE
Allow editing of existing repair schedules

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -313,11 +313,6 @@
             <artifactId>ibatis2-common</artifactId>
             <version>2.1.7.597</version>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -313,6 +313,11 @@
             <artifactId>ibatis2-common</artifactId>
             <version>2.1.7.597</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.20</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -191,7 +191,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
       FilterRegistration.Dynamic co = environment.servlets().addFilter("crossOriginRequests", CrossOriginFilter.class);
       co.setInitParameter("allowedOrigins", "*");
       co.setInitParameter("allowedHeaders", "X-Requested-With,Content-Type,Accept,Origin");
-      co.setInitParameter("allowedMethods", "OPTIONS,GET,PUT,POST,DELETE,HEAD");
+      co.setInitParameter("allowedMethods", "OPTIONS,GET,PUT,POST,DELETE,HEAD,PATCH");
       co.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import io.cassandrareaper.validators.NullOrNotBlank;
+import io.cassandrareaper.validators.ValidEditableRepairSchedule;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.cassandra.repair.RepairParallelism;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@ValidEditableRepairSchedule
+public class EditableRepairSchedule {
+  @NullOrNotBlank
+  protected String owner;
+
+  @JsonProperty(value = "repair_parallelism")
+  protected RepairParallelism repairParallelism;
+
+  @Min(value = 0)
+  @Max(value = 1)
+  protected Double intensity;
+
+  @JsonProperty(value = "scheduled_days_between")
+  @Min(value = 0)
+  @Max(value = 31)
+  protected Integer daysBetween;
+
+  @JsonProperty(value = "segment_count_per_node")
+  @Min(value = 1)
+  protected Integer segmentCountPerNode;
+}

--- a/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
@@ -50,5 +50,6 @@ public class EditableRepairSchedule {
 
   @JsonProperty(value = "segment_count_per_node")
   @Min(value = 1)
+  @Max(value = 1000)
   protected Integer segmentCountPerNode;
 }

--- a/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
@@ -23,12 +23,8 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.apache.cassandra.repair.RepairParallelism;
 
-@Data
-@NoArgsConstructor
 @ValidEditableRepairSchedule
 public class EditableRepairSchedule {
   @NullOrNotBlank
@@ -50,4 +46,52 @@ public class EditableRepairSchedule {
   @Min(value = 1)
   @Max(value = 1000)
   protected Integer segmentCountPerNode;
+
+  public EditableRepairSchedule() {
+    this.owner = null;
+    this.repairParallelism = null;
+    this.intensity = null;
+    this.daysBetween = null;
+    this.segmentCountPerNode = null;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public RepairParallelism getRepairParallelism() {
+    return repairParallelism;
+  }
+
+  public void setRepairParallelism(RepairParallelism repairParallelism) {
+    this.repairParallelism = repairParallelism;
+  }
+
+  public Double getIntensity() {
+    return intensity;
+  }
+
+  public void setIntensity(Double intensity) {
+    this.intensity = intensity;
+  }
+
+  public Integer getDaysBetween() {
+    return daysBetween;
+  }
+
+  public void setDaysBetween(Integer daysBetween) {
+    this.daysBetween = daysBetween;
+  }
+
+  public Integer getSegmentCountPerNode() {
+    return segmentCountPerNode;
+  }
+
+  public void setSegmentCountPerNode(Integer segmentCountPerNode) {
+    this.segmentCountPerNode = segmentCountPerNode;
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
@@ -43,7 +43,7 @@ public class EditableRepairSchedule {
   protected Integer daysBetween;
 
   @JsonProperty(value = "segment_count_per_node")
-  @Min(value = 1)
+  @Min(value = 0)
   @Max(value = 1000)
   protected Integer segmentCountPerNode;
 

--- a/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/EditableRepairSchedule.java
@@ -23,13 +23,11 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.cassandra.repair.RepairParallelism;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 @ValidEditableRepairSchedule
 public class EditableRepairSchedule {

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSchedule.java
@@ -28,22 +28,17 @@ import com.google.common.collect.Lists;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 
-public final class RepairSchedule {
+public final class RepairSchedule extends EditableRepairSchedule {
 
   private final UUID id;
 
   private final UUID repairUnitId;
   private final State state;
-  private final int daysBetween;
   private final DateTime nextActivation;
   private final ImmutableList<UUID> runHistory;
   @Deprecated private final int segmentCount;
-  private final RepairParallelism repairParallelism;
-  private final double intensity;
   private final DateTime creationTime;
-  private final String owner;
   private final DateTime pauseTime;
-  private final int segmentCountPerNode;
 
   private RepairSchedule(Builder builder, UUID id) {
     this.id = id;
@@ -77,10 +72,6 @@ public final class RepairSchedule {
     return state;
   }
 
-  public int getDaysBetween() {
-    return daysBetween;
-  }
-
   public DateTime getFollowingActivation() {
     return getNextActivation().plusDays(getDaysBetween());
   }
@@ -103,18 +94,6 @@ public final class RepairSchedule {
 
   public int getSegmentCount() {
     return segmentCount;
-  }
-
-  public int getSegmentCountPerNode() {
-    return segmentCountPerNode;
-  }
-
-  public RepairParallelism getRepairParallelism() {
-    return repairParallelism;
-  }
-
-  public double getIntensity() {
-    return intensity;
   }
 
   public DateTime getCreationTime() {

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -17,8 +17,6 @@
 
 package io.cassandrareaper.resources;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
@@ -56,6 +54,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.dropwizard.jersey.PATCH;
 import io.dropwizard.jersey.validation.ValidationErrorMessage;
@@ -83,11 +82,6 @@ public final class RepairScheduleResource {
     this.repairRunService = RepairRunService.create(context);
   }
 
-//  private static Map<String, List<String>> buildErrorResponseEntity(final List<String> errorMessages) {
-//    Map<String, String> errorMap = Maps.newHashMap();
-//    errorMap.put("errors")
-//  }
-
   @PATCH
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
@@ -98,14 +92,22 @@ public final class RepairScheduleResource {
       @NotNull @Valid EditableRepairSchedule editableRepairSchedule
   ) {
     if (repairScheduleId == null) {
-      ValidationErrorMessage errorMessage = new ValidationErrorMessage(ImmutableList.copyOf(Lists.newArrayList("id must not be null or empty")));
+      ValidationErrorMessage errorMessage = new ValidationErrorMessage(
+          ImmutableList.copyOf(
+              Lists.newArrayList("id must not be null or empty")
+          )
+      );
       return Response.status(400).entity(errorMessage).build();
     }
 
     // When executed through DropWizard the validation will prevent this from ever being reached
     // but to protect against an NPE if the behavior is ever changed, do a quick check of the param
     if (editableRepairSchedule == null) {
-      ValidationErrorMessage errorMessage = new ValidationErrorMessage(ImmutableList.copyOf(Lists.newArrayList("request body must not be null or empty")));
+      ValidationErrorMessage errorMessage = new ValidationErrorMessage(
+          ImmutableList.copyOf(
+              Lists.newArrayList("request body must not be null or empty")
+          )
+      );
       return Response.status(400).entity(errorMessage).build();
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -100,6 +100,7 @@ public final class RepairScheduleResource {
       }
     }
     boolean intensityValid = intensity != null && intensity >= 0.0D && intensity <= 1.0D;
+    // TODO What are good valid ranges for these values?
     boolean scheduleDaysBetweenValid = scheduleDaysBetween != null && scheduleDaysBetween > 0;
     boolean segmentCountPerNodeValid = segmentCountPerNode != null && segmentCountPerNode > 0;
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -17,6 +17,8 @@
 
 package io.cassandrareaper.resources;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
@@ -56,6 +58,7 @@ import javax.ws.rs.core.UriInfo;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import io.dropwizard.jersey.PATCH;
+import io.dropwizard.jersey.validation.ValidationErrorMessage;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -80,6 +83,11 @@ public final class RepairScheduleResource {
     this.repairRunService = RepairRunService.create(context);
   }
 
+//  private static Map<String, List<String>> buildErrorResponseEntity(final List<String> errorMessages) {
+//    Map<String, String> errorMap = Maps.newHashMap();
+//    errorMap.put("errors")
+//  }
+
   @PATCH
   @Produces(MediaType.APPLICATION_JSON)
   @Consumes(MediaType.APPLICATION_JSON)
@@ -90,7 +98,15 @@ public final class RepairScheduleResource {
       @NotNull @Valid EditableRepairSchedule editableRepairSchedule
   ) {
     if (repairScheduleId == null) {
-      return Response.status(Response.Status.NOT_FOUND).build();
+      ValidationErrorMessage errorMessage = new ValidationErrorMessage(ImmutableList.copyOf(Lists.newArrayList("id must not be null or empty")));
+      return Response.status(400).entity(errorMessage).build();
+    }
+
+    // When executed through DropWizard the validation will prevent this from ever being reached
+    // but to protect against an NPE if the behavior is ever changed, do a quick check of the param
+    if (editableRepairSchedule == null) {
+      ValidationErrorMessage errorMessage = new ValidationErrorMessage(ImmutableList.copyOf(Lists.newArrayList("request body must not be null or empty")));
+      return Response.status(400).entity(errorMessage).build();
     }
 
     // Try to find the schedule to be updated

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -17,8 +17,6 @@
 
 package io.cassandrareaper.resources;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
@@ -30,12 +28,14 @@ import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.service.RepairRunService;
 import io.cassandrareaper.service.RepairScheduleService;
 import io.cassandrareaper.service.RepairUnitService;
-import io.dropwizard.jersey.PATCH;
-import org.apache.cassandra.repair.RepairParallelism;
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -48,13 +48,14 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import io.dropwizard.jersey.PATCH;
+import org.apache.cassandra.repair.RepairParallelism;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Path("/repair_schedule")

--- a/src/server/src/main/java/io/cassandrareaper/validators/EditableRepairScheduleValidator.java
+++ b/src/server/src/main/java/io/cassandrareaper/validators/EditableRepairScheduleValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.validators;
+
+import io.cassandrareaper.core.EditableRepairSchedule;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EditableRepairScheduleValidator
+    implements ConstraintValidator<ValidEditableRepairSchedule, EditableRepairSchedule> {
+  @Override
+  public void initialize(ValidEditableRepairSchedule validEditableRepairSchedule) {
+  }
+
+  @Override
+  public boolean isValid(EditableRepairSchedule editableRepairSchedule, ConstraintValidatorContext context) {
+    return editableRepairSchedule.getOwner() != null
+        || editableRepairSchedule.getRepairParallelism() != null
+        || editableRepairSchedule.getIntensity() != null
+        || editableRepairSchedule.getDaysBetween() != null
+        || editableRepairSchedule.getSegmentCountPerNode() != null;
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/validators/NullOrNotBlank.java
+++ b/src/server/src/main/java/io/cassandrareaper/validators/NullOrNotBlank.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.validators;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ElementType.FIELD})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = NullOrNotBlankValidator.class)
+public @interface NullOrNotBlank {
+  String message() default "must not be empty if it is provided";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/server/src/main/java/io/cassandrareaper/validators/NullOrNotBlankValidator.java
+++ b/src/server/src/main/java/io/cassandrareaper/validators/NullOrNotBlankValidator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.validators;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NullOrNotBlankValidator implements ConstraintValidator<NullOrNotBlank, String> {
+  public void initialize(NullOrNotBlank parameters) {
+  }
+
+  public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+    return value == null || value.trim().length() > 0;
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/validators/ValidEditableRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/validators/ValidEditableRepairSchedule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.validators;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.NotNull;
+
+@NotNull
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EditableRepairScheduleValidator.class)
+public @interface ValidEditableRepairSchedule {
+  String message() default "must contain at least one valid field value";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/server/src/test/java/io/cassandrareaper/core/EditableRepairScheduleTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/core/EditableRepairScheduleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.core;
+
+import java.util.UUID;
+
+import org.apache.cassandra.repair.RepairParallelism;
+import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+public final class EditableRepairScheduleTest {
+
+  @Test
+  public void testEditableValueInheritance() {
+    RepairSchedule repairSchedule = RepairSchedule.builder(UUID.randomUUID())
+        .daysBetween(1)
+        .intensity(1.0D)
+        .segmentCountPerNode(2)
+        .owner("test")
+        .repairParallelism(RepairParallelism.PARALLEL)
+        .nextActivation(DateTime.now())
+        .build(UUID.randomUUID());
+
+    Assertions.assertThat(repairSchedule.getDaysBetween()).isEqualTo(1);
+    Assertions.assertThat(repairSchedule.getIntensity()).isEqualTo(1.0D);
+    Assertions.assertThat(repairSchedule.getSegmentCountPerNode()).isEqualTo(2);
+    Assertions.assertThat(repairSchedule.getOwner()).isEqualTo("test");
+  }
+}

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021- DataStax Inc.
+ * Copyright 2021-2021 DataStax, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,167 +17,63 @@
 package io.cassandrareaper.resources;
 
 import io.cassandrareaper.core.RepairSchedule;
+
+import java.util.UUID;
+
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.junit.Test;
-
-import java.util.List;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class RepairScheduleResourceTest {
-    @Test
-    public void testValidateRepairPatchParamsValidParams() {
-        String ownerValue = "test";
-        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
-        Double intensityValue = 1.0D;
-        Integer scheduleDaysBetweenValue = 2;
-        Integer segmentCountPerNodeValue = 5;
-        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.isEmpty());
-    }
+  @Test
+  public void testApplyRepairPatchParamsValidParams() {
+    DateTime nextActivation = DateTime.now();
+    UUID uuid = UUID.randomUUID();
+    RepairSchedule repairSchedule = RepairSchedule.builder(uuid)
+        .nextActivation(nextActivation)
+        .owner("test")
+        .repairParallelism(RepairParallelism.PARALLEL)
+        .intensity(1.0D)
+        .daysBetween(1)
+        .segmentCountPerNode(2)
+        .build(uuid);
 
-    @Test
-    public void testValidateRepairPatchParamsInvalidParams() {
-        String ownerValue = null;
-        String repairParallelismValue = null;
-        Double intensityValue = null;
-        Integer scheduleDaysBetweenValue = null;
-        Integer segmentCountPerNodeValue = null;
-        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 5);
-    }
+    assertTrue(nextActivation.equals(repairSchedule.getNextActivation()));
+    assertTrue(uuid.equals(repairSchedule.getRepairUnitId()));
+    assertTrue(uuid.equals(repairSchedule.getId()));
+    assertEquals("test", repairSchedule.getOwner());
+    assertEquals(RepairParallelism.PARALLEL, repairSchedule.getRepairParallelism());
+    assertTrue(1.0D == repairSchedule.getIntensity());
+    assertEquals(1, repairSchedule.getDaysBetween() != null
+        ? repairSchedule.getDaysBetween().intValue()
+        : -1);
+    assertEquals(2, repairSchedule.getSegmentCountPerNode() != null
+        ? repairSchedule.getSegmentCountPerNode().intValue()
+        : -1);
 
-    @Test
-    public void testValidateRepairPatchParamsInvalidOwnerParam() {
-        String ownerValue = null;
-        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
-        Double intensityValue = 1.0D;
-        Integer scheduleDaysBetweenValue = 2;
-        Integer segmentCountPerNodeValue = 5;
-        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("owner"));
+    RepairSchedule patchedRepairSchedule = RepairScheduleResource.applyRepairPatchParams(
+        repairSchedule,
+        "test2",
+        RepairParallelism.SEQUENTIAL,
+        0.0D,
+        2,
+        3
+    );
 
-        ownerValue = "";
-        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("owner"));
-    }
-
-    @Test
-    public void testValidateRepairPatchParamsInvalidRepairParallelismParam() {
-        String ownerValue = "test";
-        String repairParallelismValue = null;
-        Double intensityValue = 1.0D;
-        Integer scheduleDaysBetweenValue = 2;
-        Integer segmentCountPerNodeValue = 5;
-        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("repairParallelism"));
-
-        repairParallelismValue = "";
-        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("repairParallelism"));
-
-        repairParallelismValue = "INVALID";
-        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("repairParallelism"));
-    }
-
-    @Test
-    public void testValidateRepairPatchParamsInvalidIntensityParam() {
-        String ownerValue = "test";
-        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
-        Double intensityValue = null;
-        Integer scheduleDaysBetweenValue = 2;
-        Integer segmentCountPerNodeValue = 5;
-        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("intensity"));
-
-        intensityValue = 1.1D;
-        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("intensity"));
-    }
-
-    @Test
-    public void testValidateRepairPatchParamsInvalidScheduleDaysBetweenParam() {
-        String ownerValue = "test";
-        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
-        Double intensityValue = 1.0D;
-        Integer scheduleDaysBetweenValue = null;
-        Integer segmentCountPerNodeValue = 5;
-        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("scheduleDaysBetween"));
-
-        scheduleDaysBetweenValue = 0;
-        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("scheduleDaysBetween"));
-    }
-
-    @Test
-    public void testValidateRepairPatchParamsInvalidSegmentCountPerNodeParam() {
-        String ownerValue = "test";
-        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
-        Double intensityValue = 1.0D;
-        Integer scheduleDaysBetweenValue = 2;
-        Integer segmentCountPerNodeValue = null;
-        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("segmentCountPerNode"));
-
-        segmentCountPerNodeValue = 0;
-        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
-        assertTrue(invalidParams.size() == 1);
-        assertTrue(invalidParams.contains("segmentCountPerNode"));
-    }
-
-    @Test
-    public void testApplyRepairPatchParamsValidParams() {
-        DateTime nextActivation = DateTime.now();
-        UUID uuid = UUID.randomUUID();
-        RepairSchedule repairSchedule = RepairSchedule.builder(uuid)
-                .nextActivation(nextActivation)
-                .owner("test")
-                .repairParallelism(RepairParallelism.PARALLEL)
-                .intensity(1.0D)
-                .daysBetween(1)
-                .segmentCountPerNode(2)
-                .build(uuid);
-
-        assertTrue(nextActivation.equals(repairSchedule.getNextActivation()));
-        assertTrue(uuid.equals(repairSchedule.getRepairUnitId()));
-        assertTrue(uuid.equals(repairSchedule.getId()));
-        assertEquals("test", repairSchedule.getOwner());
-        assertEquals(RepairParallelism.PARALLEL, repairSchedule.getRepairParallelism());
-        assertTrue(1.0D == repairSchedule.getIntensity());
-        assertEquals(1, repairSchedule.getDaysBetween());
-        assertEquals(2, repairSchedule.getSegmentCountPerNode());
-
-        RepairSchedule patchedRepairSchedule = RepairScheduleResource.applyRepairPatchParams(
-                repairSchedule,
-                "test2",
-                RepairParallelism.SEQUENTIAL.toString(),
-                0.0D,
-                2,
-                3
-        );
-
-        assertTrue(nextActivation.equals(patchedRepairSchedule.getNextActivation()));
-        assertTrue(uuid.equals(patchedRepairSchedule.getRepairUnitId()));
-        assertTrue(uuid.equals(patchedRepairSchedule.getId()));
-        assertEquals("test2", patchedRepairSchedule.getOwner());
-        assertEquals(RepairParallelism.SEQUENTIAL, patchedRepairSchedule.getRepairParallelism());
-        assertTrue(0.0D == patchedRepairSchedule.getIntensity());
-        assertEquals(2, patchedRepairSchedule.getDaysBetween());
-        assertEquals(3, patchedRepairSchedule.getSegmentCountPerNode());
-    }
+    assertTrue(nextActivation.equals(patchedRepairSchedule.getNextActivation()));
+    assertTrue(uuid.equals(patchedRepairSchedule.getRepairUnitId()));
+    assertTrue(uuid.equals(patchedRepairSchedule.getId()));
+    assertEquals("test2", patchedRepairSchedule.getOwner());
+    assertEquals(RepairParallelism.SEQUENTIAL, patchedRepairSchedule.getRepairParallelism());
+    assertTrue(0.0D == patchedRepairSchedule.getIntensity());
+    assertEquals(2, patchedRepairSchedule.getDaysBetween() != null
+        ? patchedRepairSchedule.getDaysBetween().intValue()
+        : -1);
+    assertEquals(3, patchedRepairSchedule.getSegmentCountPerNode() != null
+        ? patchedRepairSchedule.getSegmentCountPerNode().intValue()
+        : -1);
+  }
 }

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
@@ -64,7 +64,7 @@ public class RepairScheduleResourceTest {
     // Validate that we got back 400 - an invalid schedule-id should return a 400
     assertThat(response).isNotNull();
     assertThat(Response.Status.BAD_REQUEST.getStatusCode()).isEqualTo(response.getStatus());
-    assertThat(response.getEntity());
+    assertThat(response.getEntity()).isNotNull();
 
     ValidationErrorMessage errorMessage = (ValidationErrorMessage) response.getEntity();
     assertThat(errorMessage.getErrors()).isNotNull().isNotEmpty();
@@ -85,7 +85,7 @@ public class RepairScheduleResourceTest {
     // Validate that we got back 400 - an invalid editable-repair-schedule (body) should return a 400
     assertThat(response).isNotNull();
     assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-    assertThat(response.getEntity());
+    assertThat(response.getEntity()).isNotNull();
 
     ValidationErrorMessage errorMessage = (ValidationErrorMessage) response.getEntity();
     assertThat(errorMessage.getErrors()).isNotNull().isNotEmpty();

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021- DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.resources;
+
+import io.cassandrareaper.core.RepairSchedule;
+import org.apache.cassandra.repair.RepairParallelism;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RepairScheduleResourceTest {
+    @Test
+    public void testValidateRepairPatchParamsValidParams() {
+        String ownerValue = "test";
+        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
+        Double intensityValue = 1.0D;
+        Integer scheduleDaysBetweenValue = 2;
+        Integer segmentCountPerNodeValue = 5;
+        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.isEmpty());
+    }
+
+    @Test
+    public void testValidateRepairPatchParamsInvalidParams() {
+        String ownerValue = null;
+        String repairParallelismValue = null;
+        Double intensityValue = null;
+        Integer scheduleDaysBetweenValue = null;
+        Integer segmentCountPerNodeValue = null;
+        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 5);
+    }
+
+    @Test
+    public void testValidateRepairPatchParamsInvalidOwnerParam() {
+        String ownerValue = null;
+        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
+        Double intensityValue = 1.0D;
+        Integer scheduleDaysBetweenValue = 2;
+        Integer segmentCountPerNodeValue = 5;
+        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("owner"));
+
+        ownerValue = "";
+        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("owner"));
+    }
+
+    @Test
+    public void testValidateRepairPatchParamsInvalidRepairParallelismParam() {
+        String ownerValue = "test";
+        String repairParallelismValue = null;
+        Double intensityValue = 1.0D;
+        Integer scheduleDaysBetweenValue = 2;
+        Integer segmentCountPerNodeValue = 5;
+        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("repairParallelism"));
+
+        repairParallelismValue = "";
+        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("repairParallelism"));
+
+        repairParallelismValue = "INVALID";
+        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("repairParallelism"));
+    }
+
+    @Test
+    public void testValidateRepairPatchParamsInvalidIntensityParam() {
+        String ownerValue = "test";
+        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
+        Double intensityValue = null;
+        Integer scheduleDaysBetweenValue = 2;
+        Integer segmentCountPerNodeValue = 5;
+        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("intensity"));
+
+        intensityValue = 1.1D;
+        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("intensity"));
+    }
+
+    @Test
+    public void testValidateRepairPatchParamsInvalidScheduleDaysBetweenParam() {
+        String ownerValue = "test";
+        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
+        Double intensityValue = 1.0D;
+        Integer scheduleDaysBetweenValue = null;
+        Integer segmentCountPerNodeValue = 5;
+        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("scheduleDaysBetween"));
+
+        scheduleDaysBetweenValue = 0;
+        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("scheduleDaysBetween"));
+    }
+
+    @Test
+    public void testValidateRepairPatchParamsInvalidSegmentCountPerNodeParam() {
+        String ownerValue = "test";
+        String repairParallelismValue = RepairParallelism.PARALLEL.toString();
+        Double intensityValue = 1.0D;
+        Integer scheduleDaysBetweenValue = 2;
+        Integer segmentCountPerNodeValue = null;
+        List<String> invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("segmentCountPerNode"));
+
+        segmentCountPerNodeValue = 0;
+        invalidParams = RepairScheduleResource.validateRepairPatchParams(ownerValue, repairParallelismValue, intensityValue, scheduleDaysBetweenValue, segmentCountPerNodeValue);
+        assertTrue(invalidParams.size() == 1);
+        assertTrue(invalidParams.contains("segmentCountPerNode"));
+    }
+
+    @Test
+    public void testApplyRepairPatchParamsValidParams() {
+        DateTime nextActivation = DateTime.now();
+        UUID uuid = UUID.randomUUID();
+        RepairSchedule repairSchedule = RepairSchedule.builder(uuid)
+                .nextActivation(nextActivation)
+                .owner("test")
+                .repairParallelism(RepairParallelism.PARALLEL)
+                .intensity(1.0D)
+                .daysBetween(1)
+                .segmentCountPerNode(2)
+                .build(uuid);
+
+        assertTrue(nextActivation.equals(repairSchedule.getNextActivation()));
+        assertTrue(uuid.equals(repairSchedule.getRepairUnitId()));
+        assertTrue(uuid.equals(repairSchedule.getId()));
+        assertEquals("test", repairSchedule.getOwner());
+        assertEquals(RepairParallelism.PARALLEL, repairSchedule.getRepairParallelism());
+        assertTrue(1.0D == repairSchedule.getIntensity());
+        assertEquals(1, repairSchedule.getDaysBetween());
+        assertEquals(2, repairSchedule.getSegmentCountPerNode());
+
+        RepairSchedule patchedRepairSchedule = RepairScheduleResource.applyRepairPatchParams(
+                repairSchedule,
+                "test2",
+                RepairParallelism.SEQUENTIAL.toString(),
+                0.0D,
+                2,
+                3
+        );
+
+        assertTrue(nextActivation.equals(patchedRepairSchedule.getNextActivation()));
+        assertTrue(uuid.equals(patchedRepairSchedule.getRepairUnitId()));
+        assertTrue(uuid.equals(patchedRepairSchedule.getId()));
+        assertEquals("test2", patchedRepairSchedule.getOwner());
+        assertEquals(RepairParallelism.SEQUENTIAL, patchedRepairSchedule.getRepairParallelism());
+        assertTrue(0.0D == patchedRepairSchedule.getIntensity());
+        assertEquals(2, patchedRepairSchedule.getDaysBetween());
+        assertEquals(3, patchedRepairSchedule.getSegmentCountPerNode());
+    }
+}

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
@@ -17,7 +17,6 @@
 package io.cassandrareaper.resources;
 
 import io.cassandrareaper.AppContext;
-import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.EditableRepairSchedule;
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
@@ -50,7 +49,7 @@ public class RepairScheduleResourceTest {
   private static final URI REPAIR_SCHEDULE_URI = URI.create("http://reaper_host/repair_schedule/");
 
   @Test
-  public void testPatchRepairScheduleBadPathParam() throws ReaperException {
+  public void testPatchRepairScheduleBadPathParam() {
     final MockObjects mocks = initInMemoryMocks(REPAIR_SCHEDULE_URI);
 
     RepairScheduleResource repairScheduleResource = new RepairScheduleResource(mocks.context);
@@ -71,7 +70,7 @@ public class RepairScheduleResourceTest {
   }
 
   @Test
-  public void testPatchRepairScheduleEmptyBody() throws ReaperException {
+  public void testPatchRepairScheduleEmptyBody() {
     final MockObjects mocks = initInMemoryMocks(REPAIR_SCHEDULE_URI);
 
     RepairScheduleResource repairScheduleResource = new RepairScheduleResource(mocks.context);
@@ -92,18 +91,13 @@ public class RepairScheduleResourceTest {
   }
 
   @Test
-  public void testPatchRepairScheduleFailedUpdate() throws ReaperException {
+  public void testPatchRepairScheduleFailedUpdate() {
     final MockObjects mocks = initFailedUpdateStorageMocks(REPAIR_SCHEDULE_URI, UUID.randomUUID());
     final RepairSchedule mockRepairSchedule = mocks.getRepairSchedule();
 
     // Create a set of changes to patch
     RepairScheduleResource repairScheduleResource = new RepairScheduleResource(mocks.context);
-    EditableRepairSchedule editableRepairSchedule = new EditableRepairSchedule();
-    editableRepairSchedule.setIntensity(1.0D);
-    editableRepairSchedule.setOwner("owner-test-2");
-    editableRepairSchedule.setDaysBetween(10);
-    editableRepairSchedule.setSegmentCountPerNode(20);
-    editableRepairSchedule.setRepairParallelism(RepairParallelism.SEQUENTIAL);
+    EditableRepairSchedule editableRepairSchedule = buildBasicTestEditableRepairSchedule();
 
     // Apply the changes
     Response response = repairScheduleResource.patchRepairSchedule(
@@ -118,18 +112,33 @@ public class RepairScheduleResourceTest {
   }
 
   @Test
-  public void testPatchRepairSchedule() throws ReaperException {
+  public void testPatchRepairScheduleNotFoundSchedule() {
+    final MockObjects mocks = initFailedUpdateStorageMocks(REPAIR_SCHEDULE_URI, UUID.randomUUID());
+
+    // Create a set of changes to patch
+    RepairScheduleResource repairScheduleResource = new RepairScheduleResource(mocks.context);
+    EditableRepairSchedule editableRepairSchedule = buildBasicTestEditableRepairSchedule();
+
+    // Apply the changes - with a random UUID that won't be found
+    Response response = repairScheduleResource.patchRepairSchedule(
+        mocks.uriInfo,
+        UUID.randomUUID(),
+        editableRepairSchedule
+    );
+
+    // Validate that we got back a 500 when the update was valid but fails
+    assertThat(response).isNotNull();
+    assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+  }
+
+  @Test
+  public void testPatchRepairSchedule() {
     final MockObjects mocks = initInMemoryMocks(REPAIR_SCHEDULE_URI);
     final RepairSchedule mockRepairSchedule = mocks.getRepairSchedule();
 
     // Create a set of changes to patch
     RepairScheduleResource repairScheduleResource = new RepairScheduleResource(mocks.context);
-    EditableRepairSchedule editableRepairSchedule = new EditableRepairSchedule();
-    editableRepairSchedule.setIntensity(1.0D);
-    editableRepairSchedule.setOwner("owner-test-2");
-    editableRepairSchedule.setDaysBetween(10);
-    editableRepairSchedule.setSegmentCountPerNode(20);
-    editableRepairSchedule.setRepairParallelism(RepairParallelism.SEQUENTIAL);
+    EditableRepairSchedule editableRepairSchedule = buildBasicTestEditableRepairSchedule();
 
     // Apply the changes
     Response response = repairScheduleResource.patchRepairSchedule(
@@ -304,6 +313,16 @@ public class RepairScheduleResourceTest {
     mockObjects.setRepairSchedule(repairSchedule);
 
     return mockObjects;
+  }
+
+  private static EditableRepairSchedule buildBasicTestEditableRepairSchedule() {
+    EditableRepairSchedule editableRepairSchedule = new EditableRepairSchedule();
+    editableRepairSchedule.setIntensity(1.0D);
+    editableRepairSchedule.setOwner("owner-test-2");
+    editableRepairSchedule.setDaysBetween(10);
+    editableRepairSchedule.setSegmentCountPerNode(20);
+    editableRepairSchedule.setRepairParallelism(RepairParallelism.SEQUENTIAL);
+    return editableRepairSchedule;
   }
 
   @Data

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
@@ -209,27 +209,35 @@ public class RepairScheduleResourceTest {
   }
 
   @Test
-  public void testApplyRepairPatch() {
-    DateTime nextActivation = DateTime.now();
-    UUID id = UUID.randomUUID();
-    UUID unitId = UUID.randomUUID();
-    RepairSchedule repairSchedule = RepairSchedule.builder(unitId)
-        .nextActivation(nextActivation)
-        .owner("test")
-        .repairParallelism(RepairParallelism.PARALLEL)
-        .intensity(1.0D)
-        .daysBetween(1)
-        .segmentCountPerNode(2)
-        .build(id);
+  public void testApplyRepairPatchParamsEmpty() {
+    RepairSchedule repairSchedule = buildBasicTestRepairSchedule();
 
-    assertThat(repairSchedule.getNextActivation()).isNotNull().isEqualTo(nextActivation);
-    assertThat(repairSchedule.getRepairUnitId()).isNotNull().isEqualTo(unitId);
-    assertThat(repairSchedule.getId()).isNotNull().isEqualTo(id);
-    assertThat(repairSchedule.getOwner()).isNotNull().isEqualTo("test");
-    assertThat(repairSchedule.getRepairParallelism()).isNotNull().isEqualTo(RepairParallelism.PARALLEL);
-    assertThat(repairSchedule.getIntensity()).isNotNull().isEqualTo(1.0D);
-    assertThat(repairSchedule.getDaysBetween()).isNotNull().isEqualTo(1);
-    assertThat(repairSchedule.getSegmentCountPerNode()).isNotNull().isEqualTo(2);
+    RepairSchedule patchedRepairSchedule = RepairScheduleResource.applyRepairPatchParams(
+        repairSchedule,
+        null,
+        null,
+        null,
+        null,
+        null
+    );
+
+    assertThat(patchedRepairSchedule.getNextActivation()).isNotNull().isEqualTo(repairSchedule.getNextActivation());
+    assertThat(patchedRepairSchedule.getRepairUnitId()).isNotNull().isEqualTo(repairSchedule.getRepairUnitId());
+    assertThat(patchedRepairSchedule.getId()).isNotNull().isEqualTo(repairSchedule.getId());
+    assertThat(patchedRepairSchedule.getOwner()).isNotNull().isEqualTo(repairSchedule.getOwner());
+    assertThat(patchedRepairSchedule.getRepairParallelism())
+        .isNotNull()
+        .isEqualTo(repairSchedule.getRepairParallelism());
+    assertThat(patchedRepairSchedule.getIntensity()).isNotNull().isEqualTo(repairSchedule.getIntensity());
+    assertThat(patchedRepairSchedule.getDaysBetween()).isNotNull().isEqualTo(repairSchedule.getDaysBetween());
+    assertThat(patchedRepairSchedule.getSegmentCountPerNode())
+        .isNotNull()
+        .isEqualTo(repairSchedule.getSegmentCountPerNode());
+  }
+
+  @Test
+  public void testApplyRepairPatchParams() {
+    RepairSchedule repairSchedule = buildBasicTestRepairSchedule();
 
     RepairSchedule patchedRepairSchedule = RepairScheduleResource.applyRepairPatchParams(
         repairSchedule,
@@ -240,9 +248,9 @@ public class RepairScheduleResourceTest {
         3
     );
 
-    assertThat(patchedRepairSchedule.getNextActivation()).isNotNull().isEqualTo(nextActivation);
-    assertThat(patchedRepairSchedule.getRepairUnitId()).isNotNull().isEqualTo(unitId);
-    assertThat(patchedRepairSchedule.getId()).isNotNull().isEqualTo(id);
+    assertThat(patchedRepairSchedule.getNextActivation()).isNotNull().isEqualTo(repairSchedule.getNextActivation());
+    assertThat(patchedRepairSchedule.getRepairUnitId()).isNotNull().isEqualTo(repairSchedule.getRepairUnitId());
+    assertThat(patchedRepairSchedule.getId()).isNotNull().isEqualTo(repairSchedule.getId());
     assertThat(patchedRepairSchedule.getOwner()).isNotNull().isEqualTo("test2");
     assertThat(patchedRepairSchedule.getRepairParallelism()).isNotNull().isEqualTo(RepairParallelism.SEQUENTIAL);
     assertThat(patchedRepairSchedule.getIntensity()).isNotNull().isEqualTo(0.0D);
@@ -313,6 +321,21 @@ public class RepairScheduleResourceTest {
     mockObjects.setRepairSchedule(repairSchedule);
 
     return mockObjects;
+  }
+
+  private static RepairSchedule buildBasicTestRepairSchedule() {
+    DateTime nextActivation = DateTime.now();
+    UUID id = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    RepairSchedule repairSchedule = RepairSchedule.builder(unitId)
+        .nextActivation(nextActivation)
+        .owner("test")
+        .repairParallelism(RepairParallelism.PARALLEL)
+        .intensity(1.0D)
+        .daysBetween(1)
+        .segmentCountPerNode(2)
+        .build(id);
+    return repairSchedule;
   }
 
   private static EditableRepairSchedule buildBasicTestEditableRepairSchedule() {

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
@@ -33,9 +33,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import io.dropwizard.jersey.validation.ValidationErrorMessage;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
 import org.junit.Test;
@@ -348,18 +345,54 @@ public class RepairScheduleResourceTest {
     return editableRepairSchedule;
   }
 
-  @Data
-  @AllArgsConstructor
-  @NoArgsConstructor
   private static final class MockObjects {
     private AppContext context;
     private UriInfo uriInfo;
     private RepairSchedule repairSchedule;
     private RepairUnit repairUnit;
 
+    MockObjects() {
+      context = null;
+      uriInfo = null;
+      repairSchedule = null;
+      repairUnit = null;
+    }
+
     MockObjects(AppContext context, UriInfo uriInfo) {
       this.context = context;
       this.uriInfo = uriInfo;
+    }
+
+    public AppContext getContext() {
+      return context;
+    }
+
+    public void setContext(AppContext context) {
+      this.context = context;
+    }
+
+    public UriInfo getUriInfo() {
+      return uriInfo;
+    }
+
+    public void setUriInfo(UriInfo uriInfo) {
+      this.uriInfo = uriInfo;
+    }
+
+    public RepairSchedule getRepairSchedule() {
+      return repairSchedule;
+    }
+
+    public void setRepairSchedule(RepairSchedule repairSchedule) {
+      this.repairSchedule = repairSchedule;
+    }
+
+    public RepairUnit getRepairUnit() {
+      return repairUnit;
+    }
+
+    public void setRepairUnit(RepairUnit repairUnit) {
+      this.repairUnit = repairUnit;
     }
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/validators/EditableRepairScheduleValidatorTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/validators/EditableRepairScheduleValidatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.validators;
+
+import io.cassandrareaper.core.EditableRepairSchedule;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import org.apache.cassandra.repair.RepairParallelism;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class EditableRepairScheduleValidatorTest {
+  private static Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  public void testEditableRepairScheduleWithAllNulls() {
+    EditableRepairSchedule editableRepairSchedule = new EditableRepairSchedule();
+
+    Set<ConstraintViolation<EditableRepairSchedule>> violations = validator.validate(editableRepairSchedule);
+    assertNotNull(violations);
+    // We should expect a violation because none of the fields are present
+    assertFalse(violations.isEmpty());
+  }
+
+  @Test
+  public void testEditableRepairScheduleWithOneValid() {
+    EditableRepairSchedule editableRepairSchedule = new EditableRepairSchedule();
+    editableRepairSchedule.setRepairParallelism(RepairParallelism.SEQUENTIAL);
+
+    Set<ConstraintViolation<EditableRepairSchedule>> violations = validator.validate(editableRepairSchedule);
+    assertNotNull(violations);
+    // We should not expect a violation because at least one of the fields was valid
+    assertTrue(violations.isEmpty());
+  }
+
+  @Test
+  public void testEditableRepairScheduleWithInvalidOwner() {
+    EditableRepairSchedule editableRepairSchedule = new EditableRepairSchedule();
+    editableRepairSchedule.setOwner("");
+
+    Set<ConstraintViolation<EditableRepairSchedule>> violations = validator.validate(editableRepairSchedule);
+    assertNotNull(violations);
+    // We should expect a violation
+    assertFalse(violations.isEmpty());
+    // We should expect a violation of the "owner" field because when it's provided, it can't be empty
+    // This is indirectly testing the NullOrNotBlankValidator as well as the higher-level logic
+    ConstraintViolation ownerViolation = violations.stream()
+        .filter(violation ->
+            violation.getPropertyPath() != null && violation.getPropertyPath().toString().equals("owner"))
+        .findAny()
+        .orElse(null);
+    assertNotNull(ownerViolation);
+  }
+}

--- a/src/server/src/test/java/io/cassandrareaper/validators/NullOrNotBlankValidatorTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/validators/NullOrNotBlankValidatorTest.java
@@ -22,8 +22,6 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -56,10 +54,12 @@ public class NullOrNotBlankValidatorTest {
     assertFalse(violations.isEmpty());
   }
 
-  @Data
-  @AllArgsConstructor
   private static class NullOrNotBlankTest {
     @NullOrNotBlank
     private String test;
+
+    NullOrNotBlankTest(String test) {
+      this.test = test;
+    }
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/validators/NullOrNotBlankValidatorTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/validators/NullOrNotBlankValidatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021-2021 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.validators;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class NullOrNotBlankValidatorTest {
+  @Test
+  public void testNullFieldValidation() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+
+    NullOrNotBlankTest nullOrNotBlankTest = new NullOrNotBlankTest(null);
+
+    Set<ConstraintViolation<NullOrNotBlankTest>> violations = validator.validate(nullOrNotBlankTest);
+    assertNotNull(violations);
+    assertTrue(violations.isEmpty());
+  }
+
+
+  @Test
+  public void testEmptyFieldValidation() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+
+    NullOrNotBlankTest nullOrNotBlankTest = new NullOrNotBlankTest("");
+
+    Set<ConstraintViolation<NullOrNotBlankTest>> violations = validator.validate(nullOrNotBlankTest);
+    assertNotNull(violations);
+    assertFalse(violations.isEmpty());
+  }
+
+  @Data
+  @AllArgsConstructor
+  private static class NullOrNotBlankTest {
+    @NullOrNotBlank
+    private String test;
+  }
+}

--- a/src/ui/app/jsx/repair-schedule-form.jsx
+++ b/src/ui/app/jsx/repair-schedule-form.jsx
@@ -44,7 +44,7 @@ const RepairScheduleForm = CreateReactClass({
       parallelism: this.props.repair ? this.props.repair.repair_parallelism : 'PARALLEL',
       intensity: this.props.repair ? this.props.repair.intensity : '',
       incrementalRepair: this.props.repair ? this.props.repair.incremental_repair : 'false',
-      repairThreadCount: this.props.repair ? this.props.repair.repair_thread_count : 1,
+      repairThreadCount: this.props.repair ? this.props.repair.repair_thread_count : 0,
       formType: this.props.formType,
       advancedSettingsOpen: false,
       valid: undefined  // Indicates if the current state of the form is valid or not
@@ -110,7 +110,7 @@ const RepairScheduleForm = CreateReactClass({
     const segmentsPerNodeInvalid = !state.segments ||
       state.segments == undefined ||
       state.segments == null ||
-      state.segments < 1 ||
+      state.segments < 0 ||
       state.segments > 1000;
     const parallelismInvalid = !state.parallelism || !state.parallelism.length;
 
@@ -220,7 +220,7 @@ const RepairScheduleForm = CreateReactClass({
                   {/* Segments Per Node */}
                   <div className="form-group">
                     <label htmlFor="in_segments" className="control-label">Segments per node</label>
-                    <input type="number" min={1} max={1000} className="form-control" defaultValue={this.state.segments} id="in_segments" placeholder="Number of segments per node to create for the repair run" onChange={this._formInputChangeHandler}/>
+                    <input type="number" min={0} max={1000} className="form-control" defaultValue={this.state.segments} id="in_segments" placeholder="Number of segments per node to create for the repair run" onChange={this._formInputChangeHandler}/>
                   </div>
 
                   {/* Parallelism */}

--- a/src/ui/app/jsx/repair-schedule-form.jsx
+++ b/src/ui/app/jsx/repair-schedule-form.jsx
@@ -107,14 +107,17 @@ const RepairScheduleForm = CreateReactClass({
           state.intervalDays
         )
       );
-    const segmentsPerNodeInvalid = !state.segments ||
-      state.segments == undefined ||
+    const segmentsPerNodeInvalid = state.segments == undefined ||
       state.segments == null ||
       state.segments < 0 ||
       state.segments > 1000;
+    const intensityInvalid = state.intensity == undefined ||
+      state.intensity == null ||
+      state.intensity < 0.0 ||
+      state.intensity > 1.0;
     const parallelismInvalid = !state.parallelism || !state.parallelism.length;
 
-    const invalid = idInvalid || ownerInvalid || scheduleTimeInvalid || segmentsPerNodeInvalid || parallelismInvalid;
+    const invalid = idInvalid || ownerInvalid || scheduleTimeInvalid || segmentsPerNodeInvalid || intensityInvalid || parallelismInvalid;
     return !invalid;
   },
 

--- a/src/ui/app/jsx/repair-schedule-form.jsx
+++ b/src/ui/app/jsx/repair-schedule-form.jsx
@@ -1,0 +1,238 @@
+import CreateReactClass from "create-react-class";
+import React from "react";
+import PropTypes from "prop-types";
+import moment from "moment";
+import {Collapse} from "react-bootstrap";
+import Select from "react-select";
+
+const RepairScheduleForm = CreateReactClass({
+  propTypes: {
+    repair: PropTypes.object,
+    formType: PropTypes.string.isRequired,
+    onChange: PropTypes.func  // Called fired when a valid change is detected within the form
+  },
+
+  getInitialState: function() {
+    return {
+      cluster: this.props.repair ? this.props.repair.cluster_name : '',
+      keyspace: this.props.repair ? this.props.repair.keyspace_name : '',
+      owner: this.props.repair ? this.props.repair.owner : '',
+      startTime: this.props.repair ? this.props.repair.next_activation : (this.props.formType === 'schedule' ? moment().toDate() : null),
+      intervalDays: this.props.repair ? this.props.repair.scheduled_days_between : '',
+      tables: this.props.repair ? this.props.repair.column_families : [],
+      tablesBlacklisted: this.props.repair ? this.props.repair.blacklisted_tables : [],
+      nodes: this.props.repair ? this.props.repair.nodes : [],
+      datacenters: this.props.repair ? this.props.repair.datacenters : [],
+      segments: this.props.repair ? this.props.repair.segment_count_per_node : '',
+      parallelism: this.props.repair ? this.props.repair.repair_parallelism : 'PARALLEL',
+      intensity: this.props.repair ? this.props.repair.intensity : '',
+      incrementalRepair: this.props.repair ? this.props.repair.incremental_repair : 'false',
+      repairThreadCount: this.props.repair ? this.props.repair.repair_thread_count : 1,
+      formType: this.props.formType,
+      advancedSettingsOpen: false,
+      valid: undefined  // Indicates if the current state of the form is valid or not
+    }
+  },
+
+  formSelectChangeHandler: function(valueContext, actionContext) {
+    const field = actionContext.name.split("_")[1];
+    const value = valueContext.value;
+    this.setStateFormChange(field, value);
+  },
+  
+  formInputChangeHandler: function(e) {
+    const field = e.target.id.split("_")[1];
+    const value = e.target.value;
+    this.setStateFormChange(field, value);
+  },
+
+  setStateFormChange: function(field, value) {
+    if (!field || !field.length) {
+      return;
+    }
+
+    const changeEvent = {
+      field: field,
+      value: value ? value.toString() : undefined,
+      origValue: this.state && field && this.state[field] ? this.state[field].toString() : undefined
+    }
+
+    const state = this.state;
+    if (field) {
+      state[field] = value;
+    }
+    state.valid = this.validate(state);
+    this.setState(state);
+
+    changeEvent.state = state;
+    if (this.props.onChange) {
+      this.props.onChange(changeEvent);
+    }
+  },
+
+  validate: function(state) {
+    if (!state) {
+      return false;
+    }
+
+    const clusterInvalid = !state.cluster || !state.cluster.length;
+    const keyspaceInvalid = !state.keyspace || !state.keyspace.length;
+    const ownerInvalid = !state.owner || !state.owner.length;
+    const scheduleTimeInvalid = (state.formType === "schedule" && (!state.startTime || !state.intervalDays)) || (state.formType === "repair" && (state.startTime || state.intervalDays));
+    // TODO What should the rules here be for the the combination of Datacenters and Nodes
+    const datacentersSet = state.datacenters && state.datacenters.length ? true : false;
+    const nodesSet = state.nodes && state.nodes.length ? true : false;
+    const datacentersNodesInvalid = datacentersSet && nodesSet;
+
+    const invalid = clusterInvalid || keyspaceInvalid || ownerInvalid || scheduleTimeInvalid || datacentersNodesInvalid;
+    return !invalid;
+  },
+
+  toggleAdvancedSettings: function() {
+    this.setState({advancedSettingsOpen: !this.state.advancedSettingsOpen});
+  },
+
+  render: function() {
+    this.setStateFormChange();
+
+    const ownerPlaceholder = `owner name for the ${this.state.formType} run (any string)`;
+
+    const trueFalseOptions = [
+      {label: "True", value: "true"},
+      {label: "False", value: "false"}
+    ];
+    const incrementalRepairValue = trueFalseOptions.filter(value => value.value === this.state.incrementalRepair.toString())[0];
+
+    const parallelismOptions = [
+      {label: "Sequential", value: "SEQUENTIAL"},
+      {label: "Parallel", value: "PARALLEL"},
+      {label: "DC-Aware", value: "DATACENTER_AWARE"},
+    ];
+    const parallelismValue = parallelismOptions.filter(value => value.value === this.state.parallelism)[0];
+
+    return (
+      <form>
+        {/* Cluster */}
+        <div className="form-group">
+          <label htmlFor="in_clusterName" className="control-label">Cluster*</label>
+          <input type="text" required className="form-control" defaultValue={this.state.cluster} id="in_clusterName" disabled/>
+        </div>
+
+        {/* Keyspace */}
+        <div className="form-group">
+          <label htmlFor="in_keyspace" className="control-label">Keyspace*</label>
+          <input type="text" required className="form-control" defaultValue={this.state.keyspace} id="in_keyspace" disabled/>
+        </div>
+
+        {/* Owner */}
+        <div className="form-group">
+          <label htmlFor="in_owner" className="control-label">Owner*</label>
+          <input type="text" required className="form-control" defaultValue={this.state.owner} id="in_owner" placeholder={ownerPlaceholder} onChange={this.formInputChangeHandler}/>
+        </div>
+
+        {/* Start Time */}
+        <div className="form-group">
+          <label htmlFor="in_startTime" className="control-label">Start time*</label>
+          <input type="text" required className="form-control" defaultValue={this.state.startTime} id="in_startTime" disabled/>
+        </div>
+
+        {/* Interval */}
+        <div className="form-group">
+          <label htmlFor="in_intervalDays" className="control-label">Interval in days*</label>
+          <input type="number" min={1} required className="form-control" defaultValue={this.state.intervalDays} id="in_intervalDays" placeholder="The number of days to wait between scheduling new repairs, (e.g. 7 for weekly)" onChange={this.formInputChangeHandler}/>
+        </div>
+
+        <div className="form-group">
+          <div className="panel panel-info">
+            <div className="panel-heading">
+              <div className="panel-title">
+                <a onClick={this.toggleAdvancedSettings}>
+                  <span style={{paddingRight: '.5em'}}>Advanced settings</span>
+                  <span className="glyphicon glyphicon-menu-down" aria-hidden="true" style={ this.state.advancedSettingsOpen ? { display: 'none'} : {}}></span>
+                  <span className="glyphicon glyphicon-menu-up" aria-hidden="true" style={ !this.state.advancedSettingsOpen ? { display: 'none'} : {}}></span>
+                </a>
+              </div>
+            </div>
+            <div className="panel-body" style={ !this.state.advancedSettingsOpen ? {padding: '0'} : {}}>
+              <Collapse in={this.state.advancedSettingsOpen}>
+                <div id="collapse-advanced-settings">
+
+                  {/* Tables */}
+                  <div className="form-group">
+                    <label htmlFor="in_tables" className="control-label">Tables</label>
+                    <input type="text" className="form-control" defaultValue={this.state.tables ? this.state.tables.join(', ') : ''} id="in_tables" disabled/>
+                  </div>
+
+                  {/* Blacklist */}
+                  <div className="form-group">
+                    <label htmlFor="in_blacklistedTables" className="control-label">Blacklist</label>
+                    <input type="text" className="form-control" defaultValue={this.state.blacklistedTables ? this.state.blacklistedTables.join(', ') : ''} id="in_blacklistedTables" disabled/>
+                  </div>
+
+                  {/* Nodes */}
+                  <div className="form-group">
+                    <label htmlFor="in_nodes" className="control-label">Nodes</label>
+                    <input type="text" className="form-control" defaultValue={this.state.nodes ? this.state.nodes.join(', ') : ''} id="in_nodes" disabled/>
+                  </div>
+
+                  {/* Datacenters */}
+                  <div className="form-group">
+                    <label htmlFor="in_datacenters" className="control-label">Datacenters</label>
+                    <input type="text" className="form-control" defaultValue={this.state.datacenters ? this.state.datacenters.join(', ') : ''} id="in_datacenters" disabled/>
+                  </div>
+
+                  {/* Segments Per Node */}
+                  <div className="form-group">
+                    <label htmlFor="in_segments" className="control-label">Segments per node</label>
+                    <input type="number" min="0" className="form-control" defaultValue={this.state.segments} id="in_segments" placeholder="Number of segments per node to create for the repair run" onChange={this.formInputChangeHandler}/>
+                  </div>
+
+                  {/* Parallelism */}
+                  <div className="form-group">
+                    <label htmlFor="in_parallelism" className="control-label">Parallelism</label>
+                    <Select
+                      id="in_parallelism"
+                      name="in_parallelism"
+                      classNamePrefix="select"
+                      options={parallelismOptions}
+                      value={parallelismValue}
+                      onChange={this.formSelectChangeHandler}
+                    />
+                  </div>
+
+                  {/* Intensity */}
+                  <div className="form-group">
+                    <label htmlFor="in_intensity" className="control-label">Repair Intensity</label>
+                    <input type="number" min="0" max="1" className="form-control" defaultValue={this.state.intensity} id="in_intensity" onChange={this.formInputChangeHandler}/>
+                  </div>
+
+                  {/* Incremental */}
+                  <div className="form-group">
+                    <label htmlFor="in_incrementalRepair" className="control-label">Incremental</label>
+                      <Select
+                        id="in_incrementalRepair"
+                        name="in_incrementalRepair"
+                        classNamePrefix="select"
+                        value={incrementalRepairValue}
+                        options={trueFalseOptions}
+                        isDisabled={true}
+                      />
+                  </div>
+
+                  {/* Repair Threads */}
+                  <div className="form-group">
+                    <label htmlFor="in_repairThreadCount" className="control-label">Repair Threads</label>
+                    <input type="number" min="1" className="form-control" defaultValue={this.state.repairThreadCount} id="in_repairThreadCount" disabled/>
+                  </div>
+
+                </div>
+              </Collapse>
+            </div>
+          </div>
+        </div>
+      </form>
+    )
+  }
+});
+
+export default RepairScheduleForm;

--- a/src/ui/app/jsx/repair-schedule-form.jsx
+++ b/src/ui/app/jsx/repair-schedule-form.jsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021- DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import CreateReactClass from "create-react-class";
 import React from "react";
 import PropTypes from "prop-types";

--- a/src/ui/app/jsx/repair-schedule-form.jsx
+++ b/src/ui/app/jsx/repair-schedule-form.jsx
@@ -88,16 +88,33 @@ const RepairScheduleForm = CreateReactClass({
   },
 
   _validate: function(state) {
-    debugger;
     if (!state) {
       return false;
     }
 
     const idInvalid = !state.id || !state.id.length;
     const ownerInvalid = !state.owner || !state.owner.length;
-    const scheduleTimeInvalid = (state.formType === "schedule" && (!state.startTime || !state.intervalDays)) || (state.formType === "repair" && (state.startTime || state.intervalDays));
+    const scheduleTimeInvalid = (state.formType === "schedule" &&
+        (!state.startTime ||
+          state.intervalDays == undefined ||
+          state.intervalDays == null ||
+          state.intervalDays < 0 ||
+          state.intervalDays > 31
+        )
+      ) ||
+      (state.formType === "repair" &&
+        (state.startTime ||
+          state.intervalDays
+        )
+      );
+    const segmentsPerNodeInvalid = !state.segments ||
+      state.segments == undefined ||
+      state.segments == null ||
+      state.segments < 1 ||
+      state.segments > 1000;
+    const parallelismInvalid = !state.parallelism || !state.parallelism.length;
 
-    const invalid = idInvalid || ownerInvalid || scheduleTimeInvalid;
+    const invalid = idInvalid || ownerInvalid || scheduleTimeInvalid || segmentsPerNodeInvalid || parallelismInvalid;
     return !invalid;
   },
 
@@ -158,7 +175,7 @@ const RepairScheduleForm = CreateReactClass({
         {/* Interval */}
         <div className="form-group">
           <label htmlFor="in_intervalDays" className="control-label">Interval in days*</label>
-          <input type="number" min={1} max={3650} required className="form-control" defaultValue={this.state.intervalDays} id="in_intervalDays" placeholder="The number of days to wait between scheduling new repairs, (e.g. 7 for weekly)" onChange={this._formInputChangeHandler}/>
+          <input type="number" min={0} max={31} required className="form-control" defaultValue={this.state.intervalDays} id="in_intervalDays" placeholder="The number of days to wait between scheduling new repairs, (e.g. 7 for weekly)" onChange={this._formInputChangeHandler}/>
         </div>
 
         <div className="form-group">
@@ -203,7 +220,7 @@ const RepairScheduleForm = CreateReactClass({
                   {/* Segments Per Node */}
                   <div className="form-group">
                     <label htmlFor="in_segments" className="control-label">Segments per node</label>
-                    <input type="number" min="0" className="form-control" defaultValue={this.state.segments} id="in_segments" placeholder="Number of segments per node to create for the repair run" onChange={this._formInputChangeHandler}/>
+                    <input type="number" min={1} max={1000} className="form-control" defaultValue={this.state.segments} id="in_segments" placeholder="Number of segments per node to create for the repair run" onChange={this._formInputChangeHandler}/>
                   </div>
 
                   {/* Parallelism */}

--- a/src/ui/app/jsx/repair-schedule-form.jsx
+++ b/src/ui/app/jsx/repair-schedule-form.jsx
@@ -30,6 +30,7 @@ const RepairScheduleForm = CreateReactClass({
 
   getInitialState: function() {
     return {
+      id: this.props.repair ? this.props.repair.id : '',
       cluster: this.props.repair ? this.props.repair.cluster_name : '',
       keyspace: this.props.repair ? this.props.repair.keyspace_name : '',
       owner: this.props.repair ? this.props.repair.owner : '',
@@ -50,19 +51,19 @@ const RepairScheduleForm = CreateReactClass({
     }
   },
 
-  formSelectChangeHandler: function(valueContext, actionContext) {
+  _formSelectChangeHandler: function(valueContext, actionContext) {
     const field = actionContext.name.split("_")[1];
     const value = valueContext.value;
-    this.setStateFormChange(field, value);
+    this._setStateFormChange(field, value);
   },
   
-  formInputChangeHandler: function(e) {
+  _formInputChangeHandler: function(e) {
     const field = e.target.id.split("_")[1];
     const value = e.target.value;
-    this.setStateFormChange(field, value);
+    this._setStateFormChange(field, value);
   },
 
-  setStateFormChange: function(field, value) {
+  _setStateFormChange: function(field, value) {
     if (!field || !field.length) {
       return;
     }
@@ -77,7 +78,7 @@ const RepairScheduleForm = CreateReactClass({
     if (field) {
       state[field] = value;
     }
-    state.valid = this.validate(state);
+    state.valid = this._validate(state);
     this.setState(state);
 
     changeEvent.state = state;
@@ -86,7 +87,7 @@ const RepairScheduleForm = CreateReactClass({
     }
   },
 
-  validate: function(state) {
+  _validate: function(state) {
     if (!state) {
       return false;
     }
@@ -104,12 +105,12 @@ const RepairScheduleForm = CreateReactClass({
     return !invalid;
   },
 
-  toggleAdvancedSettings: function() {
+  _toggleAdvancedSettings: function() {
     this.setState({advancedSettingsOpen: !this.state.advancedSettingsOpen});
   },
 
   render: function() {
-    this.setStateFormChange();
+    this._setStateFormChange();
 
     const ownerPlaceholder = `owner name for the ${this.state.formType} run (any string)`;
 
@@ -128,41 +129,47 @@ const RepairScheduleForm = CreateReactClass({
 
     return (
       <form>
+        {/* Id */}
+        <div className="form-group">
+          <label htmlFor="in_id" className="control-label">ID</label>
+          <input type="text" required className="form-control" defaultValue={this.state.id} id="in_id" readOnly/>
+        </div>
+
         {/* Cluster */}
         <div className="form-group">
           <label htmlFor="in_clusterName" className="control-label">Cluster*</label>
-          <input type="text" required className="form-control" defaultValue={this.state.cluster} id="in_clusterName" disabled/>
+          <input type="text" required className="form-control" defaultValue={this.state.cluster} id="in_clusterName" readOnly/>
         </div>
 
         {/* Keyspace */}
         <div className="form-group">
           <label htmlFor="in_keyspace" className="control-label">Keyspace*</label>
-          <input type="text" required className="form-control" defaultValue={this.state.keyspace} id="in_keyspace" disabled/>
+          <input type="text" required className="form-control" defaultValue={this.state.keyspace} id="in_keyspace" readOnly/>
         </div>
 
         {/* Owner */}
         <div className="form-group">
           <label htmlFor="in_owner" className="control-label">Owner*</label>
-          <input type="text" required className="form-control" defaultValue={this.state.owner} id="in_owner" placeholder={ownerPlaceholder} onChange={this.formInputChangeHandler}/>
+          <input type="text" required className="form-control" defaultValue={this.state.owner} id="in_owner" placeholder={ownerPlaceholder} onChange={this._formInputChangeHandler}/>
         </div>
 
         {/* Start Time */}
         <div className="form-group">
           <label htmlFor="in_startTime" className="control-label">Start time*</label>
-          <input type="text" required className="form-control" defaultValue={this.state.startTime} id="in_startTime" disabled/>
+          <input type="text" required className="form-control" defaultValue={this.state.startTime} id="in_startTime" readOnly/>
         </div>
 
         {/* Interval */}
         <div className="form-group">
           <label htmlFor="in_intervalDays" className="control-label">Interval in days*</label>
-          <input type="number" min={1} required className="form-control" defaultValue={this.state.intervalDays} id="in_intervalDays" placeholder="The number of days to wait between scheduling new repairs, (e.g. 7 for weekly)" onChange={this.formInputChangeHandler}/>
+          <input type="number" min={1} max={3650} required className="form-control" defaultValue={this.state.intervalDays} id="in_intervalDays" placeholder="The number of days to wait between scheduling new repairs, (e.g. 7 for weekly)" onChange={this._formInputChangeHandler}/>
         </div>
 
         <div className="form-group">
           <div className="panel panel-info">
             <div className="panel-heading">
               <div className="panel-title">
-                <a onClick={this.toggleAdvancedSettings}>
+                <a onClick={this._toggleAdvancedSettings}>
                   <span style={{paddingRight: '.5em'}}>Advanced settings</span>
                   <span className="glyphicon glyphicon-menu-down" aria-hidden="true" style={ this.state.advancedSettingsOpen ? { display: 'none'} : {}}></span>
                   <span className="glyphicon glyphicon-menu-up" aria-hidden="true" style={ !this.state.advancedSettingsOpen ? { display: 'none'} : {}}></span>
@@ -176,31 +183,31 @@ const RepairScheduleForm = CreateReactClass({
                   {/* Tables */}
                   <div className="form-group">
                     <label htmlFor="in_tables" className="control-label">Tables</label>
-                    <input type="text" className="form-control" defaultValue={this.state.tables ? this.state.tables.join(', ') : ''} id="in_tables" disabled/>
+                    <input type="text" className="form-control" defaultValue={this.state.tables ? this.state.tables.join(', ') : ''} id="in_tables" readOnly/>
                   </div>
 
                   {/* Blacklist */}
                   <div className="form-group">
                     <label htmlFor="in_blacklistedTables" className="control-label">Blacklist</label>
-                    <input type="text" className="form-control" defaultValue={this.state.blacklistedTables ? this.state.blacklistedTables.join(', ') : ''} id="in_blacklistedTables" disabled/>
+                    <input type="text" className="form-control" defaultValue={this.state.blacklistedTables ? this.state.blacklistedTables.join(', ') : ''} id="in_blacklistedTables" readOnly/>
                   </div>
 
                   {/* Nodes */}
                   <div className="form-group">
                     <label htmlFor="in_nodes" className="control-label">Nodes</label>
-                    <input type="text" className="form-control" defaultValue={this.state.nodes ? this.state.nodes.join(', ') : ''} id="in_nodes" disabled/>
+                    <input type="text" className="form-control" defaultValue={this.state.nodes ? this.state.nodes.join(', ') : ''} id="in_nodes" readOnly/>
                   </div>
 
                   {/* Datacenters */}
                   <div className="form-group">
                     <label htmlFor="in_datacenters" className="control-label">Datacenters</label>
-                    <input type="text" className="form-control" defaultValue={this.state.datacenters ? this.state.datacenters.join(', ') : ''} id="in_datacenters" disabled/>
+                    <input type="text" className="form-control" defaultValue={this.state.datacenters ? this.state.datacenters.join(', ') : ''} id="in_datacenters" readOnly/>
                   </div>
 
                   {/* Segments Per Node */}
                   <div className="form-group">
                     <label htmlFor="in_segments" className="control-label">Segments per node</label>
-                    <input type="number" min="0" className="form-control" defaultValue={this.state.segments} id="in_segments" placeholder="Number of segments per node to create for the repair run" onChange={this.formInputChangeHandler}/>
+                    <input type="number" min="0" className="form-control" defaultValue={this.state.segments} id="in_segments" placeholder="Number of segments per node to create for the repair run" onChange={this._formInputChangeHandler}/>
                   </div>
 
                   {/* Parallelism */}
@@ -212,14 +219,14 @@ const RepairScheduleForm = CreateReactClass({
                       classNamePrefix="select"
                       options={parallelismOptions}
                       value={parallelismValue}
-                      onChange={this.formSelectChangeHandler}
+                      onChange={this._formSelectChangeHandler}
                     />
                   </div>
 
                   {/* Intensity */}
                   <div className="form-group">
                     <label htmlFor="in_intensity" className="control-label">Repair Intensity</label>
-                    <input type="number" min="0" max="1" className="form-control" defaultValue={this.state.intensity} id="in_intensity" onChange={this.formInputChangeHandler}/>
+                    <input type="number" min="0" max="1" className="form-control" defaultValue={this.state.intensity} id="in_intensity" onChange={this._formInputChangeHandler}/>
                   </div>
 
                   {/* Incremental */}
@@ -238,7 +245,7 @@ const RepairScheduleForm = CreateReactClass({
                   {/* Repair Threads */}
                   <div className="form-group">
                     <label htmlFor="in_repairThreadCount" className="control-label">Repair Threads</label>
-                    <input type="number" min="1" className="form-control" defaultValue={this.state.repairThreadCount} id="in_repairThreadCount" disabled/>
+                    <input type="number" min="1" className="form-control" defaultValue={this.state.repairThreadCount} id="in_repairThreadCount" readOnly/>
                   </div>
 
                 </div>

--- a/src/ui/app/jsx/repair-schedule-form.jsx
+++ b/src/ui/app/jsx/repair-schedule-form.jsx
@@ -88,20 +88,16 @@ const RepairScheduleForm = CreateReactClass({
   },
 
   _validate: function(state) {
+    debugger;
     if (!state) {
       return false;
     }
 
-    const clusterInvalid = !state.cluster || !state.cluster.length;
-    const keyspaceInvalid = !state.keyspace || !state.keyspace.length;
+    const idInvalid = !state.id || !state.id.length;
     const ownerInvalid = !state.owner || !state.owner.length;
     const scheduleTimeInvalid = (state.formType === "schedule" && (!state.startTime || !state.intervalDays)) || (state.formType === "repair" && (state.startTime || state.intervalDays));
-    // TODO What should the rules here be for the the combination of Datacenters and Nodes
-    const datacentersSet = state.datacenters && state.datacenters.length ? true : false;
-    const nodesSet = state.nodes && state.nodes.length ? true : false;
-    const datacentersNodesInvalid = datacentersSet && nodesSet;
 
-    const invalid = clusterInvalid || keyspaceInvalid || ownerInvalid || scheduleTimeInvalid || datacentersNodesInvalid;
+    const invalid = idInvalid || ownerInvalid || scheduleTimeInvalid;
     return !invalid;
   },
 

--- a/src/ui/app/style.scss
+++ b/src/ui/app/style.scss
@@ -161,3 +161,9 @@ body {
 
 $font-size: 16px;
 $input-height: 2.5em; // at 16px, this an even 40px
+
+.edit-repair-schedule-modal-status-icon {
+	margin-right: 8px;
+	font-weight: 800;
+	font-size: 18px;
+}


### PR DESCRIPTION
Adds support within the UI for the editing of existing repair schedules.  Allows for the editing of a select set of fields as discussed in #1006 :

- days_between (which will force recomputing next_activation)
- intensity
- owner
- repair_parallelism
- segment_count_per_node

The editing is provided for via a new component that is decoupled from the schedules-list component so that it can potentially be re-used in other places:

![image](https://user-images.githubusercontent.com/7901615/131948937-3b0a5fe3-84cc-439f-9ed6-616738f62bbe.png)

The form itself includes all of the same fields that are present in the "Add Schedule" form, but most of them are presented in read-only fashion when used for editing (this is where the form component could later be enhanced to allow it to support edit and add workflows -- it doesn't do that now).

![image](https://user-images.githubusercontent.com/7901615/131949127-e3cf1983-9172-4a7f-9b8e-0bab0d6a5e18.png)

![image](https://user-images.githubusercontent.com/7901615/131949082-7d2e5c7b-865d-4b96-bf52-2043e93b85dc.png)

Edits are saved via a new API endpoint:  PATCH /repair_schedule/<id> that is provided here.

Fixes #1006 