### PR TITLE
Make heap size configurable through env variable

### DIFF
--- a/src/packaging/bin/cassandra-reaper
+++ b/src/packaging/bin/cassandra-reaper
@@ -82,13 +82,17 @@ if [ -z $JAVA ] ; then
     exit 1;
 fi
 
+if [ -z "$REAPER_HEAP_SIZE" ]; then
+    REAPER_HEAP_SIZE="2G"
+fi
+
 
 JVM_OPTS=(
     # it is safe and performant to disable assertions in production
     # environments (ie replace `-ea` with `-da`)
     -ea
-    -Xms2G
-    -Xmx2G
+    -Xms${REAPER_HEAP_SIZE}
+    -Xmx${REAPER_HEAP_SIZE}
     ${JVM_OPTS[@]}
     # Prefer binding to IPv4 network intefaces (when net.ipv6.bindv6only=1). See
     # http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6342561 (short version:

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -33,6 +33,9 @@ function wait_for {
 
 if [ "$1" = 'cassandra-reaper' ]; then
 
+    if [ -z "$REAPER_HEAP_SIZE" ]; then
+        REAPER_HEAP_SIZE="1G"
+    fi
     # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper/cassandra-reaper.yml: Interrupted system call` unknown error
     touch /etc/cassandra-reaper/cassandra-reaper.yml
 
@@ -42,6 +45,8 @@ if [ "$1" = 'cassandra-reaper' ]; then
     /usr/local/bin/configure-jmx-credentials.sh
     exec java \
             ${JAVA_OPTS} \
+            -Xms${REAPER_HEAP_SIZE} \
+            -Xmx${REAPER_HEAP_SIZE} \
             -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication server \
             /etc/cassandra-reaper/cassandra-reaper.yml
 fi


### PR DESCRIPTION
This PR makes it possible to set the heap size for Reaper through an environment variable.
Previously, we were using a hardcoded 2GB heap for non containerized deployments and no heap setting for containers (which defaults to 1G heaps).
Defaults were preserved for both types of deployments.