### PR TITLE
Allow to force create repair runs with conflicting units

### DIFF
--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -50,7 +50,7 @@ case "${TEST_TYPE}" in
                 exit 1
                 ;;
             "local")
-                mvn -B package
+                mvn -B package -DskipTests
                 mvn -B org.jacoco:jacoco-maven-plugin:${JACOCO_VERSION}:prepare-agent surefire:test -DsurefireArgLine="-Xmx256m"  -Dtest=ReaperShiroIT -Dcucumber.options="$CUCUMBER_OPTIONS" org.jacoco:jacoco-maven-plugin:${JACOCO_VERSION}:report
                 mvn -B org.jacoco:jacoco-maven-plugin:${JACOCO_VERSION}:prepare-agent surefire:test -DsurefireArgLine="-Xmx256m"  -Dtest=ReaperIT -Dcucumber.options="$CUCUMBER_OPTIONS" org.jacoco:jacoco-maven-plugin:${JACOCO_VERSION}:report
                 ;;

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairScheduleResource.java
@@ -360,19 +360,28 @@ public final class RepairScheduleResource {
       }
     }
 
-    RepairUnit unit = repairUnitService.getOrCreateRepairUnit(cluster, unitBuilder, force);
+    Optional<RepairUnit> maybeUnit = repairUnitService.getOrCreateRepairUnit(cluster, unitBuilder, force);
 
-    Preconditions
-        .checkState(unit.getIncrementalRepair() == incremental, "%s!=%s", unit.getIncrementalRepair(), incremental);
-    Preconditions
-        .checkState((percentUnrepairedThreshold > 0 && incremental) || percentUnrepairedThreshold <= 0,
-          "Setting a % repaired threshold can only be done on incremental schedules");
+    if (maybeUnit.isPresent()) {
+      RepairUnit unit = maybeUnit.get();
+      Preconditions
+          .checkState(unit.getIncrementalRepair() == incremental, "%s!=%s", unit.getIncrementalRepair(), incremental);
+      Preconditions
+          .checkState((percentUnrepairedThreshold > 0 && incremental) || percentUnrepairedThreshold <= 0,
+            "Setting a % repaired threshold can only be done on incremental schedules");
 
-    RepairSchedule newRepairSchedule = repairScheduleService
-        .storeNewRepairSchedule(
-          cluster, unit, days, next, owner, segments, parallel, intensity, force, adaptive, percentUnrepairedThreshold);
+      RepairSchedule newRepairSchedule = repairScheduleService
+          .storeNewRepairSchedule(
+            cluster, unit, days, next, owner, segments,
+            parallel, intensity, force, adaptive, percentUnrepairedThreshold);
 
-    return Response.created(buildRepairScheduleUri(uriInfo, newRepairSchedule)).build();
+      return Response.created(buildRepairScheduleUri(uriInfo, newRepairSchedule)).build();
+    }
+
+    return Response
+            .status(Response.Status.NO_CONTENT)
+            .entity("Repair schedule couldn't be created as an existing repair unit seems to conflict with it.")
+            .build();
   }
 
   private int getDaysBetween(Optional<Integer> scheduleDaysBetween) {

--- a/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/ClusterRepairScheduler.java
@@ -128,7 +128,7 @@ public final class ClusterRepairScheduler {
 
     RepairSchedule repairSchedule = repairScheduleService.storeNewRepairSchedule(
             cluster,
-            repairUnitService.getOrCreateRepairUnit(cluster, builder),
+            repairUnitService.getOrCreateRepairUnit(cluster, builder).get(),
             context.config.getScheduleDaysBetween(),
             nextActivationTime,
             REPAIR_OWNER,

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairUnitService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairUnitService.java
@@ -59,11 +59,11 @@ public final class RepairUnitService {
     return new RepairUnitService(context);
   }
 
-  public RepairUnit getOrCreateRepairUnit(Cluster cluster, RepairUnit.Builder params) {
+  public Optional<RepairUnit> getOrCreateRepairUnit(Cluster cluster, RepairUnit.Builder params) {
     return getOrCreateRepairUnit(cluster, params, false);
   }
 
-  public RepairUnit getOrCreateRepairUnit(Cluster cluster, RepairUnit.Builder params, boolean force) {
+  public Optional<RepairUnit> getOrCreateRepairUnit(Cluster cluster, RepairUnit.Builder params, boolean force) {
     if (params.incrementalRepair) {
       try {
         String version = ClusterFacade.create(context).getCassandraVersion(cluster);
@@ -75,7 +75,17 @@ public final class RepairUnitService {
       }
     }
     Optional<RepairUnit> repairUnit = context.storage.getRepairUnit(params);
-    return repairUnit.isPresent() ? repairUnit.get() : createRepairUnit(cluster, params, force);
+    if (repairUnit.isPresent()) {
+      return repairUnit;
+    }
+
+    try {
+      return Optional.of(createRepairUnit(cluster, params, force));
+    } catch (IllegalArgumentException e) {
+      return Optional.empty();
+    }
+
+
   }
 
   /**

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -1030,6 +1030,24 @@ public final class BasicSteps {
     }
   }
 
+  @When("^a new repair is added for the last added cluster and keyspace \"([^\"]*)\" with force option$")
+  public void a_new_repair_is_added_for_the_last_added_cluster_and_keyspace_force(String keyspace) throws Throwable {
+    synchronized (BasicSteps.class) {
+      ReaperTestJettyRunner runner = RUNNERS.get(RAND.nextInt(RUNNERS.size()));
+      Map<String, String> params = Maps.newHashMap();
+      params.put("clusterName", TestContext.TEST_CLUSTER);
+      params.put("keyspace", keyspace);
+      params.put("owner", TestContext.TEST_USER);
+      params.put("force", "true");
+      Response response = runner.callReaper("POST", "/repair_run", Optional.of(params));
+      assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+      String responseData = response.readEntity(String.class);
+      Assertions.assertThat(responseData).isNotBlank();
+      RepairRunStatus run = SimpleReaperClient.parseRepairRunStatusJSON(responseData);
+      testContext.addCurrentRepairId(run.getId());
+    }
+  }
+
   @And("^the last added repair has table \"([^\"]*)\" in the blacklist$")
   public void the_last_added_repair_has_table_in_the_blacklist(String blacklistedTable) throws Throwable {
     synchronized (BasicSteps.class) {

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -266,7 +266,11 @@ Feature: Using Reaper
     When reaper is upgraded to latest
     Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
-    And all added repair runs are deleted for the last added cluster
+    And a new repair is added for the last added cluster and keyspace "booya"
+    Then reaper has 1 repairs for cluster called "test"
+    When a new repair is added for the last added cluster and keyspace "booya" with force option
+    Then reaper has 2 repairs for cluster called "test"
+    When all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
   ${cucumber.upgrade-versions}

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -266,11 +266,12 @@ Feature: Using Reaper
     When reaper is upgraded to latest
     Then reaper has 1 started or done repairs for the last added cluster
     When the last added repair is stopped
-    And a new repair is added for the last added cluster and keyspace "booya"
-    Then reaper has 1 repairs for cluster called "test"
     When a new repair is added for the last added cluster and keyspace "booya" with force option
+    And the last added repair is activated
+    And we wait for at least 1 segments to be repaired
     Then reaper has 2 repairs for cluster called "test"
-    When all added repair runs are deleted for the last added cluster
+    When the last added repair is stopped
+    And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
   ${cucumber.upgrade-versions}

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -429,8 +429,8 @@ const repairForm = CreateReactClass({
                   </Modal.Header>
                   <Modal.Body>
                     <p>{this.state.addRepairResultMsg}</p>
-                    <p>It is not reccommended to create overlapping repair schedules.</p>
-                    <p>For Cassandra 4.0 and later, you can force creating this schedule by clicking the "Force" button below.</p>
+                    <p>It is not reccommended to create overlapping repair schedules/runs.</p>
+                    <p>For Cassandra 4.0 and later, you can force creating this schedule/run by clicking the "Force" button below.</p>
                   </Modal.Body>
                   <Modal.Footer>
                     <Button variant="secondary" onClick={this._onClose}>Cancel</Button>


### PR DESCRIPTION
Similar to what was done with schedules, this PR builds on top of that previous work to allow force creation of repair runs.