### PR TITLE
Add GH project automation

### DIFF
--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020-2020 The Last Pickle Ltd
+# Copyright 2022-2022 DataStax, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,21 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+name: Add issues to GH project
 
 on:
-  issues: {types: opened}
+  issues:
+    types:
+      - opened
 
 jobs:
-  apply-label:
+  add-to-project:
+    name: Add issue to GH project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@0.9.0
+      - uses: actions/add-to-project@v0.3.0
         with:
-          github-token: ${{secrets.MY_GITHUB_TOKEN}}
-          script: |
-            github.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['new']
-            })
+          project-url: https://github.com/orgs/k8ssandra/projects/8
+          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}

--- a/.github/workflows/check_pr_linked_issue.yaml
+++ b/.github/workflows/check_pr_linked_issue.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022-2022 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check_pull_requests:
+    runs-on: ubuntu-latest
+    name: Check linked issues
+    steps:
+      - uses: nearform/github-action-check-linked-issues@v1
+        continue-on-error: true
+        id: check-linked-issues
+        with:
+          exclude-branches: "dependabot/**"
+          comment: true


### PR DESCRIPTION
Add GHA workflows to add new issues to the k8ssandra project board, and check that open PRs have a linked issue.