### PR TITLE
Restructure table cell contents to allow wrapping

### DIFF
--- a/src/ui/app/jsx/mixin.jsx
+++ b/src/ui/app/jsx/mixin.jsx
@@ -103,16 +103,12 @@ export const DeleteStatusMessageMixin = {
 export const CFsListRender = CreateReactClass({
   render: function() {
     return (
-      <div>
-        <div>
-          <p>
-            {
-              this.props.list.map(function(listValue) {
-                return (<span className="text-span-label" key={listValue}>{listValue}</span>);
-              })
-            }
-          </p>
-        </div>
+      <div style={{display: "flex", flexWrap: "wrap"}}>
+        {
+          this.props.list.map(function(listValue) {
+            return (<span className="text-span-label" key={listValue}>{listValue}</span>);
+          })
+        }
       </div>
     )
   }


### PR DESCRIPTION
Restructure the contents of the Table/Blacklist cells in the Schedule table to allow for better wrapping of long lists of tables.

Fixes #1183

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/7901615/161191769-8e93d68c-3866-416f-b618-38c601e13c07.png">

<img width="852" alt="image" src="https://user-images.githubusercontent.com/7901615/161191806-b45ab9f4-f496-48a2-8139-ab94979e4ec2.png">
