### PR TITLE
UI tooling update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,9 +54,6 @@ jobs:
         with:
           node-version: '10.x'
 
-      - name: Setup bower
-        run: npm install -g bower
-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -102,9 +99,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-
-      - name: Setup bower
-        run: npm install -g bower
 
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -187,9 +181,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-
-      - name: Setup bower
-        run: npm install -g bower
 
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -283,9 +274,6 @@ jobs:
         with:
           node-version: '10.x'
 
-      - name: Setup bower
-        run: npm install -g bower
-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -356,9 +344,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-
-      - name: Setup bower
-        run: npm install -g bower
 
       - name: Install ECM
         run: |
@@ -454,9 +439,6 @@ jobs:
         with:
           node-version: '10.x'
 
-      - name: Setup bower
-        run: npm install -g bower
-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -531,9 +513,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-
-      - name: Setup bower
-        run: npm install -g bower
 
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -627,9 +606,6 @@ jobs:
         with:
           node-version: '10.x'
 
-      - name: Setup bower
-        run: npm install -g bower
-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -708,9 +684,6 @@ jobs:
         with:
           node-version: '10.x'
 
-      - name: Setup bower
-        run: npm install -g bower
-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -780,9 +753,6 @@ jobs:
         with:
           node-version: '10.x'
 
-      - name: Setup bower
-        run: npm install -g bower
-
       - name: Install ECM
         run: |
           wget -O ecm-ccm-elassandra.zip https://github.com/strapdata/ecm/archive/ccm-elassandra.zip
@@ -843,9 +813,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-
-      - name: Setup bower
-        run: npm install -g bower
 
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -591,21 +591,6 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>exec-bower-install</id>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <executable>bower</executable>
-                            <workingDirectory>../ui</workingDirectory>
-                            <arguments>
-                                <argument>--allow-root</argument>
-                                <argument>install</argument>
-                            </arguments>
-                        </configuration>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>exec-npm-run</id>
                         <phase>generate-sources</phase>
                         <configuration>

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -17,8 +17,7 @@ Instruction to rebuild and embed the UI in Reaper can be found in the root [READ
 
 Getting started to work with the source code is easy. You will need to install
 
-* [node](https://nodejs.org/) (v7.7.0+ recommended)
-* [bower](http://bower.io/) (1.8.0+ recommended)
+* [node](https://nodejs.org/) (v7.7.0-v14-lts recommended)
 
 Then run:
 
@@ -26,7 +25,6 @@ Then run:
 # Assume we are in the reaper project parent directory
 $ cd src/ui/
 $ npm install
-$ bower install
 ```
 
 The dev-server can be started as follows:

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -19,6 +19,7 @@
     "babel-preset-react": "^6.0.0",
     "babel-runtime": "^6.26.0",
     "bootstrap": "^3.3.7",
+    "bower": "^1.8.14",
     "css-loader": "^3.5.0",
     "dom-helpers": "^3.4.0",
     "html-webpack-plugin": "^3.0.0",
@@ -46,7 +47,9 @@
     "minimize": "webpack -p --progress --colors --devtool none",
     "zip": "zip -jr release.zip build",
     "start": "node server.js --env.project=$REAPER_HOST",
-    "navbar": "./build-navbar.sh"
+    "navbar": "./build-navbar.sh",
+    "bower": "bower install",
+    "postinstall": "npm run bower"
   },
   "dependencies": {
     "core-js": "^2.6.11",


### PR DESCRIPTION
After forgetting on two different machines I was trying out to install bower...

* Remove the manually installed dependency on bower by moving it within the npm dependencies and scripts
* Consolidates the UI dev/build process to be exclusively controlled through npm
* The `bower install` will happen automatically following an `npm install`

Also updated the README to note that it requires Node <= 14 (had all sorts of strange problem on 16 at first)