### PR TITLE
Recompute segment replicas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,8 @@
                 <version>3.0.1</version>
                 <configuration>
                   <doclint>none</doclint>
+                  <source>8</source>
+                  <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>
             </plugin>
             <plugin>
@@ -262,7 +264,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -292,7 +292,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>4.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/server/src/main/java/io/cassandrareaper/jmx/ClusterFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/jmx/ClusterFacade.java
@@ -201,7 +201,6 @@ public final class ClusterFacade {
    * In SIDECAR : Enforce connecting to the local node to get the information
    *
    * @param cluster the cluster to connect to
-   * @param endpoints the list of endpoints to connect to
    * @return a NodeStatus object with all nodes state
    * @throws ReaperException any runtime exception we catch
    */
@@ -266,7 +265,7 @@ public final class ClusterFacade {
    * local node to get the information
    *
    * @param cluster the cluster to connect to
-   * @param keyspaceName the ks to get a map of token ranges for
+   * @param keyspace the ks to get a map of token ranges for
    * @return a map of token ranges with endpoints as items
    * @throws ReaperException any runtime exception we catch
    */
@@ -533,7 +532,6 @@ public final class ClusterFacade {
    * Collect ClientRequest metrics through JMX on a specific node.
    *
    * @param node the node to collect metrics on
-   * @param collectedMetrics the list of metrics to collect
    * @return the list of collected metrics
    * @throws ReaperException any runtime exception we catch in the process
    */
@@ -860,7 +858,6 @@ public final class ClusterFacade {
    * In SIDECAR : We skip that code path as we don’t need to pre-heat connections
    *
    * @param cluster the cluster to connect to
-   * @param endpoints the list of endpoints to connect to
    * @return a JmxProxy object
    * @throws ReaperException any runtime exception we catch
    */

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -205,7 +205,6 @@ public final class RepairRunService {
     return segmentsWithReplicas;
   }
 
-  @VisibleForTesting
   Map<String, String> getDCsByNodeForRepairSegment(
       Cluster cluster,
       Segment segment,

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -99,8 +99,6 @@ public interface IStorage extends Managed {
 
   /**
    * @param runId the run id that the segment belongs to.
-   * @param range a ring range. The start of the range may be greater than or equal to the end. This case has to be
-   *      handled. When start = end, consider that as a range that covers the whole ring.
    * @return a segment enclosed by the range with state NOT_STARTED, or nothing.
    */
   List<RepairSegment> getNextFreeSegments(UUID runId);

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -72,7 +72,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyCollectionOf;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -160,9 +160,9 @@ public final class RepairRunResourceTest {
             any(BigInteger.class),
             anyString(),
             any(RepairParallelism.class),
-            anyCollectionOf(String.class),
+            anyCollection(),
             anyBoolean(),
-            anyCollectionOf(String.class),
+            anyCollection(),
             any(),
             any(),
             any(Integer.class)))

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -815,7 +815,7 @@ public final class RepairRunnerTest {
     return map;
   }
 
-  @Test(expected = ConditionTimeoutException.class)
+  @Test
   public void testDontFailRepairAfterTopologyChange() throws InterruptedException, ReaperException,
       MalformedObjectNameException, ReflectionException, IOException {
     final String ksName = "reaper";
@@ -943,13 +943,11 @@ public final class RepairRunnerTest {
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
       .thenReturn(Lists.newArrayList(nodeSetAfterTopologyChange));
     context.repairManager.resumeRunningRepairRuns();
-    // The repair should now fail as the list of replicas for the segments are different from storage
-    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
-      return RepairRun.RunState.ERROR == storage.getRepairRun(runId).get().getRunState();
-    });
 
-    // We shouldn't get here at all
-    assertEquals(RepairRun.RunState.ERROR, storage.getRepairRun(runId).get().getRunState());
+    // The repair run should succeed despite the topology change.
+    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+      return RepairRun.RunState.DONE == storage.getRepairRun(runId).get().getRunState();
+    });
   }
 
   private RepairRun addNewRepairRun(

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -103,6 +103,10 @@ public final class RepairRunnerTest {
   private static final Logger LOG = LoggerFactory.getLogger(RepairRunnerTest.class);
   private static final Set<String> TABLES = ImmutableSet.of("table1");
   private static final Duration POLL_INTERVAL = Duration.TWO_SECONDS;
+  private static final List<BigInteger> THREE_TOKENS = Lists.newArrayList(
+      BigInteger.valueOf(0L),
+      BigInteger.valueOf(100L),
+      BigInteger.valueOf(200L));
 
   private final Cluster cluster = Cluster.builder()
             .withName("test_" + RandomStringUtils.randomAlphabetic(12))
@@ -440,10 +444,7 @@ public final class RepairRunnerTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final IStorage storage = new MemoryStorage();
     AppContext context = new AppContext();
     context.storage = storage;
@@ -571,10 +572,7 @@ public final class RepairRunnerTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final IStorage storage = new MemoryStorage();
     AppContext context = new AppContext();
     context.storage = storage;
@@ -817,25 +815,23 @@ public final class RepairRunnerTest {
     return map;
   }
 
-  @Test
-  public void testFailRepairAfterTopologyChange() throws InterruptedException, ReaperException,
+  @Test(expected = ConditionTimeoutException.class)
+  public void testDontFailRepairAfterTopologyChange() throws InterruptedException, ReaperException,
       MalformedObjectNameException, ReflectionException, IOException {
     final String ksName = "reaper";
     final Set<String> cfNames = Sets.newHashSet("reaper");
     final boolean incrementalRepair = false;
     final Set<String> nodeSet = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
     final List<String> nodeSetAfterTopologyChange = Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.4");
-    final Map<String, String> nodeMap = ImmutableMap.of(
-        "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1");
+    final Map<String, String> nodeMap = ImmutableMap.of("127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1");
+    final Map<String, String> nodeMapAfterTopologyChange = ImmutableMap.of(
+        "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.4", "dc1");
     final Set<String> datacenters = Collections.emptySet();
     final Set<String> blacklistedTables = Collections.emptySet();
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final IStorage storage = new MemoryStorage();
     AppContext context = new AppContext();
     context.storage = storage;
@@ -853,26 +849,7 @@ public final class RepairRunnerTest {
             .repairThreadCount(repairThreadCount)
             .timeout(segmentTimeout))
         .getId();
-    RepairRun run = storage.addRepairRun(
-            RepairRun.builder(cluster.getName(), cf)
-                .intensity(intensity)
-                .segmentCount(1)
-                .repairParallelism(RepairParallelism.PARALLEL)
-                .tables(TABLES),
-            Lists.newArrayList(
-                RepairSegment.builder(
-                        Segment.builder()
-                            .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
-                            .withReplicas(nodeMap)
-                            .build(), cf)
-                    .withState(RepairSegment.State.RUNNING)
-                    .withStartTime(DateTime.now())
-                    .withCoordinatorHost("reaper"),
-                RepairSegment.builder(
-                    Segment.builder()
-                        .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
-                        .withReplicas(nodeMap)
-                        .build(), cf)));
+    RepairRun run = addNewRepairRun(nodeMap, intensity, storage, cf);
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegment(runId, segmentId).get().getState(), RepairSegment.State.NOT_STARTED);
@@ -958,6 +935,11 @@ public final class RepairRunnerTest {
     storage.updateRepairRun(
         run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(runId));
     // We'll now change the list of replicas for any segment, making the stored ones obsolete
+    when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
+        .thenReturn((Map)ImmutableMap.of(
+            Lists.newArrayList("0", "100"), Lists.newArrayList(nodeSetAfterTopologyChange),
+            Lists.newArrayList("100", "200"), Lists.newArrayList(nodeSetAfterTopologyChange)));
+    when(clusterFacade.getEndpointToHostId(any())).thenReturn(nodeMapAfterTopologyChange);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
       .thenReturn(Lists.newArrayList(nodeSetAfterTopologyChange));
     context.repairManager.resumeRunningRepairRuns();
@@ -965,7 +947,37 @@ public final class RepairRunnerTest {
     await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
       return RepairRun.RunState.ERROR == storage.getRepairRun(runId).get().getRunState();
     });
+
+    // We shouldn't get here at all
     assertEquals(RepairRun.RunState.ERROR, storage.getRepairRun(runId).get().getRunState());
+  }
+
+  private RepairRun addNewRepairRun(
+      final Map<String, String> nodeMap,
+      final double intensity,
+      final IStorage storage,
+      UUID cf
+  ) {
+    return storage.addRepairRun(
+            RepairRun.builder(cluster.getName(), cf)
+                .intensity(intensity)
+                .segmentCount(1)
+                .repairParallelism(RepairParallelism.PARALLEL)
+                .tables(TABLES),
+            Lists.newArrayList(
+                RepairSegment.builder(
+                        Segment.builder()
+                            .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                            .withReplicas(nodeMap)
+                            .build(), cf)
+                    .withState(RepairSegment.State.RUNNING)
+                    .withStartTime(DateTime.now())
+                    .withCoordinatorHost("reaper"),
+                RepairSegment.builder(
+                    Segment.builder()
+                        .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
+                        .withReplicas(nodeMap)
+                        .build(), cf)));
   }
 
   @Test
@@ -998,10 +1010,7 @@ public final class RepairRunnerTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
     context.storage = Mockito.mock(CassandraStorage.class);
     RepairUnit repairUnit = RepairUnit.builder()
@@ -1072,10 +1081,7 @@ public final class RepairRunnerTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final IStorage storage = new MemoryStorage();
     AppContext context = new AppContext();
     context.storage = storage;
@@ -1094,28 +1100,7 @@ public final class RepairRunnerTest {
             .timeout(segmentTimeout))
         .getId();
     DateTimeUtils.setCurrentMillisFixed(timeRun);
-    RepairRun run = storage.addRepairRun(
-            RepairRun.builder(cluster.getName(), cf)
-                .intensity(intensity)
-                .segmentCount(1)
-                .repairParallelism(RepairParallelism.PARALLEL)
-                .tables(TABLES),
-            Lists.newArrayList(
-                RepairSegment.builder(
-                        Segment.builder()
-                            .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
-                            .withReplicas(nodeMap)
-                            .build(),
-                        cf)
-                    .withState(RepairSegment.State.RUNNING)
-                    .withStartTime(DateTime.now())
-                    .withCoordinatorHost("reaper"),
-                RepairSegment.builder(
-                    Segment.builder()
-                        .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
-                        .withReplicas(nodeMap)
-                        .build(),
-                    cf)));
+    RepairRun run = addNewRepairRun(nodeMap, intensity, storage, cf);
     final UUID runId = run.getId();
     final UUID segmentId = storage.getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegment(runId, segmentId).get().getState(), RepairSegment.State.NOT_STARTED);
@@ -1173,10 +1158,7 @@ public final class RepairRunnerTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
     context.storage = Mockito.mock(CassandraStorage.class);
     RepairUnit repairUnit = RepairUnit.builder()
@@ -1261,10 +1243,7 @@ public final class RepairRunnerTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
     context.storage = Mockito.mock(CassandraStorage.class);
     RepairUnit repairUnit = RepairUnit.builder()
@@ -1350,10 +1329,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final int maxDuration = 10;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
     context.storage = Mockito.mock(CassandraStorage.class);
     RepairUnit repairUnit = RepairUnit.builder()
@@ -1439,10 +1415,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final int maxDuration = 10;
-    final List<BigInteger> tokens = Lists.newArrayList(
-        BigInteger.valueOf(0L),
-        BigInteger.valueOf(100L),
-        BigInteger.valueOf(200L));
+    final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
     context.storage = Mockito.mock(CassandraStorage.class);
     RepairUnit repairUnit = RepairUnit.builder()


### PR DESCRIPTION
Fixes the K8ssandra issue reported [here](https://github.com/k8ssandra/k8ssandra/issues/1314).
Fixes #1105

When nodes get replaced or if pods restart in Cassandra, they may get a new IP which is different from the one recorded at the segment creation time.
While capturing the list of IPs on the segments is important for efficient scheduling of segments, we need to recompute the actual list when segments are scheduled so that we can handle IP changes.