### PR TITLE
Avoid exiting the JVM in SchedulingManager on database errors

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -126,7 +126,7 @@ public final class SchedulingManager extends TimerTask {
         LOG.error("Error while scheduling repairs due to a connection problem with the database", e);
       } catch (Throwable ex) {
         if (lastId == null) {
-          LOG.error("Failed to managing repair schedules", ex);
+          LOG.error("Failed managing repair schedules", ex);
         } else {
           LOG.error("Failed to managing repair schedule with id '{}'", lastId, ex);
         }

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -128,7 +128,7 @@ public final class SchedulingManager extends TimerTask {
         if (lastId == null) {
           LOG.error("Failed managing repair schedules", ex);
         } else {
-          LOG.error("Failed to managing repair schedule with id '{}'", lastId, ex);
+          LOG.error("Failed managing repair schedule with id '{}'", lastId, ex);
         }
         try {
           assert false : "if assertions are enabled then exit the jvm";

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -34,6 +34,7 @@ import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.DriverInternalError;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
@@ -121,9 +122,14 @@ public final class SchedulingManager extends TimerTask {
         }
       } catch (DriverInternalError expected) {
         LOG.debug("Driver connection closed, Reaper is shutting down.");
+      } catch (DriverException e) {
+        LOG.error("Error while scheduling repairs due to a connection problem with the database", e);
       } catch (Throwable ex) {
-        LOG.error("failed managing schedule for run with id: {}", lastId);
-        LOG.error("catch exception", ex);
+        if (lastId == null) {
+          LOG.error("Failed to managing repair schedules", ex);
+        } else {
+          LOG.error("Failed to managing repair schedule with id '{}'", lastId, ex);
+        }
         try {
           assert false : "if assertions are enabled then exit the jvm";
         } catch (AssertionError ae) {


### PR DESCRIPTION
Fixes #989

The scheduling manager exits the JVM if there's an uncaught exception and assertions are enabled (which is the default in production mode).
While it's good to be aware that the scheduler is having troubles, it's a bit too sensitive as this behavior will trigger for any communication error with the database.
In this PR, I'm keeping the exit jvm behavior but catch all driver related exceptions and log them without exiting.