### PR TITLE
Fix broken unit test

### DIFF
--- a/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairUnitServiceTest.java
@@ -78,6 +78,7 @@ public final class RepairUnitServiceTest {
     context.config.setBlacklistTwcsTables(true);
     IStorage storage = mock(IStorage.class);
     when(storage.getRepairUnit(any(RepairUnit.Builder.class))).thenReturn(Optional.empty());
+    when(storage.addRepairUnit(any(RepairUnit.Builder.class))).thenReturn(mock(RepairUnit.class));
     context.storage = storage;
     context.jmxConnectionFactory = mock(JmxConnectionFactory.class);
     service = RepairUnitService.create(context);


### PR DESCRIPTION
The latest PR merge broke a unit test because a storage class mock was lacking a return object when storing a new repair unit.