### PR TITLE
Topology change resilience for incremental repair

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -44,7 +44,7 @@ public final class RepairSegment {
   private final DateTime startTime;
   private final DateTime endTime;
   private final Map<String, String> replicas;
-  private final UUID hostID;
+  private final UUID hostID; // This field is only ever populated for incremental repairs. For full repairs it is always null.
 
 
   private RepairSegment(Builder builder, @Nullable UUID id) {

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -44,6 +44,8 @@ public final class RepairSegment {
   private final DateTime startTime;
   private final DateTime endTime;
   private final Map<String, String> replicas;
+  private final UUID hostID;
+
 
   private RepairSegment(Builder builder, @Nullable UUID id) {
     this.id = id;
@@ -58,6 +60,7 @@ public final class RepairSegment {
     this.replicas = builder.replicas != null
         ? ImmutableMap.copyOf(builder.replicas)
         : null;
+    this.hostID = builder.hostID;
   }
 
   public static Builder builder(Segment tokenRange, UUID repairUnitId) {
@@ -129,6 +132,10 @@ public final class RepairSegment {
     return null != endTime;
   }
 
+  public UUID getHostID() {
+    return hostID;
+  }
+
   /** Reset to NOT_STARTED state, with nulled startTime and endTime. */
   public Builder reset() {
     Builder builder = new Builder(this);
@@ -159,6 +166,7 @@ public final class RepairSegment {
     private DateTime startTime;
     private DateTime endTime;
     private Map<String, String> replicas;
+    private UUID hostID;
 
     private Builder() {}
 
@@ -170,6 +178,7 @@ public final class RepairSegment {
       this.failCount = 0;
       this.state = State.NOT_STARTED;
       this.replicas = tokenRange.getReplicas();
+      this.hostID = hostID;
     }
 
     private Builder(RepairSegment original) {
@@ -183,6 +192,7 @@ public final class RepairSegment {
       startTime = original.startTime;
       endTime = original.endTime;
       replicas = original.replicas;
+      hostID = original.hostID;
     }
 
     public Builder withRunId(UUID runId) {
@@ -241,6 +251,12 @@ public final class RepairSegment {
       this.replicas = replicas;
       return this;
     }
+
+    public Builder withHostID(UUID hostID) {
+      this.hostID = hostID;
+      return this;
+    }
+
 
     public RepairSegment build() {
       // a null segmentId is a special case where the storage uses a sequence for it

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -44,7 +44,8 @@ public final class RepairSegment {
   private final DateTime startTime;
   private final DateTime endTime;
   private final Map<String, String> replicas;
-  private final UUID hostID; // This field is only ever populated for incremental repairs. For full repairs it is always null.
+  // hostID field is only ever populated for incremental repairs. For full repairs it is always null.
+  private final UUID hostID;
 
 
   private RepairSegment(Builder builder, @Nullable UUID id) {

--- a/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/core/RepairSegment.java
@@ -178,7 +178,7 @@ public final class RepairSegment {
       this.failCount = 0;
       this.state = State.NOT_STARTED;
       this.replicas = tokenRange.getReplicas();
-      this.hostID = hostID;
+      this.hostID = null;
     }
 
     private Builder(RepairSegment original) {

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -30,8 +30,17 @@ import io.cassandrareaper.jmx.EndpointSnitchInfoProxy;
 import io.cassandrareaper.jmx.JmxProxy;
 
 import java.math.BigInteger;
-import java.util.*;
+
+import java.util.Arrays;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -331,7 +340,7 @@ public final class RepairRunService {
       Cluster cluster,
       ClusterFacade clusterFacade) throws ReaperException {
 
-    Map<String, String> endpointHostIDMap = clusterFacade.getEndpointToHostId(cluster);
+    Map<String, String> endpointHostIdMap = clusterFacade.getEndpointToHostId(cluster);
 
     List<RepairSegment.Builder> repairSegmentBuilders = Lists.newArrayList();
 
@@ -347,10 +356,8 @@ public final class RepairRunService {
                             repairUnit.getId())
                         .withReplicas(Collections.emptyMap())
                         .withCoordinatorHost(range.getKey())
-                        .withHostID(UUID.fromString(endpointHostIDMap.get(range.getKey())))
-                )
-        );
-
+                        .withHostID(UUID.fromString(endpointHostIdMap.get(range.getKey())))
+                ));
     return repairSegmentBuilders;
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -353,10 +353,8 @@ public final class RepairRunService {
                       .build(),
                   repairUnit.getId())
               .withReplicas(Collections.emptyMap())
-              .withCoordinatorHost(range.getKey());
-          if (repairUnit.getIncrementalRepair()) {
-            segment.withHostID(UUID.fromString(endpointHostIdMap.get(range.getKey())));
-          }
+              .withCoordinatorHost(range.getKey())
+              .withHostID(UUID.fromString(endpointHostIdMap.get(range.getKey())));
           repairSegmentBuilders.add(segment);
         });
     return repairSegmentBuilders;

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -346,18 +346,19 @@ public final class RepairRunService {
 
     nodes
         .entrySet()
-        .forEach(
-            range ->
-                repairSegmentBuilders.add(
-                    RepairSegment.builder(
-                            Segment.builder()
-                                .withTokenRanges(Arrays.asList(range.getValue()))
-                                .build(),
-                            repairUnit.getId())
-                        .withReplicas(Collections.emptyMap())
-                        .withCoordinatorHost(range.getKey())
-                        .withHostID(UUID.fromString(endpointHostIdMap.get(range.getKey())))
-                ));
+        .forEach(range -> {
+          RepairSegment.Builder segment = RepairSegment.builder(
+                  Segment.builder()
+                      .withTokenRanges(Arrays.asList(range.getValue()))
+                      .build(),
+                  repairUnit.getId())
+              .withReplicas(Collections.emptyMap())
+              .withCoordinatorHost(range.getKey());
+          if (repairUnit.getIncrementalRepair()) {
+            segment.withHostID(UUID.fromString(endpointHostIdMap.get(range.getKey())));
+          }
+          repairSegmentBuilders.add(segment);
+        });
     return repairSegmentBuilders;
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -483,11 +483,6 @@ final class RepairRunner implements Runnable {
       } else {
         potentialReplicas = potentialReplicaMap.keySet();
       }
-      if (potentialReplicas.size() < 1) {
-        throw new ReaperException(
-            String.format("No potential replicas found for segment ID %s", segment.getId().toString())
-        );
-      }
       JmxProxy coordinator = clusterFacade.connect(cluster, potentialReplicas);
       if (nodesReadyForNewRepair(coordinator, segment, potentialReplicaMap, repairRunId)) {
         nextRepairSegment = Optional.of(segment);

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -471,7 +471,7 @@ final class RepairRunner implements Runnable {
         UUID segmentHostID = segment.getHostID();
         if (segmentHostID == null) {
           throw new ReaperException(
-            String.format("No host ID for repair segment %s", segment.getId())
+            String.format("No host ID for repair segment %s", segment.getId().toString())
           );
         }
         for (Entry<String, String> e : endpointHostIdMap.entrySet()) {
@@ -485,7 +485,7 @@ final class RepairRunner implements Runnable {
       }
       if (potentialReplicas.size() < 1) {
         throw new ReaperException(
-            String.format("No potential replicas found for segment ID %s", segment.getId())
+            String.format("No potential replicas found for segment ID %s", segment.getId().toString())
         );
       }
       JmxProxy coordinator = clusterFacade.connect(cluster, potentialReplicas);

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -475,8 +475,8 @@ final class RepairRunner implements Runnable {
           );
         }
         for (Entry<String, String> e : endpointHostIdMap.entrySet()) {
-          if (segmentHostID.toString() == e.getValue()) {
-            potentialReplicas = Collections.singletonList(e.getKey());
+          if (segmentHostID.toString().equals(e.getValue())) {
+            potentialReplicas.add(e.getKey());
             break;
           }
         }

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -466,10 +466,10 @@ final class RepairRunner implements Runnable {
     for (RepairSegment segment : nextRepairSegments) {
       Map<String, String> potentialReplicaMap = this.repairRunService.getDCsByNodeForRepairSegment(
           cluster, segment.getTokenRange(), repairUnit.getKeyspaceName(), repairUnit);
-      Map<String, String> endpointHostIDMap = clusterFacade.getEndpointToHostId(cluster);
+      Map<String, String> endpointHostIdMap = clusterFacade.getEndpointToHostId(cluster);
       String segmentHostID = segment.getHostID().toString();
       if (repairUnit.getIncrementalRepair()) {
-        for (Entry<String, String> e : endpointHostIDMap.entrySet()) {
+        for (Entry<String, String> e : endpointHostIdMap.entrySet()) {
           if (segmentHostID == e.getValue()) {
             potentialReplicas = Collections.singletonList(e.getKey());
             break;

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -466,8 +466,8 @@ final class RepairRunner implements Runnable {
     for (RepairSegment segment : nextRepairSegments) {
       Map<String, String> potentialReplicaMap = this.repairRunService.getDCsByNodeForRepairSegment(
           cluster, segment.getTokenRange(), repairUnit.getKeyspaceName(), repairUnit);
-      Map<String, String> endpointHostIdMap = clusterFacade.getEndpointToHostId(cluster);
       if (repairUnit.getIncrementalRepair()) {
+        Map<String, String> endpointHostIdMap = clusterFacade.getEndpointToHostId(cluster);
         UUID segmentHostID = segment.getHostID();
         if (segmentHostID == null) {
           throw new ReaperException(

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -478,7 +478,7 @@ final class RepairRunner implements Runnable {
       } else {
         potentialReplicas.addAll(potentialReplicaMap.keySet());
       }
-      LOG.info("Potential replicas for segment {}: {}", segment.getId(), potentialReplicas);
+      LOG.debug("Potential replicas for segment {}: {}", segment.getId(), potentialReplicas);
       JmxProxy coordinator = clusterFacade.connect(cluster, potentialReplicas);
       if (nodesReadyForNewRepair(coordinator, segment, potentialReplicaMap, repairRunId)) {
         nextRepairSegment = Optional.of(segment);
@@ -543,7 +543,7 @@ final class RepairRunner implements Runnable {
       UUID segmentId) {
 
     Collection<String> nodes = getNodesInvolvedInSegment(dcByNode);
-    LOG.info("Nodes involved in segment {}: {}", segmentId, nodes);
+    LOG.debug("Nodes involved in segment {}: {}", segmentId, nodes);
     String dc = EndpointSnitchInfoProxy.create(coordinator).getDataCenter();
     boolean requireAllHostMetrics = DatacenterAvailability.LOCAL != context.config.getDatacenterAvailability();
     boolean allLocalDcHostsChecked = true;
@@ -588,7 +588,7 @@ final class RepairRunner implements Runnable {
       LOG.debug("Ok to repair segment '{}' on repair run with id '{}'", segment.getId(), segment.getRunId());
       return true;
     } else {
-      LOG.info("Couldn't get metrics for hosts {}, will retry later", unreachableNodes);LOG.info("Couldn't get metrics for hosts {}, will retry later", unreachableNodes);
+      LOG.debug("Couldn't get metrics for hosts {}, will retry later", unreachableNodes);
       String msg = String.format(
           "Postponed repair segment %s on repair run with id %s because we couldn't get %shosts metrics on %s",
           segment.getId(),

--- a/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/CassandraStorage.java
@@ -1237,6 +1237,10 @@ public final class CassandraStorage implements IStorage, IDistributedStorage {
       builder = builder.withReplicas(segmentRow.getMap("replicas", String.class, String.class));
     }
 
+    if (null != segmentRow.getUUID("host_id")) {
+      builder = builder.withHostID(segmentRow.getUUID("host_id"));
+    }
+
     return builder.withId(segmentRow.getUUID("segment_id")).build();
   }
 

--- a/src/server/src/main/resources/db/cassandra/031_add_hostID.cql
+++ b/src/server/src/main/resources/db/cassandra/031_add_hostID.cql
@@ -1,0 +1,18 @@
+--
+--  Copyright 2021-2021 Datastax inc.
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+-- Store the percent unrepaired threshold to trigger incremental repair schedules
+
+ALTER TABLE repair_run ADD host_id uuid;

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -495,6 +495,12 @@ public final class RepairRunServiceTest {
         .thenReturn((Map)ImmutableMap.of(Lists.newArrayList("0", "100"), Lists.newArrayList(NODES)));
     when(clusterFacade.getCassandraVersion(any())).thenReturn("3.11.6");
     when(clusterFacade.getTokens(any())).thenReturn(TOKENS);
+    when(clusterFacade.getEndpointToHostId(any(Cluster.class))).thenReturn(Collections.emptyMap());
+    Map<String, String> endpointToHostIDMap = new HashMap<String, String>();
+    endpointToHostIDMap.put("127.0.0.1", UUID.randomUUID().toString());
+    endpointToHostIDMap.put("127.0.0.2", UUID.randomUUID().toString());
+    endpointToHostIDMap.put("127.0.0.3", UUID.randomUUID().toString());
+    when(clusterFacade.getEndpointToHostId(any(Cluster.class))).thenReturn(endpointToHostIDMap);
 
     RepairRunService repairRunService = RepairRunService.create(context, () -> clusterFacade);
 

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -667,7 +667,7 @@ public final class RepairRunServiceTest {
         .timeout(segmentTimeout).build(UUIDs.timeBased());
 
     List<RepairSegment.Builder> segmentBuilders
-        = RepairRunService.createRepairSegmentsForIncrementalRepair(nodes, repairUnit);
+        = RepairRunService.createRepairSegmentsForIncrementalRepair(nodes, repairUnit, cluster);
     assertEquals("Not enough segment builders were created", 2, segmentBuilders.size());
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -129,6 +129,7 @@ public final class RepairRunnerTest {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:methodlength")
   public void testHangingRepair() throws InterruptedException, ReaperException, JMException, IOException {
     final String ksName = "reaper";
     final Set<String> cfNames = Sets.newHashSet("reaper");

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -997,7 +997,10 @@ public final class RepairRunnerTest {
                     Segment.builder()
                         .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
                         .withReplicas(nodeMap)
-                        .build(), cf)));
+                        .build(), cf)
+                    .withHostID(hostID)
+            )
+    );
   }
 
   @Test
@@ -1153,7 +1156,7 @@ public final class RepairRunnerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // The repair run should succeed despite the topology change.
-    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+    await().with().atMost(60, TimeUnit.SECONDS).until(() -> {
       return RepairRun.RunState.DONE == storage.getRepairRun(runId).get().getRunState();
     });
   }


### PR DESCRIPTION
Ensure that, in an incremental repair, the replica list is updated on every repair run. This addresses cases where the node IPs change.

Fixes https://github.com/thelastpickle/cassandra-reaper/issues/1213