### PR TITLE
Fixing broken Dropwizard Link

### DIFF
--- a/src/docs/content/docs/metrics/_index.md
+++ b/src/docs/content/docs/metrics/_index.md
@@ -7,7 +7,7 @@ identifier = "metrics"
 
 # Metrics Reporting
 
-Reaper metrics are provided via the [Dropwizard Metrics](http://www.dropwizard.io/1.1.4/docs/manual/configuration.html#metrics) interface. The interface gives Reaper the ability to configure various metrics reporting systems. Metrics reporting can be configured in Reaper with the **metrics** property in the Reaper configuration YAML file. The **metrics** property has two fields; **frequency** and **reporters**. Specific metric reporters are defined in the **reporters** field as follows.
+Reaper metrics are provided via the [Dropwizard Metrics](https://www.dropwizard.io/en/release-2.0.x/manual/configuration.html#metrics) interface. The interface gives Reaper the ability to configure various metrics reporting systems. Metrics reporting can be configured in Reaper with the **metrics** property in the Reaper configuration YAML file. The **metrics** property has two fields; **frequency** and **reporters**. Specific metric reporters are defined in the **reporters** field as follows.
 
 ```yaml
 metrics:


### PR DESCRIPTION
Looks like Reaper moved to Dropwizard 2.0 as part of #1148 so fixing this link to point to the newer Dropwizard.io page. 