### PR TITLE
Identify Stargate nodes

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
@@ -43,6 +43,7 @@ public final class NodesStatus {
   private static final List<Pattern> ENDPOINT_SEVERITY_PATTERNS = Lists.newArrayList();
   private static final List<Pattern> ENDPOINT_HOSTID_PATTERNS = Lists.newArrayList();
   private static final List<Pattern> ENDPOINT_TOKENS_PATTERNS = Lists.newArrayList();
+  private static final List<Pattern> ENDPOINT_TYPE_PATTERNS = Lists.newArrayList();
 
   private static final Pattern ENDPOINT_NAME_PATTERN_IP4
       = Pattern.compile("^([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})", Pattern.MULTILINE | Pattern.DOTALL);
@@ -65,6 +66,7 @@ public final class NodesStatus {
   private static final Pattern ENDPOINT_SEVERITY_21_PATTERN = Pattern.compile("(SEVERITY)(:)([0-9.]+)");
   private static final Pattern ENDPOINT_HOSTID_21_PATTERN = Pattern.compile("(HOST_ID)(:)([0-9a-z-]+)");
   private static final Pattern ENDPOINT_LOAD_SCYLLA_44_PATTERN = Pattern.compile("(LOAD)(:)([0-9eE.\\+]+)");
+  private static final Pattern ENDPOINT_TYPE_STARGATE_PATTERN = Pattern.compile("(X10):([0-9]*):(stargate)");
 
   private static final String NOT_AVAILABLE = "Not available";
 
@@ -146,6 +148,7 @@ public final class NodesStatus {
       Optional<String> tokens = parseEndpointState(ENDPOINT_TOKENS_PATTERNS, endpointString, 2, String.class);
       Optional<Double> load = parseEndpointState(ENDPOINT_LOAD_PATTERNS, endpointString, 3, Double.class);
       totalLoad += load.orElse(0.0);
+      Optional<String> stargate = parseEndpointState(ENDPOINT_TYPE_PATTERNS, endpointString, 3, String.class);
 
       EndpointState endpointState = new EndpointState(
           endpoint.orElse(NOT_AVAILABLE),
@@ -156,7 +159,8 @@ public final class NodesStatus {
           severity.orElse(0.0),
           releaseVersion.orElse(NOT_AVAILABLE),
           tokens.orElse(NOT_AVAILABLE),
-          load.orElse(0.0));
+          load.orElse(0.0),
+          stargate.isPresent());
 
       if (!status.orElse(NOT_AVAILABLE).toLowerCase().contains("left")
           && !status.orElse(NOT_AVAILABLE).toLowerCase().contains("removed")) {
@@ -207,6 +211,7 @@ public final class NodesStatus {
     ENDPOINT_SEVERITY_PATTERNS.addAll(Arrays.asList(ENDPOINT_SEVERITY_22_PATTERN, ENDPOINT_SEVERITY_21_PATTERN));
     ENDPOINT_HOSTID_PATTERNS.addAll(Arrays.asList(ENDPOINT_HOSTID_22_PATTERN, ENDPOINT_HOSTID_21_PATTERN));
     ENDPOINT_TOKENS_PATTERNS.add(ENDPOINT_TOKENS_22_PATTERN);
+    ENDPOINT_TYPE_PATTERNS.add(ENDPOINT_TYPE_STARGATE_PATTERN);
   }
 
   public static final class GossipInfo {
@@ -265,6 +270,9 @@ public final class NodesStatus {
     @JsonProperty
     public final Double load;
 
+    @JsonProperty
+    public final Boolean stargate;
+
     public EndpointState(
         String endpoint,
         String hostId,
@@ -274,7 +282,8 @@ public final class NodesStatus {
         Double severity,
         String releaseVersion,
         String tokens,
-        Double load) {
+        Double load,
+        Boolean stargate) {
 
       this.endpoint = endpoint;
       this.hostId = hostId;
@@ -285,6 +294,7 @@ public final class NodesStatus {
       this.releaseVersion = releaseVersion;
       this.tokens = tokens;
       this.load = load;
+      this.stargate = stargate;
     }
 
     public String getDc() {
@@ -322,7 +332,10 @@ public final class NodesStatus {
           + hostId
           + " / "
           + "Tokens : "
-          + tokens;
+          + tokens
+          + " / "
+          + "Stargate : "
+          + stargate;
     }
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/view/NodesStatus.java
@@ -160,7 +160,7 @@ public final class NodesStatus {
           releaseVersion.orElse(NOT_AVAILABLE),
           tokens.orElse(NOT_AVAILABLE),
           load.orElse(0.0),
-          stargate.isPresent());
+          stargate.isPresent() ? NodeType.STARGATE : NodeType.CASSANDRA);
 
       if (!status.orElse(NOT_AVAILABLE).toLowerCase().contains("left")
           && !status.orElse(NOT_AVAILABLE).toLowerCase().contains("removed")) {
@@ -241,6 +241,11 @@ public final class NodesStatus {
     }
   }
 
+  public enum NodeType {
+    CASSANDRA,
+    STARGATE;
+  }
+
   public static final class EndpointState {
 
     @JsonProperty
@@ -271,7 +276,7 @@ public final class NodesStatus {
     public final Double load;
 
     @JsonProperty
-    public final Boolean stargate;
+    public final NodeType type;
 
     public EndpointState(
         String endpoint,
@@ -283,7 +288,7 @@ public final class NodesStatus {
         String releaseVersion,
         String tokens,
         Double load,
-        Boolean stargate) {
+        NodeType type) {
 
       this.endpoint = endpoint;
       this.hostId = hostId;
@@ -294,7 +299,7 @@ public final class NodesStatus {
       this.releaseVersion = releaseVersion;
       this.tokens = tokens;
       this.load = load;
-      this.stargate = stargate;
+      this.type = type;
     }
 
     public String getDc() {
@@ -334,8 +339,8 @@ public final class NodesStatus {
           + "Tokens : "
           + tokens
           + " / "
-          + "Stargate : "
-          + stargate;
+          + "Type : "
+          + type;
     }
   }
 }

--- a/src/ui/app/jsx/cluster-list.jsx
+++ b/src/ui/app/jsx/cluster-list.jsx
@@ -55,17 +55,15 @@ const Cluster = CreateReactClass({
           method: 'GET',
           component: this,
           complete: function(data) {
-            console.log(this.component.props.name + " complete.");
             this.component.setState({clusterStatuses: setTimeout(this.component._refreshClusterStatus, 30000),
                                      clusterStatus: $.parseJSON(data.responseText)});
             
             if(this.component.state.clusterStatus.nodes_status){
               this.component.setState({nodes_status: this.component.state.clusterStatus.nodes_status});
             }
-            console.log(this.component.props.name + " : Next attempt in 30s.")
           },
           error: function(data) {
-            console.log(this.component.props.name + " failed.");
+            console.error(this.component.props.name + " failed.");
             this.component.setState({clusterStatuses: setTimeout(this.component._refreshClusterStatus, 30000)});
 
           }

--- a/src/ui/app/jsx/event-subscription-form.jsx
+++ b/src/ui/app/jsx/event-subscription-form.jsx
@@ -20,6 +20,7 @@ import CreateReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
 import {getUrlPrefix} from "jsx/mixin";
+import {getNodeOptions} from "../node-utils";
 
 
 const subscriptionForm = CreateReactClass({
@@ -197,11 +198,7 @@ const subscriptionForm = CreateReactClass({
   },
 
   _getNodeOptions: function() {
-    this.setState({
-      nodeOptions: this.state.clusterStatus.nodes_status.endpointStates[0].endpointNames.map(
-        obj => { return {value: obj, label: obj}; }
-      )
-    });
+    this.setState(getNodeOptions(this.state.clusterStatus.nodes_status.endpointStates, true));
   },
 
   _handleSelectOnChange: function(valueContext, actionContext) {

--- a/src/ui/app/jsx/node-status.jsx
+++ b/src/ui/app/jsx/node-status.jsx
@@ -213,8 +213,14 @@ const NodeStatus = CreateReactClass({
   
       let buttonStyle = "btn btn-xs btn-success";
       let largeButtonStyle = "btn btn-lg btn-static btn-success";
-  
-      if(!this.props.endpointStatus.status.endsWith('UP')){
+
+      // If the node is a Stargate node we won't have real status for it
+      // so we'll display it slightly differently
+      if (this.props.endpointStatus.stargate) {
+          buttonStyle = "btn btn-xs btn-info";
+          largeButtonStyle = "btn btn-lg btn-static btn-info";
+      // If it's not a stargate node, then we can appropriately use its status
+      } else if(!this.props.endpointStatus.status.endsWith('UP')){
         buttonStyle = "btn btn-xs btn-danger";
         largeButtonStyle = "btn btn-lg btn-static btn-danger";
       }
@@ -236,7 +242,13 @@ const NodeStatus = CreateReactClass({
       }
   
       const tooltip = (
-        <Tooltip id="tooltip"><strong>{this.props.endpointStatus.endpoint}</strong> ({humanFileSize(this.props.endpointStatus.load, 1024)})</Tooltip>
+        <Tooltip id="tooltip">
+          <strong>{this.props.endpointStatus.endpoint}</strong>
+          {this.props.endpointStatus.stargate &&
+            <span>&nbsp;(Stargate)</span>
+          }
+          &nbsp;({humanFileSize(this.props.endpointStatus.load, 1024)})
+        </Tooltip>
       );
 
       const tokenList = this.state.tokens.map(token => <div key={token}>{token}</div>);

--- a/src/ui/app/jsx/node-status.jsx
+++ b/src/ui/app/jsx/node-status.jsx
@@ -185,6 +185,8 @@ const NodeStatus = CreateReactClass({
     },
   
     render: function() {
+      const isStargate = this.props.endpointStatus.type === "STARGATE";
+
       let displayNodeStyle = {
         display: "none"
       }
@@ -214,7 +216,6 @@ const NodeStatus = CreateReactClass({
       let buttonStyle = "btn btn-xs btn-success";
       let largeButtonStyle = "btn btn-lg btn-static btn-success";
 
-      const isStargate = this.props.endpointStatus.type === "STARGATE";
       // If the node is a Stargate node we won't have real status for it
       // so we'll display it slightly differently
       if (isStargate) {
@@ -241,6 +242,15 @@ const NodeStatus = CreateReactClass({
         overflow: "auto",
         height: "200px"
       }
+
+      const modalTitle = (
+          <Modal.Title>
+              Endpoint {this.props.endpointStatus.endpoint}
+              {isStargate &&
+                  <span>&nbsp;(Stargate)</span>
+              }
+          </Modal.Title>
+      );
   
       const tooltip = (
         <Tooltip id="tooltip">
@@ -284,7 +294,7 @@ const NodeStatus = CreateReactClass({
               <OverlayTrigger placement="top" overlay={tooltip}><button type="button" style={btStyle} className={buttonStyle} onClick={this.open}>&nbsp;</button></OverlayTrigger>
               <Modal show={this.state.showModal} onHide={this.close} bsSize="large" aria-labelledby="contained-modal-title-lg" dialogClassName="large-modal">
                 <Modal.Header closeButton>
-                  <Modal.Title>Endpoint {this.props.endpointStatus.endpoint}</Modal.Title>
+                  {modalTitle}
                 </Modal.Header>
                 <Modal.Body>
                   <div className="row">
@@ -297,26 +307,39 @@ const NodeStatus = CreateReactClass({
                       <p>{this.props.endpointStatus.dc} / {this.props.endpointStatus.rack}</p>
                     </div>
                     <div className="col-lg-3">
+                      <h4>Node Type</h4>
+                      <p>{isStargate ? "Stargate" : "Cassandra"}</p>
+                    </div>
+                    <div className="col-lg-3">
                       <h4>Release version</h4>
                       <p>{this.props.endpointStatus.releaseVersion}</p>
                     </div>
-                    <div className="col-lg-3">
-                      <h4>Tokens</h4>
-                      <p><OverlayTrigger trigger="click" placement="bottom" overlay={tokens}><button type="button" className="btn btn-md btn-info" style={takeSnapshotStyle}>{this.state.tokens.length}</button></OverlayTrigger></p>
-                    </div>
-                    <div className="col-lg-3">
-                      <h4>Status</h4>
-                      <p><button type="button" className={largeButtonStyle}>{this.props.endpointStatus.status}</button></p>
-                    </div>
-                    <div className="col-lg-3">                  
-                      <h4>Severity</h4>
-                      <p>{this.props.endpointStatus.severity}</p>
-                    </div>
-                    <div className="col-lg-3">                  
-                      <h4>Data size on disk</h4>
-                      <p>{humanFileSize(this.props.endpointStatus.load, 1024)}</p>
-                    </div>
+                    {!isStargate &&
+                      <div className="col-lg-3">
+                        <h4>Tokens</h4>
+                        <p><OverlayTrigger trigger="click" placement="bottom" overlay={tokens}><button type="button" className="btn btn-md btn-info" style={takeSnapshotStyle}>{this.state.tokens.length}</button></OverlayTrigger></p>
+                      </div>
+                    }
+                    {!isStargate &&
+                      <div className="col-lg-3">
+                        <h4>Status</h4>
+                        <p><button type="button" className={largeButtonStyle}>{this.props.endpointStatus.status}</button></p>
+                      </div>
+                    }
+                    {!isStargate &&
+                      <div className="col-lg-3">
+                        <h4>Severity</h4>
+                        <p>{this.props.endpointStatus.severity}</p>
+                      </div>
+                    }
+                    {!isStargate &&
+                      <div className="col-lg-3">
+                        <h4>Data size on disk</h4>
+                        <p>{humanFileSize(this.props.endpointStatus.load, 1024)}</p>
+                      </div>
+                    }
                   </div>
+                  {!isStargate &&
                   <div className="row">
                   <div className="col-lg-12">
                   <Tabs defaultActiveKey={1} id="node-tab">
@@ -355,10 +378,10 @@ const NodeStatus = CreateReactClass({
                                 </p>
                               </div>
                             }
-                            <OverlayTrigger trigger="focus" placement="bottom" overlay={takeSnapshotClick}><button type="button" className="btn btn-md btn-success" style={takeSnapshotStyle}>Take a snapshot</button></OverlayTrigger>                  
+                            <OverlayTrigger trigger="focus" placement="bottom" overlay={takeSnapshotClick}><button type="button" className="btn btn-md btn-success" style={takeSnapshotStyle}>Take a snapshot</button></OverlayTrigger>
                             <button type="button" className="btn btn-md btn-success" style={progressStyle} disabled>Taking a snapshot...</button>
                           </div>
-                          <div className="col-lg-12">&nbsp;</div> 
+                          <div className="col-lg-12">&nbsp;</div>
                             {snapshots}
                           </div>
                         </div>
@@ -367,10 +390,10 @@ const NodeStatus = CreateReactClass({
                       <Tab eventKey={6} title="Streams">
                           <Streams endpoint={this.props.endpointStatus.endpoint} clusterName={this.props.clusterName}/>
                       </Tab>
-                    </Tabs>               
+                    </Tabs>
                     </div>
                     </div>
-                  
+                  }
                 </Modal.Body>
                 <Modal.Footer>
                   <Button onClick={this.close}>Close</Button>

--- a/src/ui/app/jsx/node-status.jsx
+++ b/src/ui/app/jsx/node-status.jsx
@@ -214,9 +214,10 @@ const NodeStatus = CreateReactClass({
       let buttonStyle = "btn btn-xs btn-success";
       let largeButtonStyle = "btn btn-lg btn-static btn-success";
 
+      const isStargate = this.props.endpointStatus.type === "STARGATE";
       // If the node is a Stargate node we won't have real status for it
       // so we'll display it slightly differently
-      if (this.props.endpointStatus.stargate) {
+      if (isStargate) {
           buttonStyle = "btn btn-xs btn-info";
           largeButtonStyle = "btn btn-lg btn-static btn-info";
       // If it's not a stargate node, then we can appropriately use its status
@@ -244,7 +245,7 @@ const NodeStatus = CreateReactClass({
       const tooltip = (
         <Tooltip id="tooltip">
           <strong>{this.props.endpointStatus.endpoint}</strong>
-          {this.props.endpointStatus.stargate &&
+          {isStargate &&
             <span>&nbsp;(Stargate)</span>
           }
           &nbsp;({humanFileSize(this.props.endpointStatus.load, 1024)})

--- a/src/ui/app/jsx/repair-form.jsx
+++ b/src/ui/app/jsx/repair-form.jsx
@@ -25,6 +25,7 @@ import Moment from 'moment';
 import moment from "moment";
 import Modal from 'react-bootstrap/lib/Modal';
 import Button from 'react-bootstrap/lib/Button';
+import {getNodeOptions} from "../node-utils";
 
 Moment.locale(navigator.language);
 
@@ -164,55 +165,8 @@ const repairForm = CreateReactClass({
     });
   },
 
-  /**
-   * Utility method for digging through the endpointStates API response structure
-   * to identify all of the possible nodes
-   *
-   * @returns An array of node/endpoint object
-   * @private
-   */
-  _getNodes: function() {
-    const nodes = [];
-    for(let endpointState of this.state.clusterStatus.nodes_status.endpointStates) {
-      if (!endpointState || !endpointState.endpoints) {
-        continue;
-      }
-      for (let datacenterId in endpointState.endpoints) {
-        const datacenter = endpointState.endpoints[datacenterId];
-        if (!datacenter) {
-          continue;
-        }
-        for (let rackId in datacenter) {
-          const rack = datacenter[rackId];
-          if (!rack) {
-            continue;
-          }
-          for (let endpoint of rack) {
-            if (endpoint) {
-              nodes.push(endpoint);
-            }
-          }
-        }
-      }
-    }
-    return nodes;
-  },
-
   _getNodeOptions: function() {
-    let nodes = this._getNodes();
-    if (!nodes) {
-      this.setState({
-        nodeOptions: []
-      });
-      return;
-    }
-    // We should not return Stargate nodes as options, filter them out
-    const nonStargateNodes = nodes.filter(node => node.type !== "STARGATE")
-    this.setState({
-      nodeOptions: nonStargateNodes.map(node => node.endpoint).sort().map(
-          obj => { return {value: obj, label: obj}; }
-      )
-    });
+    this.setState(getNodeOptions(this.state.clusterStatus.nodes_status.endpointStates, true));
   },
 
   _getKeyspaceOptions: function() {

--- a/src/ui/app/node-utils.js
+++ b/src/ui/app/node-utils.js
@@ -1,0 +1,60 @@
+/**
+ * Utility method for digging through the endpointStates API response structure
+ * to identify the possible nodes
+ *
+ * @returns An array of node/endpoint objects
+ */
+import {node} from "prop-types";
+
+export const getNodesFromEndpointStates = function(endpointStates) {
+  const nodes = [];
+  if (!endpointStates || !endpointStates.length) {
+    return nodes;
+  }
+
+  for(let endpointState of endpointStates) {
+    if (!endpointState || !endpointState.endpoints) {
+      continue;
+    }
+    for (let datacenterId in endpointState.endpoints) {
+      const datacenter = endpointState.endpoints[datacenterId];
+      if (!datacenter) {
+        continue;
+      }
+      for (let rackId in datacenter) {
+        const rack = datacenter[rackId];
+        if (!rack) {
+          continue;
+        }
+        for (let endpoint of rack) {
+          if (endpoint) {
+            nodes.push(endpoint);
+          }
+        }
+      }
+    }
+  }
+  return nodes;
+}
+
+/**
+ * Utility function for generating a set of options for a select representing a drop down of nodes.
+ * If excludeStargateNodes is true stargate nodes will not be included in the set of options generated.
+ * @param endpointStates
+ * @param excludeStargateNodes
+ * @returns {{nodeOptions: {label: *, value: *}[]}|{nodeOptions: *[]}}
+ */
+export const getNodeOptions = function(endpointStates, excludeStargateNodes) {
+  let nodes = getNodesFromEndpointStates(endpointStates);
+  if (!nodes) {
+    return {
+      nodeOptions: []
+    }
+  }
+  const includedNodes = excludeStargateNodes ? nodes.filter(node => node.type !== "STARGATE") : nodes;
+  return {
+    nodeOptions: includedNodes.map(node => node.endpoint).sort().map(
+      obj => { return {value: obj, label: obj}; }
+    )
+  };
+}

--- a/src/ui/app/node-utils.js
+++ b/src/ui/app/node-utils.js
@@ -1,10 +1,22 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 /**
  * Utility method for digging through the endpointStates API response structure
  * to identify the possible nodes
  *
+ * @param endpointStates - Array
  * @returns An array of node/endpoint objects
  */
-import {node} from "prop-types";
 
 export const getNodesFromEndpointStates = function(endpointStates) {
   const nodes = [];
@@ -40,9 +52,10 @@ export const getNodesFromEndpointStates = function(endpointStates) {
 /**
  * Utility function for generating a set of options for a select representing a drop down of nodes.
  * If excludeStargateNodes is true stargate nodes will not be included in the set of options generated.
- * @param endpointStates
- * @param excludeStargateNodes
- * @returns {{nodeOptions: {label: *, value: *}[]}|{nodeOptions: *[]}}
+ *
+ * @param endpointStates - Array
+ * @param excludeStargateNodes - Boolean
+ * @returns An object suitable for passing to Select component
  */
 export const getNodeOptions = function(endpointStates, excludeStargateNodes) {
   let nodes = getNodesFromEndpointStates(endpointStates);


### PR DESCRIPTION
Add the ability to identify stargate nodes and distinguish them in the UI.
* Updates the `cluster/{name}` endpoint response to include a new `type` property, will either be `CASSANDRA` or `STARGATE`

```json
{
   "name":"stargate",
   "jmx_username":"",
   "jmx_password_is_set":false,
   "seed_hosts":[
      "127.0.0.2",
      "127.0.0.1"
   ],
   "repair_runs":[
      
   ],
   "repair_schedules":[
      
   ],
   "nodes_status":{
      "endpointStates":[
         {
            "sourceNode":"127.0.0.1",
            "endpoints":{
               "datacenter1":{
                  "rack1":[
                     {
                        "endpoint":"127.0.0.2",
                        "hostId":"bed76ae4-10c4-4f3b-af4b-e245011dbcc3",
                        "dc":"datacenter1",
                        "rack":"rack1",
                        "status":"Not available",
                        "severity":0.0,
                        "releaseVersion":"4.0.3",
                        "tokens":"",
                        "load":105498.0,
                        "type":"STARGATE"
                     },
                     {
                        "endpoint":"127.0.0.1",
                        "hostId":"8de68c6a-55e4-46ef-8be2-ccca39a9e9e1",
                        "dc":"datacenter1",
                        "rack":"rack1",
                        "status":"NORMAL - UP",
                        "severity":0.0,
                        "releaseVersion":"4.0.3",
                        "tokens":"18",
                        "load":93656.0,
                        "type":"CASSANDRA"
                     }
                  ]
               }
            },
            "totalLoad":199154.0,
            "endpointNames":[
               "127.0.0.2",
               "127.0.0.1"
            ]
         }
      ]
   }
}
```

* Updated the cluster visualization to display Stargate nodes differently from Cassandra nodes - Stargate nodes now appear in clue with a note on their tooltip

![image](https://user-images.githubusercontent.com/7901615/160220414-db75d3aa-9e9d-467e-939e-e95bc3e6bc2b.png)

* Updated the node status visualization to hide details that will not be available for Stargate nodes, also added the `(Stargate)` label to the modal title as well as a display field called `Node Type` which will either be `Cassandra` or `Stargate`

<img width="760" alt="image" src="https://user-images.githubusercontent.com/7901615/160296907-4f1fb56c-bb3d-44d8-9b12-290a20a1d13e.png">

* Stargate nodes will also be excluded from `Node` select options when creating repairs/schedules.

Fixes #1145 