### PR TITLE
Revert to /etc/cassandra-reaper

### DIFF
--- a/docs/docs/configuration/docker_vars/index.html
+++ b/docs/docs/configuration/docker_vars/index.html
@@ -336,7 +336,7 @@
 <p>Example :</p>
 <pre><code>REAPER_CASS_ADDRESS_TRANSLATOR_TYPE=multiIpPerNode
 REAPER_CASS_ADDRESS_TRANSLATOR_MAPPING=host1:ip1,host2:ip2
-</code></pre><p>config bloc at the container startup file &lsquo;/etc/reaper/cassandra-reaper.yml&rsquo; :</p>
+</code></pre><p>config bloc at the container startup file &lsquo;/etc/cassandra-reaper/cassandra-reaper.yml&rsquo; :</p>
 <pre><code> addressTranslator:
     type: multiIpPerNode
     ipTranslations:

--- a/src/docs/content/docs/configuration/docker_vars.md
+++ b/src/docs/content/docs/configuration/docker_vars.md
@@ -72,7 +72,7 @@ Example :
 REAPER_CASS_ADDRESS_TRANSLATOR_TYPE=multiIpPerNode
 REAPER_CASS_ADDRESS_TRANSLATOR_MAPPING=host1:ip1,host2:ip2
 ```
-config bloc at the container startup file '/etc/reaper/cassandra-reaper.yml' :
+config bloc at the container startup file '/etc/cassandra-reaper/cassandra-reaper.yml' :
 ```
  addressTranslator:
     type: multiIpPerNode

--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -86,8 +86,8 @@ RUN apk add --update \
   && rm -rf /var/cache/apk/*
 
 
-ADD cassandra-reaper.yml /etc/reaper/cassandra-reaper.yml
-ADD shiro.ini /etc/reaper/shiro.ini
+ADD cassandra-reaper.yml /etc/cassandra-reaper/cassandra-reaper.yml
+ADD shiro.ini /etc/cassandra-reaper/shiro.ini
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh
 ADD configure-persistence.sh /usr/local/bin/configure-persistence.sh
 ADD configure-metrics.sh /usr/local/bin/configure-metrics.sh
@@ -97,18 +97,18 @@ ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
 ADD spreaper /usr/local/bin/spreaper
 
 
-# get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/reaper/cassandra-reaper.yml: Interrupted system call` unknown error
-RUN touch /etc/reaper/cassandra-reaper.yml
-# get around `/usr/local/bin/configure-webui-authentication.sh: line 44: can't `create` /etc/reaper/shiro.ini: Interrupted system call` unknown error
-RUN touch /etc/reaper/shiro.ini
+# get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper/cassandra-reaper.yml: Interrupted system call` unknown error
+RUN touch /etc/cassandra-reaper/cassandra-reaper.yml
+# get around `/usr/local/bin/configure-webui-authentication.sh: line 44: can't `create` /etc/cassandra-reaper/shiro.ini: Interrupted system call` unknown error
+RUN touch /etc/cassandra-reaper/shiro.ini
 
 
 RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
     mkdir -p /var/lib/cassandra-reaper && \
-    mkdir -p /etc/reaper/shiro && \
+    mkdir -p /etc/cassandra-reaper/shiro && \
     mkdir -p /var/log/cassandra-reaper && \
     chown reaper:reaper \
-        /etc/reaper/cassandra-reaper.yml \
+        /etc/cassandra-reaper/cassandra-reaper.yml \
         /usr/local/lib/cassandra-reaper.jar \
         /usr/local/bin/entrypoint.sh \
         /usr/local/bin/configure-persistence.sh \
@@ -116,10 +116,10 @@ RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
         /usr/local/bin/configure-metrics.sh \
         /usr/local/bin/configure-jmx-credentials.sh \
         /usr/local/bin/spreaper \
-        /etc/reaper/shiro.ini && \
+        /etc/cassandra-reaper/shiro.ini && \
     chown -R reaper:reaper \
         /var/lib/cassandra-reaper \
-        /etc/reaper/shiro \
+        /etc/cassandra-reaper/shiro \
         /var/log/cassandra-reaper && \
     chmod +x \
         /usr/local/bin/entrypoint.sh \
@@ -130,7 +130,7 @@ RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
         /usr/local/bin/spreaper
 
 VOLUME /var/lib/cassandra-reaper
-VOLUME /etc/reaper/shiro
+VOLUME /etc/cassandra-reaper/shiro
 
 USER reaper
 

--- a/src/server/src/main/docker/configure-jmx-credentials.sh
+++ b/src/server/src/main/docker/configure-jmx-credentials.sh
@@ -17,7 +17,7 @@
 # we expect the jmx credentials to be a comma-separated list of 'user:passowrd@cluster' entries
 if [ ! -z "${REAPER_JMX_CREDENTIALS}" ]; then
 
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 jmxCredentials:
 EOT
 
@@ -29,7 +29,7 @@ EOT
     PASSWORD=$(echo "${ENTRY}" | cut -d'@' -f1 | cut -d':' -f2)
 
     # finally, write out the YAML entries
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
   ${CLUSTER}:
     username: ${USERNAME}
     password: ${PASSWORD}
@@ -41,7 +41,7 @@ fi
 
 
 if [ ! -z "${REAPER_JMX_AUTH_USERNAME}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 jmxAuth:
   username: ${REAPER_JMX_AUTH_USERNAME}
   password: ${REAPER_JMX_AUTH_PASSWORD}
@@ -50,7 +50,7 @@ EOT
 fi
 
 if [ ! -z "${CRYPTO_SYSTEM_PROPERTY_SECRET}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 cryptograph:
   type: symmetric
   systemPropertySecret: ${CRYPTO_SYSTEM_PROPERTY_SECRET}

--- a/src/server/src/main/docker/configure-metrics.sh
+++ b/src/server/src/main/docker/configure-metrics.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 if [ "true" = "${REAPER_METRICS_ENABLED}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 metrics:
   frequency: ${REAPER_METRICS_FREQUENCY}
   reporters: ${REAPER_METRICS_REPORTERS}

--- a/src/server/src/main/docker/configure-persistence.sh
+++ b/src/server/src/main/docker/configure-persistence.sh
@@ -16,20 +16,20 @@
 
 # Add specific jmxAddressTranslator
 if [ ! -z "${JMX_ADDRESS_TRANSLATOR_TYPE}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 jmxAddressTranslator:
   type: ${JMX_ADDRESS_TRANSLATOR_TYPE}
 EOT
 fi
 
 if [ "multiIpPerNode" = "${JMX_ADDRESS_TRANSLATOR_TYPE}" ] && [ -n "$JMX_ADDRESS_TRANSLATOR_MAPPING" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
   ipTranslations:
 EOT
 IFS=',' read -ra mappings <<< "$JMX_ADDRESS_TRANSLATOR_MAPPING"
 for mapping in "${mappings[@]}"; do
 IFS=':' read -ra mapping <<< "$mapping"
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
     - from: "${mapping[0]}"
       to: "${mapping[1]}"
 EOT
@@ -40,7 +40,7 @@ case ${REAPER_STORAGE_TYPE} in
     "cassandra")
 
 # BEGIN cassandra persistence options
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 activateQueryLogger: ${REAPER_CASS_ACTIVATE_QUERY_LOGGER}
 
 cassandra:
@@ -59,7 +59,7 @@ cassandra:
 EOT
 
 if [ "true" = "${REAPER_CASS_AUTH_ENABLED}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
   authProvider:
     type: plainText
     username: ${REAPER_CASS_AUTH_USERNAME}
@@ -68,27 +68,27 @@ EOT
 fi
 
 if [ "true" = "${REAPER_CASS_NATIVE_PROTOCOL_SSL_ENCRYPTION_ENABLED}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
   ssl:
     type: jdk
 EOT
 fi
 
 if [ "true" = "${REAPER_CASS_ADDRESS_TRANSLATOR_ENABLED}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
   addressTranslator:
     type: ${REAPER_CASS_ADDRESS_TRANSLATOR_TYPE}
 EOT
 fi
 
 if [ "multiIpPerNode" = "${REAPER_CASS_ADDRESS_TRANSLATOR_TYPE}" ] && [ -n "$REAPER_CASS_ADDRESS_TRANSLATOR_MAPPING" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
     ipTranslations:
 EOT
 IFS=',' read -ra mappings <<< "$REAPER_CASS_ADDRESS_TRANSLATOR_MAPPING"
 for mapping in "${mappings[@]}"; do
 IFS=':' read -ra mapping <<< "$mapping"
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
     - from: "${mapping[0]}"
       to: "${mapping[1]}"
 EOT

--- a/src/server/src/main/docker/configure-webui-authentication.sh
+++ b/src/server/src/main/docker/configure-webui-authentication.sh
@@ -18,21 +18,21 @@ if [ "false" = "${REAPER_AUTH_ENABLED}" ]; then
 fi
 
 if [ ! -z "${REAPER_SHIRO_INI}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 accessControl:
   sessionTimeout: PT10M
   shiro:
     iniConfigs: ["file:${REAPER_SHIRO_INI}"]
 EOT
 elif [ ! -z "${REAPER_AUTH_USER}" ]; then
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 accessControl:
   sessionTimeout: PT10M
   shiro:
-    iniConfigs: ["file:/etc/reaper/shiro.ini"]
+    iniConfigs: ["file:/etc/cassandra-reaper/shiro.ini"]
 EOT
 else
-cat <<EOT >> /etc/reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
 accessControl:
   sessionTimeout: PT10M
   shiro:
@@ -41,7 +41,7 @@ EOT
 fi
 
 if [ ! -z "${REAPER_AUTH_USER}" ]; then
-cat <<EOT2 >> /etc/reaper/shiro.ini
+cat <<EOT2 >> /etc/cassandra-reaper/shiro.ini
 ${REAPER_AUTH_USER} = ${REAPER_AUTH_PASSWORD}, operator
 EOT2
 fi

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -33,8 +33,8 @@ function wait_for {
 
 if [ "$1" = 'cassandra-reaper' ]; then
 
-    # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/reaper/cassandra-reaper.yml: Interrupted system call` unknown error
-    touch /etc/reaper/cassandra-reaper.yml
+    # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper/cassandra-reaper.yml: Interrupted system call` unknown error
+    touch /etc/cassandra-reaper/cassandra-reaper.yml
 
     /usr/local/bin/configure-persistence.sh
     /usr/local/bin/configure-webui-authentication.sh
@@ -43,13 +43,13 @@ if [ "$1" = 'cassandra-reaper' ]; then
     exec java \
             ${JAVA_OPTS} \
             -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication server \
-            /etc/reaper/cassandra-reaper.yml
+            /etc/cassandra-reaper/cassandra-reaper.yml
 fi
 
 if [ "$1" = 'schema-migration' ]; then
 
-    # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/reaper/cassandra-reaper.yml: Interrupted system call` unknown error
-    touch /etc/reaper/cassandra-reaper.yml
+    # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper/cassandra-reaper.yml: Interrupted system call` unknown error
+    touch /etc/cassandra-reaper/cassandra-reaper.yml
 
     /usr/local/bin/configure-persistence.sh
     /usr/local/bin/configure-webui-authentication.sh
@@ -58,7 +58,7 @@ if [ "$1" = 'schema-migration' ]; then
     exec java \
             ${JAVA_OPTS} \
             -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication schema-migration \
-            /etc/reaper/cassandra-reaper.yml
+            /etc/cassandra-reaper/cassandra-reaper.yml
 fi
 
 if [ "$1" = 'register-clusters' ]; then


### PR DESCRIPTION
Adjustment to revert changes made in `cassandra-reaper` [PR#1113](https://github.com/thelastpickle/cassandra-reaper/pull/1113) to support this [k8ssandra PR](https://github.com/k8ssandra/k8ssandra/pull/1062) in `k8ssandra` for mount path changes.

Moving change of `/etc/reaper` to `/etc/cassandra-reaper` to reduce complexity of those deploying Reaper outside of a container.