### PR TITLE
Cleanup schedule related metrics on a regular basis

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -39,6 +39,7 @@ import static io.cassandrareaper.metrics.MetricNameUtils.cleanName;
 
 public final class RepairScheduleService {
 
+  public static final String MILLIS_SINCE_LAST_REPAIR_METRIC_NAME = "millisSinceLastRepairForSchedule";
   private final AppContext context;
   private final RepairUnitService repairUnitService;
 
@@ -143,7 +144,7 @@ public final class RepairScheduleService {
   private void registerScheduleMetrics(UUID repairScheduleId) {
     RepairSchedule schedule = context.storage.getRepairSchedule(repairScheduleId).get();
     RepairUnit repairUnit = context.storage.getRepairUnit(schedule.getRepairUnitId());
-    String metricName = metricName("millisSinceLastRepairForSchedule",
+    String metricName = metricName(MILLIS_SINCE_LAST_REPAIR_METRIC_NAME,
             repairUnit.getClusterName(),
             repairUnit.getKeyspaceName(),
             schedule.getId());
@@ -157,7 +158,7 @@ public final class RepairScheduleService {
     Optional<RepairSchedule> schedule = context.storage.getRepairSchedule(repairScheduleId);
     schedule.ifPresent(sched -> {
       RepairUnit repairUnit = context.storage.getRepairUnit(sched.getRepairUnitId());
-      String metricName = metricName("millisSinceLastRepairForSchedule",
+      String metricName = metricName(MILLIS_SINCE_LAST_REPAIR_METRIC_NAME,
           repairUnit.getClusterName(),
           repairUnit.getKeyspaceName(),
           sched.getId());


### PR DESCRIPTION
fixes #1211 

This PR implements a cleanup of the metrics registry for `millisSinceLastRepairForSchedule.*.*.*` metrics which have no corresponding schedule.
This can happen if multiple Reaper instances exist and on deletes a repair schedule. As the entry disappears from the database, other Reaper instances will keep the metric in memory until the next restart.