### PR TITLE
Don't exit reaper if endpointToRange is empty and segment count 0

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -182,6 +182,9 @@ public final class RepairRunService {
 
     } catch (ReaperException e) {
       LOG.warn("couldn't connect to any host: {}, life sucks...", targetCluster.getSeedHosts(), e);
+    } catch (IllegalArgumentException e) {
+      LOG.error("Couldn't get endpoints for tokens");
+      throw new ReaperException("Couldn't get endpoints for tokens", e);
     }
 
     if (segments.isEmpty() && !repairUnit.getIncrementalRepair()) {


### PR DESCRIPTION
We have seen reaper exiting dueing this condition and this turns
it into a reaper exception instead of hitting the assertion in
computeGlobalSegmentCount.

