### PR TITLE
Add reference for custom shiro.ini

### DIFF
--- a/src/docs/content/docs/configuration/authentication.md
+++ b/src/docs/content/docs/configuration/authentication.md
@@ -39,6 +39,7 @@ user2 = password2
 
 …
 ```
+If you use a container, make sure you set the environment variable `REAPER_SHIRO_INI` to a valid path inside the container otherwise your custom shiro.ini will not be used.
 
 ## With encrypted passwords
 


### PR DESCRIPTION
In the documentation for the authentication via the shiro.ini is missing the hint that you have to pass the env variable REAPER_SHIRO_INI to your container, so that the custom config is also used. This cost me unnecessary time to look into the code: https://github.com/thelastpickle/cassandra-reaper/blob/master/src/server/src/main/docker/configure-webui-authentication.sh#L20-L26
Maybe it will save someone else time.