### PR TITLE
repairProgress metrics are updated on subsequent runs.

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -157,9 +157,10 @@ final class RepairRunner implements Runnable {
   }
 
   private void registerMetric(String metricName, Gauge<?> gauge) {
-    if (!context.metricRegistry.getMetrics().containsKey(metricName)) {
-      context.metricRegistry.register(metricName, gauge);
+    if (context.metricRegistry.getMetrics().containsKey(metricName)) {
+      context.metricRegistry.remove(metricName);
     }
+    context.metricRegistry.register(metricName, gauge);
   }
 
   UUID getRepairRunId() {


### PR DESCRIPTION
- When subsequent runs are executed on the same cluster/keyspace,
 exposed metrics are not updated.
- Unregistering/registering the metric at the start of a run repair
  triggers the metrics update.
- This fixes #959 and #1071