### PR TITLE
Updated the registry clusters entrypoint to support the use of custom username and password combinations

### DIFF
--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -87,8 +87,22 @@ if [ "$1" = 'register-clusters' ]; then
     REAPER_PORT=$4
   fi
 
+  if [ -z "$REAPER_AUTH_USER" ]; then
+    echo "The register-clusters command did not find a value for the REAPER_AUTH_USER environment variable. Defaulting to the admin user."
+    USERNAME="admin"
+  else
+    USERNAME=$REAPER_AUTH_USER
+  fi
+
+if [ -z "$REAPER_AUTH_PASSWORD" ]; then
+    echo "The register-clusters command did not find a value for the REAPER_AUTH_PASSWORD environment variable. Defaulting to the default admin password."
+    PASSWORD="admin"
+  else
+    PASSWORD=$REAPER_AUTH_PASSWORD
+  fi
+
   mkdir -p ~/.reaper
-  echo "admin" > ~/.reaper/credentials
+  echo ${PASSWORD} > ~/.reaper/credentials
 
   wait_for ${REAPER_HOST} ${REAPER_PORT}
 
@@ -96,7 +110,7 @@ if [ "$1" = 'register-clusters' ]; then
     SEED_HOST=$(echo ${SEED} | cut -d':' -f1)
     SEED_PORT=$(echo ${SEED} | cut -d':' -f2)
     wait_for ${SEED_HOST} ${SEED_PORT}
-    /usr/local/bin/spreaper login --reaper-host "${REAPER_HOST}" --reaper-port "${REAPER_PORT}" admin
+    /usr/local/bin/spreaper login --reaper-host "${REAPER_HOST}" --reaper-port "${REAPER_PORT}" $USERNAME
     /usr/local/bin/spreaper add-cluster --reaper-host "${REAPER_HOST}" --reaper-port "${REAPER_PORT}" "${SEED_HOST}" "${SEED_PORT}"
   done
 


### PR DESCRIPTION
The current implementation of the register clusters entrypoint sets the password to "admin" in the credentials file and fails on authentication if any other username/password combination is used. This value is picked up by the get_password method in the spreaper, as this finds the value in the file, and thus attempts authentication with this hard coded value.

This PR maintains the default support for the default username and password while allowing those who change the username/password for the Cassandra Reaper to also use these via environment variable (REAPER_AUTH_USER and REAPER_AUTH_PASSWORD).

This would enable more flexible use of this register-cluster method while allowing better security though stronger credentials in its usage.