### PR TITLE
Removing references to queryOptions from the Docs

### DIFF
--- a/src/docs/content/docs/backends/cassandra.md
+++ b/src/docs/content/docs/backends/cassandra.md
@@ -15,9 +15,6 @@ cassandra:
   clusterName: "test"
   contactPoints: ["127.0.0.1"]
   keyspace: reaper_db
-  queryOptions:
-    consistencyLevel: LOCAL_QUORUM
-    serialConsistencyLevel: SERIAL
 ```
 
 If you're using authentication or SSL:

--- a/src/docs/content/docs/configuration/backend_specific.md
+++ b/src/docs/content/docs/configuration/backend_specific.md
@@ -146,10 +146,6 @@ loadBalancingPolicy:
   type:
 speculativeExecutionPolicy:
   type:
-queryOptions:
-  consistencyLevel:
-  serialConsistencyLevel:
-  fetchSize:
 socketOptions:
   connectTimeoutMillis:
   readTimeoutMillis:


### PR DESCRIPTION
Resolves #1005 by simply removing the references from the documentation. I'm assuming this is the preferred approach since it seems the code to override any passed in parameters was added 5 years ago. 