### PR TITLE
Switch to ubuntu 20.04 and use nodejs 10.x for docker builder

### DIFF
--- a/src/packaging/docker-build/Dockerfile
+++ b/src/packaging/docker-build/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # use a common app path, copied from python-onbuild:latest
 ENV WORKDIR /usr/src/app
@@ -24,27 +24,21 @@ WORKDIR ${WORKDIR}
 RUN apt-get update \
     && apt-get install -y \
         curl \
-    && curl -sL https://deb.nodesource.com/setup_6.x -o nodesource_setup.sh \
+    && curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh \
     && bash nodesource_setup.sh \
-    && apt-get update \
-    && apt-get install -y \
+    && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
         build-essential \
         git \
+        openjdk-8-jdk \
         maven \
         nodejs \
-        openjdk-8-jdk \
         rpm \
         ruby-dev \
+    && apt-get remove --purge -y openjdk-11-jre-headless \
     && mvn --version \
     && gem install fpm \
     && npm install -g bower
 
-# cache maven dependencies, useful during Dockerfile testing
-COPY pom.xml /tmp/
-RUN mkdir -p /tmp/src
-COPY src/server /tmp/src/server
-COPY src/ui /tmp/src/ui
-WORKDIR /tmp
 WORKDIR ${WORKDIR}
 
 # Add entrypoint script


### PR DESCRIPTION
- Based on what is already done on CI: use of ubuntu 20.04 LTS and nodejs
  10.x (looks like the ui part does not build with more recent version of nodejs)
- Simplify a bit the Dockerfile by removing useless lines