### PR TITLE
Additional changes for /etc/reaper paths

### DIFF
--- a/docs/docs/backends/astra/index.html
+++ b/docs/docs/backends/astra/index.html
@@ -343,7 +343,7 @@
 <p>Schema initialization and migration will be done automatically upon startup.</p>
 <h2 id="ssl-settings">SSL settings</h2>
 <p>Astra enables client to node encryption by default, which requires some additional setup in Reaper.
-After installing Reaper and configuring the yaml file, copy the <code>cassandra-reaper-ssl.properties</code> file to the <code>/etc/cassandra-reaper</code> directory (the temmplate can be found under <code>/etc/cassandra-reaper/configs/</code>) and configure it as follows:</p>
+After installing Reaper and configuring the yaml file, copy the <code>cassandra-reaper-ssl.properties</code> file to the <code>/etc/reaper</code> directory (the temmplate can be found under <code>/etc/reaper/configs/</code>) and configure it as follows:</p>
 <pre><code>-Djavax.net.ssl.keyStore=/path/to/identity.jks
 -Djavax.net.ssl.keyStorePassword=keystore_password
 

--- a/docs/docs/download/install/index.html
+++ b/docs/docs/download/install/index.html
@@ -372,8 +372,8 @@ sudo apt-get install reaper
 sudo apt-get install reaper
 </code></pre><p>In case of problem, check the alternate procedure on <a href="https://cloudsmith.io/~thelastpickle/repos/reaper-beta/setup/#formats-deb">cloudsmith.io</a>.</p>
 <h2 id="service-configuration">Service Configuration</h2>
-<p>The yaml file used by the service is located at <code>/etc/cassandra-reaper/cassandra-reaper.yaml</code> and alternate config templates can be found under <code>/etc/cassandra-reaper/configs</code>.
-It is recommended to create a new file with your specific configuration and symlink it as <code>/etc/cassandra-reaper/cassandra-reaper.yaml</code> to avoid your configuration from being overwritten during upgrades.<br>
+<p>The yaml file used by the service is located at <code>/etc/reaper/cassandra-reaper.yaml</code> and alternate config templates can be found under <code>/etc/reaper/configs</code>.
+It is recommended to create a new file with your specific configuration and symlink it as <code>/etc/reaper/cassandra-reaper.yaml</code> to avoid your configuration from being overwritten during upgrades.<br>
 Adapt the config file to suit your setup and then run <code>sudo service cassandra-reaper start</code>.</p>
 <p>Log files can be found at <code>/var/log/cassandra-reaper.log</code> and <code>/var/log/cassandra-reaper.err</code>.</p>
 <p>Stop the service by running : <code>sudo service cassandra-reaper stop</code></p>

--- a/docs/docs/install/index.html
+++ b/docs/docs/install/index.html
@@ -269,8 +269,8 @@ sudo dpkg -i reaper_*.*.*_amd64.deb
 
 <h2 id="service-configuration">Service Configuration</h2>
 
-<p>The yaml file used by the service is located at <code>/etc/cassandra-reaper/cassandra-reaper.yaml</code> and alternate config templates can be found under <code>/etc/cassandra-reaper/configs</code>.
-It is recommended to create a new file with your specific configuration and symlink it as <code>/etc/cassandra-reaper/cassandra-reaper.yaml</code> to avoid your configuration from being overwritten during upgrades.<br />
+<p>The yaml file used by the service is located at <code>/etc/reaper/cassandra-reaper.yaml</code> and alternate config templates can be found under <code>/etc/reaper/configs</code>.
+It is recommended to create a new file with your specific configuration and symlink it as <code>/etc/reaper/cassandra-reaper.yaml</code> to avoid your configuration from being overwritten during upgrades.<br />
 Adapt the config file to suit your setup and then run <code>sudo service cassandra-reaper start</code>.</p>
 
 <p>Log files can be found at <code>/var/log/cassandra-reaper.log</code> and <code>/var/log/cassandra-reaper.err</code>.</p>

--- a/docs/download/index.html
+++ b/docs/download/index.html
@@ -248,8 +248,8 @@ make package
 <p>Install the RPM (Fedora based distros like RHEL or Centos) using : <code>sudo rpm -ivh reaper-*.*.*.x86_64.rpm</code><br />
 Install the DEB (Debian based distros like Ubuntu) using : <code>sudo dpkg -i reaper_*.*.*_amd64.deb</code></p>
 
-<p>The yaml file used by the service is located at <code>/etc/cassandra-reaper/cassandra-reaper.yaml</code> and alternate config templates can be found under <code>/etc/cassandra-reaper/configs</code>.
-It is recommended to create a new file with your specific configuration and symlink it as <code>/etc/cassandra-reaper/cassandra-reaper.yaml</code> to avoid your configuration from being overwritten during upgrades.<br />
+<p>The yaml file used by the service is located at <code>/etc/reaper/cassandra-reaper.yaml</code> and alternate config templates can be found under <code>/etc/reaper/configs</code>.
+It is recommended to create a new file with your specific configuration and symlink it as <code>/etc/reaper/cassandra-reaper.yaml</code> to avoid your configuration from being overwritten during upgrades.<br />
 Adapt the config file to suit your setup and then run <code>sudo service cassandra-reaper start</code>.</p>
 
 <p>Log files can be found at <code>/var/log/cassandra-reaper.log</code> and <code>/var/log/cassandra-reaper.err</code>.</p>

--- a/src/docs/content/docs/backends/astra.md
+++ b/src/docs/content/docs/backends/astra.md
@@ -33,7 +33,7 @@ Schema initialization and migration will be done automatically upon startup.
 ## SSL settings
 
 Astra enables client to node encryption by default, which requires some additional setup in Reaper.
-After installing Reaper and configuring the yaml file, copy the `cassandra-reaper-ssl.properties` file to the `/etc/cassandra-reaper` directory (the temmplate can be found under `/etc/cassandra-reaper/configs/`) and configure it as follows:
+After installing Reaper and configuring the yaml file, copy the `cassandra-reaper-ssl.properties` file to the `/etc/reaper` directory (the template can be found under `/etc/reaper/configs/`) and configure it as follows:
 
 ```
 -Djavax.net.ssl.keyStore=/path/to/identity.jks

--- a/src/docs/content/docs/download/install.md
+++ b/src/docs/content/docs/download/install.md
@@ -114,8 +114,8 @@ In case of problem, check the alternate procedure on [cloudsmith.io](https://clo
 
 ## Service Configuration
 
-The yaml file used by the service is located at `/etc/cassandra-reaper/cassandra-reaper.yaml` and alternate config templates can be found under `/etc/cassandra-reaper/configs`.
-It is recommended to create a new file with your specific configuration and symlink it as `/etc/cassandra-reaper/cassandra-reaper.yaml` to avoid your configuration from being overwritten during upgrades.  
+The yaml file used by the service is located at `/etc/reaper/cassandra-reaper.yaml` and alternate config templates can be found under `/etc/reaper/configs`.
+It is recommended to create a new file with your specific configuration and symlink it as `/etc/reaper/cassandra-reaper.yaml` to avoid your configuration from being overwritten during upgrades.  
 Adapt the config file to suit your setup and then run `sudo service cassandra-reaper start`.  
   
 Log files can be found at `/var/log/cassandra-reaper.log` and `/var/log/cassandra-reaper.err`.  

--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -23,13 +23,13 @@ prepare:
 	mkdir -p build/usr/share/cassandra-reaper
 	mkdir -p build/usr/local/bin
 	mkdir -p build/etc/init.d
-	mkdir -p build/etc/cassandra-reaper
-	mkdir -p build/etc/cassandra-reaper/configs
+	mkdir -p build/etc/reaper
+	mkdir -p build/etc/reaper/configs
 	mkdir -p build/etc/bash_completion.d
 	mkdir -p build/lib/systemd/system/
-	cp resource/cassandra-reaper.yaml build/etc/cassandra-reaper/
-	cp resource/cassandra-reaper*.yaml build/etc/cassandra-reaper/configs
-	cp resource/cassandra-reaper-ssl.properties build/etc/cassandra-reaper/configs
+	cp resource/cassandra-reaper.yaml build/etc/reaper/
+	cp resource/cassandra-reaper*.yaml build/etc/reaper/configs
+	cp resource/cassandra-reaper-ssl.properties build/etc/reaper/configs
 	cp ../server/target/cassandra-reaper-$(VERSION).jar build/usr/share/cassandra-reaper/
 	cp bin/* build/usr/local/bin/
 	cp etc/bash_completion.d/spreaper build/etc/bash_completion.d/
@@ -41,7 +41,7 @@ deb: prepare
 	fpm -s dir -t deb -n reaper -v $(VERSION) --pre-install debian/preinstall.sh --post-install debian/postinstall.sh -C build .
 
 rpm: prepare
-	fpm -s dir -t rpm -n reaper -v $(VERSION) --pre-install redhat/preinstall.sh --post-install redhat/postinstall.sh --config-files /etc/cassandra-reaper/cassandra-reaper.yaml -C build .
+	fpm -s dir -t rpm -n reaper -v $(VERSION) --pre-install redhat/preinstall.sh --post-install redhat/postinstall.sh --config-files /etc/reaper/cassandra-reaper.yaml -C build .
 
 all: package deb rpm
 

--- a/src/packaging/bin/cassandra-reaper
+++ b/src/packaging/bin/cassandra-reaper
@@ -45,15 +45,15 @@ if [ -z "$CLASS_PATH" ]; then
 fi
 
 if [ $# -eq 0 ]; then
-    CONFIG_PATH="/usr/local/etc/cassandra-reaper/cassandra-reaper.yaml"
+    CONFIG_PATH="/usr/local/etc/reaper/cassandra-reaper.yaml"
     if [ ! -e "$CONFIG_PATH" ]; then
-        CONFIG_PATH="/etc/cassandra-reaper/cassandra-reaper.yaml"
+        CONFIG_PATH="/etc/reaper/cassandra-reaper.yaml"
     fi
 else
     CONFIG_PATH="$@"
 fi
 
-SSL_CONFIG_PATH="/etc/cassandra-reaper/cassandra-reaper-ssl.properties"
+SSL_CONFIG_PATH="/etc/reaper/cassandra-reaper-ssl.properties"
 if [ -r "$SSL_CONFIG_PATH" ]; then
     echo "Loading SSL configuration from $SSL_CONFIG_PATH"
     # The `sed` expression below removes empty lines and comments


### PR DESCRIPTION
Additional changes related to PR #1113, which change reference from `/etc/cassandra-reaper` to `/etc/reaper` to support applied security.