### PR TITLE
Allow for OPTIONS requests to be passed through auth filters

### DIFF
--- a/src/server/src/main/docker/shiro.ini
+++ b/src/server/src/main/docker/shiro.ini
@@ -16,6 +16,17 @@
 #  by default it is not used. see cassandra-reaper.yaml
 
 [main]
+sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
+sessionManager.sessionIdCookieEnabled = true
+sessionManager.sessionIdCookie.secure = true
+sessionManager.sessionIdCookie.sameSite = NONE
+securityManager.sessionManager = $sessionManager
+
+rememberMeManager = org.apache.shiro.web.mgt.CookieRememberMeManager
+rememberMeManager.cookie.secure = true
+rememberMeManager.cookie.sameSite = NONE
+securityManager.rememberMeManager = $rememberMeManager
+
 authc = org.apache.shiro.web.filter.authc.PassThruAuthenticationFilter
 authc.loginUrl = /webui/login.html
 

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -32,7 +32,6 @@ import io.cassandrareaper.resources.ClusterResource;
 import io.cassandrareaper.resources.CryptoResource;
 import io.cassandrareaper.resources.DiagEventSseResource;
 import io.cassandrareaper.resources.DiagEventSubscriptionResource;
-import io.cassandrareaper.resources.InfoResource;
 import io.cassandrareaper.resources.NodeStatsResource;
 import io.cassandrareaper.resources.PingResource;
 import io.cassandrareaper.resources.ReaperHealthCheck;
@@ -204,9 +203,6 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     LOG.info("creating resources and registering endpoints");
     final PingResource pingResource = new PingResource(healthCheck);
     environment.jersey().register(pingResource);
-
-    final InfoResource infoResource = new InfoResource(context, healthCheck);
-    environment.jersey().register(infoResource);
 
     final ClusterResource addClusterResource = ClusterResource.create(context, cryptograph);
     environment.jersey().register(addClusterResource);

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -32,6 +32,7 @@ import io.cassandrareaper.resources.ClusterResource;
 import io.cassandrareaper.resources.CryptoResource;
 import io.cassandrareaper.resources.DiagEventSseResource;
 import io.cassandrareaper.resources.DiagEventSubscriptionResource;
+import io.cassandrareaper.resources.InfoResource;
 import io.cassandrareaper.resources.NodeStatsResource;
 import io.cassandrareaper.resources.PingResource;
 import io.cassandrareaper.resources.ReaperHealthCheck;

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -38,6 +38,7 @@ import io.cassandrareaper.resources.ReaperHealthCheck;
 import io.cassandrareaper.resources.ReaperResource;
 import io.cassandrareaper.resources.RepairRunResource;
 import io.cassandrareaper.resources.RepairScheduleResource;
+import io.cassandrareaper.resources.RequestUtils;
 import io.cassandrareaper.resources.SnapshotResource;
 import io.cassandrareaper.resources.auth.LoginResource;
 import io.cassandrareaper.resources.auth.ShiroExceptionMapper;
@@ -185,6 +186,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
         TimeUnit.SECONDS,
         maxParallelRepairs);
 
+    RequestUtils.setCorsEnabled(config.isEnableCrossOrigin());
     // Enable cross-origin requests for using external GUI applications.
     if (config.isEnableCrossOrigin() || System.getProperty("enableCrossOrigin") != null) {
       FilterRegistration.Dynamic co = environment.servlets().addFilter("crossOriginRequests", CrossOriginFilter.class);

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -189,7 +189,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     if (config.isEnableCrossOrigin() || System.getProperty("enableCrossOrigin") != null) {
       FilterRegistration.Dynamic co = environment.servlets().addFilter("crossOriginRequests", CrossOriginFilter.class);
       co.setInitParameter("allowedOrigins", "*");
-      co.setInitParameter("allowedHeaders", "X-Requested-With,Content-Type,Accept,Origin");
+      co.setInitParameter("allowedHeaders", "X-Requested-With,Content-Type,Accept,Origin,Authorization");
       co.setInitParameter("allowedMethods", "OPTIONS,GET,PUT,POST,DELETE,HEAD,PATCH");
       co.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
     }
@@ -204,8 +204,10 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     final PingResource pingResource = new PingResource(healthCheck);
     environment.jersey().register(pingResource);
 
-    final ClusterResource addClusterResource = ClusterResource.create(context, cryptograph);
+    final InfoResource infoResource = new InfoResource(context, healthCheck);
+    environment.jersey().register(infoResource);
 
+    final ClusterResource addClusterResource = ClusterResource.create(context, cryptograph);
     environment.jersey().register(addClusterResource);
     final RepairRunResource addRepairRunResource = new RepairRunResource(context);
     environment.jersey().register(addRepairRunResource);

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -24,10 +24,18 @@ import javax.ws.rs.HttpMethod;
 import com.google.common.annotations.VisibleForTesting;
 
 public final class RequestUtils {
-  public static final String ENABLE_CORS_ENV_VAR_NAME = "REAPER_ENABLE_CROSS_ORIGIN";
+  private static boolean isCorsEnabled = false;
 
   private RequestUtils() {}
 
+  public static void setCorsEnabled(boolean enabled) {
+    isCorsEnabled = enabled;
+  }
+  
+  public static boolean isCorsEnabled() {
+    return isCorsEnabled;
+  }
+  
   public static boolean isOptionsRequest(ServletRequest request) {
     if (request != null && request instanceof HttpServletRequest) {
       if (((HttpServletRequest) request).getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)) {
@@ -35,18 +43,5 @@ public final class RequestUtils {
       }
     }
     return false;
-  }
-
-  @VisibleForTesting
-  static boolean isCorsEnabled(String corsEnabledEnvVarValue) {
-    if (corsEnabledEnvVarValue != null) {
-      return Boolean.parseBoolean(corsEnabledEnvVarValue.trim().toLowerCase());
-    }
-    return false;
-  }
-
-  public static boolean isCorsEnabled() {
-    String corsEnabledEnvVarValue = System.getenv(ENABLE_CORS_ENV_VAR_NAME);
-    return isCorsEnabled(corsEnabledEnvVarValue);
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -29,11 +29,11 @@ public final class RequestUtils {
   public static void setCorsEnabled(boolean enabled) {
     isCorsEnabled = enabled;
   }
-  
+
   public static boolean isCorsEnabled() {
     return isCorsEnabled;
   }
-  
+
   public static boolean isOptionsRequest(ServletRequest request) {
     if (request != null && request instanceof HttpServletRequest) {
       if (((HttpServletRequest) request).getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)) {

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -21,8 +21,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
 
-import com.google.common.annotations.VisibleForTesting;
-
 public final class RequestUtils {
   private static boolean isCorsEnabled = false;
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -26,27 +26,9 @@ import com.google.common.annotations.VisibleForTesting;
 public final class RequestUtils {
   public static final String ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME = "ALLOW_ALL_OPTIONS_REQUESTS";
 
-  private static class RequestUtilsHelper {
-    private static final RequestUtils INSTANCE = new RequestUtils();
-  }
+  private RequestUtils() {}
 
-  private Boolean allowAllOptionsRequests;
-
-  private RequestUtils() {
-  }
-
-  public static RequestUtils getInstance() {
-    return RequestUtilsHelper.INSTANCE;
-  }
-
-  public boolean isAllowAllOptionsRequests() {
-    if (allowAllOptionsRequests == null) {
-      allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();
-    }
-    return allowAllOptionsRequests;
-  }
-
-  public boolean isOptionsRequest(ServletRequest request) {
+  public static boolean isOptionsRequest(ServletRequest request) {
     if (request != null && request instanceof HttpServletRequest) {
       if (((HttpServletRequest) request).getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)) {
         return true;
@@ -56,15 +38,15 @@ public final class RequestUtils {
   }
 
   @VisibleForTesting
-  String getAllowAllOptionsRequestsEnvironmentVariable() {
-    return System.getenv(ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME);
-  }
-
-  private boolean getAllowAllOptionsRequestsFromEnvironment() {
-    String allowAllOptionsRequestsEnvVarValue = getAllowAllOptionsRequestsEnvironmentVariable();
+  static boolean isAllowAllOptionsRequests(String allowAllOptionsRequestsEnvVarValue) {
     if (allowAllOptionsRequestsEnvVarValue != null) {
       return Boolean.parseBoolean(allowAllOptionsRequestsEnvVarValue.trim().toLowerCase());
     }
     return false;
+  }
+
+  public static boolean isAllowAllOptionsRequests() {
+    String allowAllOptionsRequestsEnvVarValue = System.getenv(ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME);
+    return isAllowAllOptionsRequests(allowAllOptionsRequestsEnvVarValue);
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -24,7 +24,7 @@ import javax.ws.rs.HttpMethod;
 import com.google.common.annotations.VisibleForTesting;
 
 public final class RequestUtils {
-  public static final String ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME = "ALLOW_ALL_OPTIONS_REQUESTS";
+  public static final String ENABLE_CORS_ENV_VAR_NAME = "REAPER_ENABLE_CROSS_ORIGIN";
 
   private RequestUtils() {}
 
@@ -38,15 +38,15 @@ public final class RequestUtils {
   }
 
   @VisibleForTesting
-  static boolean isAllowAllOptionsRequests(String allowAllOptionsRequestsEnvVarValue) {
-    if (allowAllOptionsRequestsEnvVarValue != null) {
-      return Boolean.parseBoolean(allowAllOptionsRequestsEnvVarValue.trim().toLowerCase());
+  static boolean isCorsEnabled(String corsEnabledEnvVarValue) {
+    if (corsEnabledEnvVarValue != null) {
+      return Boolean.parseBoolean(corsEnabledEnvVarValue.trim().toLowerCase());
     }
     return false;
   }
 
-  public static boolean isAllowAllOptionsRequests() {
-    String allowAllOptionsRequestsEnvVarValue = System.getenv(ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME);
-    return isAllowAllOptionsRequests(allowAllOptionsRequestsEnvVarValue);
+  public static boolean isCorsEnabled() {
+    String corsEnabledEnvVarValue = System.getenv(ENABLE_CORS_ENV_VAR_NAME);
+    return isCorsEnabled(corsEnabledEnvVarValue);
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -21,27 +21,49 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public final class RequestUtils {
   public static final String ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME = "ALLOW_ALL_OPTIONS_REQUESTS";
+
+  private static class RequestUtilsHelper {
+    private static final RequestUtils INSTANCE = new RequestUtils();
+  }
+
+  private Boolean allowAllOptionsRequests;
 
   private RequestUtils() {
   }
 
-  public static boolean getAllowAllOptionsRequestsFromEnvironment() {
-    String allowAllOptionsRequestsEnvVarValue = System.getenv(
-        ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME
-    );
-    if (allowAllOptionsRequestsEnvVarValue != null) {
-      return Boolean.parseBoolean(allowAllOptionsRequestsEnvVarValue.trim().toLowerCase());
-    }
-    return false;
+  public static RequestUtils getInstance() {
+    return RequestUtilsHelper.INSTANCE;
   }
 
-  public static boolean isOptionsRequest(ServletRequest request) {
+  public boolean isAllowAllOptionsRequests() {
+    if (allowAllOptionsRequests == null) {
+      allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();
+    }
+    return allowAllOptionsRequests;
+  }
+
+  public boolean isOptionsRequest(ServletRequest request) {
     if (request != null && request instanceof HttpServletRequest) {
       if (((HttpServletRequest) request).getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)) {
         return true;
       }
+    }
+    return false;
+  }
+
+  @VisibleForTesting
+  String getAllowAllOptionsRequestsEnvironmentVariable() {
+    return System.getenv(ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME);
+  }
+
+  private boolean getAllowAllOptionsRequestsFromEnvironment() {
+    String allowAllOptionsRequestsEnvVarValue = getAllowAllOptionsRequestsEnvironmentVariable();
+    if (allowAllOptionsRequestsEnvVarValue != null) {
+      return Boolean.parseBoolean(allowAllOptionsRequestsEnvVarValue.trim().toLowerCase());
     }
     return false;
   }

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -1,0 +1,35 @@
+package io.cassandrareaper.resources;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+
+public class RequestUtils {
+    private static final Logger log = LoggerFactory.getLogger(RequestUtils.class);
+
+    public static final String ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME = "ALLOW_ALL_OPTIONS_REQUESTS";
+
+    public static boolean getAllowAllOptionsRequestsFromEnvironment() {
+        String allowAllOptionsRequestsEnvVarValue = System.getenv(ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME);
+        if (allowAllOptionsRequestsEnvVarValue != null) {
+            try {
+                return Boolean.parseBoolean(allowAllOptionsRequestsEnvVarValue.trim().toLowerCase());
+            } catch (Exception e) {
+                log.warn("Unable to parse environment variable \"" + ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME + "\" value \"" + allowAllOptionsRequestsEnvVarValue + "\", default of false will be used.", e);
+                return false;
+            }
+        }
+        return false;
+    }
+    public static boolean isOptionsRequest(ServletRequest request) {
+        if(request != null && request instanceof HttpServletRequest){
+            if(((HttpServletRequest) request).getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)){
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -1,35 +1,48 @@
-package io.cassandrareaper.resources;
+/*
+ *
+ * Copyright 2022-2022 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+package io.cassandrareaper.resources;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
 
-public class RequestUtils {
-    private static final Logger log = LoggerFactory.getLogger(RequestUtils.class);
+public final class RequestUtils {
+  public static final String ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME = "ALLOW_ALL_OPTIONS_REQUESTS";
 
-    public static final String ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME = "ALLOW_ALL_OPTIONS_REQUESTS";
+  private RequestUtils() {
+  }
 
-    public static boolean getAllowAllOptionsRequestsFromEnvironment() {
-        String allowAllOptionsRequestsEnvVarValue = System.getenv(ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME);
-        if (allowAllOptionsRequestsEnvVarValue != null) {
-            try {
-                return Boolean.parseBoolean(allowAllOptionsRequestsEnvVarValue.trim().toLowerCase());
-            } catch (Exception e) {
-                log.warn("Unable to parse environment variable \"" + ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME + "\" value \"" + allowAllOptionsRequestsEnvVarValue + "\", default of false will be used.", e);
-                return false;
-            }
-        }
-        return false;
+  public static boolean getAllowAllOptionsRequestsFromEnvironment() {
+    String allowAllOptionsRequestsEnvVarValue = System.getenv(
+        ALLOW_ALL_OPTIONS_REQUESTS_ENV_VAR_NAME
+    );
+    if (allowAllOptionsRequestsEnvVarValue != null) {
+      return Boolean.parseBoolean(allowAllOptionsRequestsEnvVarValue.trim().toLowerCase());
     }
-    public static boolean isOptionsRequest(ServletRequest request) {
-        if(request != null && request instanceof HttpServletRequest){
-            if(((HttpServletRequest) request).getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)){
-                return true;
-            }
-        }
-        return false;
+    return false;
+  }
+
+  public static boolean isOptionsRequest(ServletRequest request) {
+    if (request != null && request instanceof HttpServletRequest) {
+      if (((HttpServletRequest) request).getMethod().equalsIgnoreCase(HttpMethod.OPTIONS)) {
+        return true;
+      }
     }
+    return false;
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
@@ -17,46 +17,48 @@
 
 package io.cassandrareaper.resources.auth;
 
-import org.apache.shiro.subject.Subject;
-import org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter;
-import org.apache.shiro.web.util.WebUtils;
+import java.io.IOException;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter;
+import org.apache.shiro.web.util.WebUtils;
 
 import static io.cassandrareaper.resources.RequestUtils.getAllowAllOptionsRequestsFromEnvironment;
 import static io.cassandrareaper.resources.RequestUtils.isOptionsRequest;
 
 public final class RestPermissionsFilter extends HttpMethodPermissionFilter {
-    private final boolean allowAllOptionsRequests;
+  private final boolean allowAllOptionsRequests;
 
-    public RestPermissionsFilter() {
-        allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();
-    }
+  public RestPermissionsFilter() {
+    allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();
+  }
 
-    @Override
-    public boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) throws IOException {
-        if (allowAllOptionsRequests && isOptionsRequest(request)) {
-            return true;
-        }
-        return super.isAccessAllowed(request, response, mappedValue);
+  @Override
+  public boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue)
+      throws IOException {
+    if (allowAllOptionsRequests && isOptionsRequest(request)) {
+      return true;
     }
+    return super.isAccessAllowed(request, response, mappedValue);
+  }
 
-    @Override
-    protected Subject getSubject(ServletRequest request, ServletResponse response) {
-        return ShiroJwtVerifyingFilter.getJwtSubject(super.getSubject(request, response), request, response);
-    }
+  @Override
+  protected Subject getSubject(ServletRequest request, ServletResponse response) {
+    return ShiroJwtVerifyingFilter.getJwtSubject(super.getSubject(request, response), request, response);
+  }
 
-    @Override
-    protected boolean onAccessDenied(ServletRequest req, ServletResponse res) throws IOException {
-        WebUtils.toHttp(res).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        WebUtils.toHttp(res).setHeader("Content-Type", "text/plain");
-        Object user = getSubject(req, res).getPrincipal();
-        String err = String.format("Unauthorized `%s` operation for user: %s.", getHttpMethodAction(req), user);
-        WebUtils.toHttp(res).getOutputStream().print(err);
-        WebUtils.toHttp(res).flushBuffer();
-        return false;
-    }
+  @Override
+  protected boolean onAccessDenied(ServletRequest req, ServletResponse res) throws IOException {
+    WebUtils.toHttp(res).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    WebUtils.toHttp(res).setHeader("Content-Type", "text/plain");
+    Object user = getSubject(req, res).getPrincipal();
+    String err = String.format("Unauthorized `%s` operation for user: %s.", getHttpMethodAction(req), user);
+    WebUtils.toHttp(res).getOutputStream().print(err);
+    WebUtils.toHttp(res).flushBuffer();
+    return false;
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
@@ -31,15 +31,10 @@ import org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter;
 import org.apache.shiro.web.util.WebUtils;
 
 public final class RestPermissionsFilter extends HttpMethodPermissionFilter {
-  private final boolean isCorsEnabled;
-
-  public RestPermissionsFilter() {
-    isCorsEnabled = RequestUtils.isCorsEnabled();
-  }
 
   @VisibleForTesting
   boolean isCorsEnabled() {
-    return isCorsEnabled;
+    return RequestUtils.isCorsEnabled();
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
@@ -17,6 +17,8 @@
 
 package io.cassandrareaper.resources.auth;
 
+import io.cassandrareaper.resources.RequestUtils;
+
 import java.io.IOException;
 
 import javax.servlet.ServletRequest;
@@ -27,20 +29,17 @@ import org.apache.shiro.subject.Subject;
 import org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter;
 import org.apache.shiro.web.util.WebUtils;
 
-import static io.cassandrareaper.resources.RequestUtils.getAllowAllOptionsRequestsFromEnvironment;
-import static io.cassandrareaper.resources.RequestUtils.isOptionsRequest;
-
 public final class RestPermissionsFilter extends HttpMethodPermissionFilter {
   private final boolean allowAllOptionsRequests;
 
   public RestPermissionsFilter() {
-    allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();
+    allowAllOptionsRequests = RequestUtils.getInstance().isAllowAllOptionsRequests();
   }
 
   @Override
   public boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue)
       throws IOException {
-    if (allowAllOptionsRequests && isOptionsRequest(request)) {
+    if (allowAllOptionsRequests && RequestUtils.getInstance().isOptionsRequest(request)) {
       return true;
     }
     return super.isAccessAllowed(request, response, mappedValue);

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
@@ -17,32 +17,46 @@
 
 package io.cassandrareaper.resources.auth;
 
-import java.io.IOException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter;
 import org.apache.shiro.web.util.WebUtils;
 
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static io.cassandrareaper.resources.RequestUtils.getAllowAllOptionsRequestsFromEnvironment;
+import static io.cassandrareaper.resources.RequestUtils.isOptionsRequest;
+
 public final class RestPermissionsFilter extends HttpMethodPermissionFilter {
+    private final boolean allowAllOptionsRequests;
 
-  public RestPermissionsFilter() {}
+    public RestPermissionsFilter() {
+        allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();
+    }
 
-  @Override
-  protected Subject getSubject(ServletRequest request, ServletResponse response) {
-    return ShiroJwtVerifyingFilter.getJwtSubject(super.getSubject(request, response), request, response);
-  }
+    @Override
+    public boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) throws IOException {
+        if (allowAllOptionsRequests && isOptionsRequest(request)) {
+            return true;
+        }
+        return super.isAccessAllowed(request, response, mappedValue);
+    }
 
-  @Override
-  protected boolean onAccessDenied(ServletRequest req, ServletResponse res) throws IOException {
-    WebUtils.toHttp(res).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-    WebUtils.toHttp(res).setHeader("Content-Type", "text/plain");
-    Object user = getSubject(req, res).getPrincipal();
-    String err = String.format("Unauthorized `%s` operation for user: %s.", getHttpMethodAction(req), user);
-    WebUtils.toHttp(res).getOutputStream().print(err);
-    WebUtils.toHttp(res).flushBuffer();
-    return false;
-  }
+    @Override
+    protected Subject getSubject(ServletRequest request, ServletResponse response) {
+        return ShiroJwtVerifyingFilter.getJwtSubject(super.getSubject(request, response), request, response);
+    }
+
+    @Override
+    protected boolean onAccessDenied(ServletRequest req, ServletResponse res) throws IOException {
+        WebUtils.toHttp(res).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        WebUtils.toHttp(res).setHeader("Content-Type", "text/plain");
+        Object user = getSubject(req, res).getPrincipal();
+        String err = String.format("Unauthorized `%s` operation for user: %s.", getHttpMethodAction(req), user);
+        WebUtils.toHttp(res).getOutputStream().print(err);
+        WebUtils.toHttp(res).flushBuffer();
+        return false;
+    }
 }

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
@@ -25,6 +25,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter;
 import org.apache.shiro.web.util.WebUtils;
@@ -33,13 +34,18 @@ public final class RestPermissionsFilter extends HttpMethodPermissionFilter {
   private final boolean allowAllOptionsRequests;
 
   public RestPermissionsFilter() {
-    allowAllOptionsRequests = RequestUtils.getInstance().isAllowAllOptionsRequests();
+    allowAllOptionsRequests = RequestUtils.isAllowAllOptionsRequests();
+  }
+
+  @VisibleForTesting
+  boolean isAllowAllOptionsRequests() {
+    return allowAllOptionsRequests;
   }
 
   @Override
   public boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue)
       throws IOException {
-    if (allowAllOptionsRequests && RequestUtils.getInstance().isOptionsRequest(request)) {
+    if (isAllowAllOptionsRequests() && RequestUtils.isOptionsRequest(request)) {
       return true;
     }
     return super.isAccessAllowed(request, response, mappedValue);

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/RestPermissionsFilter.java
@@ -31,21 +31,21 @@ import org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter;
 import org.apache.shiro.web.util.WebUtils;
 
 public final class RestPermissionsFilter extends HttpMethodPermissionFilter {
-  private final boolean allowAllOptionsRequests;
+  private final boolean isCorsEnabled;
 
   public RestPermissionsFilter() {
-    allowAllOptionsRequests = RequestUtils.isAllowAllOptionsRequests();
+    isCorsEnabled = RequestUtils.isCorsEnabled();
   }
 
   @VisibleForTesting
-  boolean isAllowAllOptionsRequests() {
-    return allowAllOptionsRequests;
+  boolean isCorsEnabled() {
+    return isCorsEnabled;
   }
 
   @Override
   public boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue)
       throws IOException {
-    if (isAllowAllOptionsRequests() && RequestUtils.isOptionsRequest(request)) {
+    if (isCorsEnabled() && RequestUtils.isOptionsRequest(request)) {
       return true;
     }
     return super.isAccessAllowed(request, response, mappedValue);

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
@@ -45,20 +45,20 @@ public final class ShiroJwtVerifyingFilter extends AccessControlFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShiroJwtVerifyingFilter.class);
 
-  private final boolean allowAllOptionsRequests;
+  private final boolean isCorsEnabled;
 
   public ShiroJwtVerifyingFilter() {
-    allowAllOptionsRequests = RequestUtils.isAllowAllOptionsRequests();
+    isCorsEnabled = RequestUtils.isCorsEnabled();
   }
 
   @VisibleForTesting
-  boolean isAllowAllOptionsRequests() {
-    return allowAllOptionsRequests;
+  boolean isCorsEnabled() {
+    return isCorsEnabled;
   }
 
   @Override
   protected boolean isAccessAllowed(ServletRequest req, ServletResponse res, Object mappedValue) throws Exception {
-    if (isAllowAllOptionsRequests() && RequestUtils.isOptionsRequest(req)) {
+    if (isCorsEnabled() && RequestUtils.isOptionsRequest(req)) {
       return true;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
@@ -17,31 +17,35 @@
 
 package io.cassandrareaper.resources.auth;
 
+import java.util.Optional;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.lang.Strings;
+
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.web.filter.AccessControlFilter;
 import org.apache.shiro.web.subject.WebSubject;
 import org.apache.shiro.web.util.WebUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
-import java.util.Optional;
 
 import static io.cassandrareaper.resources.RequestUtils.getAllowAllOptionsRequestsFromEnvironment;
 import static io.cassandrareaper.resources.RequestUtils.isOptionsRequest;
 
 public final class ShiroJwtVerifyingFilter extends AccessControlFilter {
-  private final boolean allowAllOptionsRequests;
 
   private static final Logger LOG = LoggerFactory.getLogger(ShiroJwtVerifyingFilter.class);
+
+  private final boolean allowAllOptionsRequests;
 
   public ShiroJwtVerifyingFilter() {
     allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
@@ -25,6 +25,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
@@ -47,12 +48,17 @@ public final class ShiroJwtVerifyingFilter extends AccessControlFilter {
   private final boolean allowAllOptionsRequests;
 
   public ShiroJwtVerifyingFilter() {
-    allowAllOptionsRequests = RequestUtils.getInstance().isAllowAllOptionsRequests();
+    allowAllOptionsRequests = RequestUtils.isAllowAllOptionsRequests();
+  }
+
+  @VisibleForTesting
+  boolean isAllowAllOptionsRequests() {
+    return allowAllOptionsRequests;
   }
 
   @Override
   protected boolean isAccessAllowed(ServletRequest req, ServletResponse res, Object mappedValue) throws Exception {
-    if (allowAllOptionsRequests && RequestUtils.getInstance().isOptionsRequest(req)) {
+    if (isAllowAllOptionsRequests() && RequestUtils.isOptionsRequest(req)) {
       return true;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
@@ -17,6 +17,8 @@
 
 package io.cassandrareaper.resources.auth;
 
+import io.cassandrareaper.resources.RequestUtils;
+
 import java.util.Optional;
 
 import javax.servlet.ServletRequest;
@@ -38,9 +40,6 @@ import org.apache.shiro.web.util.WebUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.cassandrareaper.resources.RequestUtils.getAllowAllOptionsRequestsFromEnvironment;
-import static io.cassandrareaper.resources.RequestUtils.isOptionsRequest;
-
 public final class ShiroJwtVerifyingFilter extends AccessControlFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShiroJwtVerifyingFilter.class);
@@ -48,12 +47,12 @@ public final class ShiroJwtVerifyingFilter extends AccessControlFilter {
   private final boolean allowAllOptionsRequests;
 
   public ShiroJwtVerifyingFilter() {
-    allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();
+    allowAllOptionsRequests = RequestUtils.getInstance().isAllowAllOptionsRequests();
   }
 
   @Override
   protected boolean isAccessAllowed(ServletRequest req, ServletResponse res, Object mappedValue) throws Exception {
-    if (allowAllOptionsRequests && isOptionsRequest(req)) {
+    if (allowAllOptionsRequests && RequestUtils.getInstance().isOptionsRequest(req)) {
       return true;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
@@ -17,11 +17,6 @@
 
 package io.cassandrareaper.resources.auth;
 
-import java.util.Optional;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
@@ -35,14 +30,29 @@ import org.apache.shiro.web.util.WebUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+
+import static io.cassandrareaper.resources.RequestUtils.getAllowAllOptionsRequestsFromEnvironment;
+import static io.cassandrareaper.resources.RequestUtils.isOptionsRequest;
+
 public final class ShiroJwtVerifyingFilter extends AccessControlFilter {
+  private final boolean allowAllOptionsRequests;
 
   private static final Logger LOG = LoggerFactory.getLogger(ShiroJwtVerifyingFilter.class);
 
-  public ShiroJwtVerifyingFilter() {}
+  public ShiroJwtVerifyingFilter() {
+    allowAllOptionsRequests = getAllowAllOptionsRequestsFromEnvironment();
+  }
 
   @Override
   protected boolean isAccessAllowed(ServletRequest req, ServletResponse res, Object mappedValue) throws Exception {
+    if (allowAllOptionsRequests && isOptionsRequest(req)) {
+      return true;
+    }
+
     Subject nonJwt = getSubject(req, res);
 
     return null != nonJwt.getPrincipal() && (nonJwt.isRemembered() || nonJwt.isAuthenticated())

--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilter.java
@@ -45,15 +45,9 @@ public final class ShiroJwtVerifyingFilter extends AccessControlFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(ShiroJwtVerifyingFilter.class);
 
-  private final boolean isCorsEnabled;
-
-  public ShiroJwtVerifyingFilter() {
-    isCorsEnabled = RequestUtils.isCorsEnabled();
-  }
-
   @VisibleForTesting
   boolean isCorsEnabled() {
-    return isCorsEnabled;
+    return RequestUtils.isCorsEnabled();
   }
 
   @Override

--- a/src/server/src/main/resources/shiro.ini
+++ b/src/server/src/main/resources/shiro.ini
@@ -13,6 +13,17 @@
 # limitations under the License.
 
 [main]
+sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
+sessionManager.sessionIdCookieEnabled = true
+sessionManager.sessionIdCookie.secure = true
+sessionManager.sessionIdCookie.sameSite = NONE
+securityManager.sessionManager = $sessionManager
+
+rememberMeManager = org.apache.shiro.web.mgt.CookieRememberMeManager
+rememberMeManager.cookie.secure = true
+rememberMeManager.cookie.sameSite = NONE
+securityManager.rememberMeManager = $rememberMeManager 
+
 authc = org.apache.shiro.web.filter.authc.PassThruAuthenticationFilter
 authc.loginUrl = /webui/login.html
 

--- a/src/server/src/test/java/io/cassandrareaper/resources/RequestUtilsTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RequestUtilsTest.java
@@ -28,30 +28,6 @@ import static org.mockito.Mockito.when;
 
 public class RequestUtilsTest {
   @Test
-  public void testIsCorsEnabledFromEnvironmentWithEmptyEnvironmentReturnsFalse() {
-    boolean allowAll = RequestUtils.isCorsEnabled();
-    Assertions.assertThat(allowAll).isFalse();
-  }
-
-  @Test
-  public void testIsCorsEnabledFromEnvironmentWithTrueEnvironmentReturnsTrue() {
-    boolean allowAll = RequestUtils.isCorsEnabled("true");
-    Assertions.assertThat(allowAll).isTrue();
-  }
-
-  @Test
-  public void testIsCorsEnabledFromEnvironmentWithFalseEnvironmentReturnsFalse() {
-    boolean allowAll = RequestUtils.isCorsEnabled("false");
-    Assertions.assertThat(allowAll).isFalse();
-  }
-
-  @Test
-  public void testIsCorsEnabledFromInvalidEnvironmentWithEnvironmentReturnsFalse() {
-    boolean allowAll = RequestUtils.isCorsEnabled("bad");
-    Assertions.assertThat(allowAll).isFalse();
-  }
-
-  @Test
   public void testIsOptionsRequestInvalidInputReturnsFalse() {
     boolean isOptionsRequest = RequestUtils.isOptionsRequest(null);
     Assertions.assertThat(isOptionsRequest).isFalse();

--- a/src/server/src/test/java/io/cassandrareaper/resources/RequestUtilsTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RequestUtilsTest.java
@@ -28,26 +28,26 @@ import static org.mockito.Mockito.when;
 
 public class RequestUtilsTest {
   @Test
-  public void testGetAllowAllOptionsRequestsFromEnvironmentWithEmptyEnvironmentReturnsFalse() {
-    boolean allowAll = RequestUtils.isAllowAllOptionsRequests();
+  public void testIsCorsEnabledFromEnvironmentWithEmptyEnvironmentReturnsFalse() {
+    boolean allowAll = RequestUtils.isCorsEnabled();
     Assertions.assertThat(allowAll).isFalse();
   }
 
   @Test
-  public void testGetAllowAllOptionsRequestsFromEnvironmentWithTrueEnvironmentReturnsTrue() {
-    boolean allowAll = RequestUtils.isAllowAllOptionsRequests("true");
+  public void testIsCorsEnabledFromEnvironmentWithTrueEnvironmentReturnsTrue() {
+    boolean allowAll = RequestUtils.isCorsEnabled("true");
     Assertions.assertThat(allowAll).isTrue();
   }
 
   @Test
-  public void testGetAllowAllOptionsRequestsFromEnvironmentWithFalseEnvironmentReturnsFalse() {
-    boolean allowAll = RequestUtils.isAllowAllOptionsRequests("false");
+  public void testIsCorsEnabledFromEnvironmentWithFalseEnvironmentReturnsFalse() {
+    boolean allowAll = RequestUtils.isCorsEnabled("false");
     Assertions.assertThat(allowAll).isFalse();
   }
 
   @Test
-  public void testGetAllowAllOptionsRequestsFromInvalidEnvironmentWithEnvironmentReturnsFalse() {
-    boolean allowAll = RequestUtils.isAllowAllOptionsRequests("bad");
+  public void testIsCorsEnabledFromInvalidEnvironmentWithEnvironmentReturnsFalse() {
+    boolean allowAll = RequestUtils.isCorsEnabled("bad");
     Assertions.assertThat(allowAll).isFalse();
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/resources/RequestUtilsTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RequestUtilsTest.java
@@ -1,0 +1,73 @@
+/*
+ *
+ * Copyright 2019-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.resources;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class RequestUtilsTest {
+  @Test
+  public void testGetAllowAllOptionsRequestsFromEnvironmentWithEmptyEnvironmentReturnsFalse() {
+    boolean allowAll = RequestUtils.getInstance().isAllowAllOptionsRequests();
+    Assertions.assertThat(allowAll).isEqualTo(false);
+  }
+
+  @Test
+  public void testGetAllowAllOptionsRequestsFromEnvironmentWithEnvironmentReturnsTrue() {
+    RequestUtils mockRequestUtils = spy(RequestUtils.class);
+    when(mockRequestUtils.getAllowAllOptionsRequestsEnvironmentVariable()).thenReturn("true");
+    boolean allowAll = mockRequestUtils.isAllowAllOptionsRequests();
+    Assertions.assertThat(allowAll).isEqualTo(true);
+  }
+
+  @Test
+  public void testGetAllowAllOptionsRequestsFromInvalidEnvironmentWithEnvironmentReturnsFalse() {
+    RequestUtils mockRequestUtils = spy(RequestUtils.class);
+    when(mockRequestUtils.getAllowAllOptionsRequestsEnvironmentVariable()).thenReturn("bad");
+    boolean allowAll = mockRequestUtils.isAllowAllOptionsRequests();
+    Assertions.assertThat(allowAll).isEqualTo(false);
+  }
+
+  @Test
+  public void testIsOptionsRequestInvalidInputReturnsFalse() {
+    boolean isOptionsRequest = RequestUtils.getInstance().isOptionsRequest(null);
+    Assertions.assertThat(isOptionsRequest).isEqualTo(false);
+  }
+
+  @Test
+  public void testIsOptionsRequestOptionsServletInputReturnsTrue() {
+    HttpServletRequest mockServletRequest = spy(HttpServletRequest.class);
+    when(mockServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS);
+    boolean isOptionsRequest = RequestUtils.getInstance().isOptionsRequest(mockServletRequest);
+    Assertions.assertThat(isOptionsRequest).isEqualTo(true);
+  }
+
+  @Test
+  public void testIsOptionsRequestGetServletInputReturnsTrue() {
+    HttpServletRequest mockServletRequest = spy(HttpServletRequest.class);
+    when(mockServletRequest.getMethod()).thenReturn(HttpMethod.GET);
+    boolean isOptionsRequest = RequestUtils.getInstance().isOptionsRequest(mockServletRequest);
+    Assertions.assertThat(isOptionsRequest).isEqualTo(false);
+  }
+}

--- a/src/server/src/test/java/io/cassandrareaper/resources/RequestUtilsTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RequestUtilsTest.java
@@ -29,45 +29,47 @@ import static org.mockito.Mockito.when;
 public class RequestUtilsTest {
   @Test
   public void testGetAllowAllOptionsRequestsFromEnvironmentWithEmptyEnvironmentReturnsFalse() {
-    boolean allowAll = RequestUtils.getInstance().isAllowAllOptionsRequests();
-    Assertions.assertThat(allowAll).isEqualTo(false);
+    boolean allowAll = RequestUtils.isAllowAllOptionsRequests();
+    Assertions.assertThat(allowAll).isFalse();
   }
 
   @Test
-  public void testGetAllowAllOptionsRequestsFromEnvironmentWithEnvironmentReturnsTrue() {
-    RequestUtils mockRequestUtils = spy(RequestUtils.class);
-    when(mockRequestUtils.getAllowAllOptionsRequestsEnvironmentVariable()).thenReturn("true");
-    boolean allowAll = mockRequestUtils.isAllowAllOptionsRequests();
-    Assertions.assertThat(allowAll).isEqualTo(true);
+  public void testGetAllowAllOptionsRequestsFromEnvironmentWithTrueEnvironmentReturnsTrue() {
+    boolean allowAll = RequestUtils.isAllowAllOptionsRequests("true");
+    Assertions.assertThat(allowAll).isTrue();
+  }
+
+  @Test
+  public void testGetAllowAllOptionsRequestsFromEnvironmentWithFalseEnvironmentReturnsFalse() {
+    boolean allowAll = RequestUtils.isAllowAllOptionsRequests("false");
+    Assertions.assertThat(allowAll).isFalse();
   }
 
   @Test
   public void testGetAllowAllOptionsRequestsFromInvalidEnvironmentWithEnvironmentReturnsFalse() {
-    RequestUtils mockRequestUtils = spy(RequestUtils.class);
-    when(mockRequestUtils.getAllowAllOptionsRequestsEnvironmentVariable()).thenReturn("bad");
-    boolean allowAll = mockRequestUtils.isAllowAllOptionsRequests();
-    Assertions.assertThat(allowAll).isEqualTo(false);
+    boolean allowAll = RequestUtils.isAllowAllOptionsRequests("bad");
+    Assertions.assertThat(allowAll).isFalse();
   }
 
   @Test
   public void testIsOptionsRequestInvalidInputReturnsFalse() {
-    boolean isOptionsRequest = RequestUtils.getInstance().isOptionsRequest(null);
-    Assertions.assertThat(isOptionsRequest).isEqualTo(false);
+    boolean isOptionsRequest = RequestUtils.isOptionsRequest(null);
+    Assertions.assertThat(isOptionsRequest).isFalse();
   }
 
   @Test
   public void testIsOptionsRequestOptionsServletInputReturnsTrue() {
     HttpServletRequest mockServletRequest = spy(HttpServletRequest.class);
     when(mockServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS);
-    boolean isOptionsRequest = RequestUtils.getInstance().isOptionsRequest(mockServletRequest);
-    Assertions.assertThat(isOptionsRequest).isEqualTo(true);
+    boolean isOptionsRequest = RequestUtils.isOptionsRequest(mockServletRequest);
+    Assertions.assertThat(isOptionsRequest).isTrue();
   }
 
   @Test
   public void testIsOptionsRequestGetServletInputReturnsTrue() {
     HttpServletRequest mockServletRequest = spy(HttpServletRequest.class);
     when(mockServletRequest.getMethod()).thenReturn(HttpMethod.GET);
-    boolean isOptionsRequest = RequestUtils.getInstance().isOptionsRequest(mockServletRequest);
-    Assertions.assertThat(isOptionsRequest).isEqualTo(false);
+    boolean isOptionsRequest = RequestUtils.isOptionsRequest(mockServletRequest);
+    Assertions.assertThat(isOptionsRequest).isFalse();
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/resources/auth/RestPermissionsFilterTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/auth/RestPermissionsFilterTest.java
@@ -1,0 +1,45 @@
+/*
+ *
+ * Copyright 2022-2022 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.resources.auth;
+
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class RestPermissionsFilterTest {
+
+  @Test
+  public void testOptionsRequestWithoutAuthorizationIsAllowed() throws Exception {
+    RestPermissionsFilter filter = Mockito.spy(RestPermissionsFilter.class);
+    HttpServletRequest mockHttpServletRequest = Mockito.spy(HttpServletRequest.class);
+    Mockito.when(mockHttpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS);
+    Mockito.when(filter.isAllowAllOptionsRequests()).thenReturn(true);
+
+    boolean allowed = filter.isAccessAllowed(
+        mockHttpServletRequest,
+        Mockito.mock(ServletResponse.class),
+        Mockito.mock(Object.class)
+    );
+    Assertions.assertThat(allowed).isTrue();
+  }
+
+}

--- a/src/server/src/test/java/io/cassandrareaper/resources/auth/RestPermissionsFilterTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/auth/RestPermissionsFilterTest.java
@@ -32,7 +32,7 @@ public class RestPermissionsFilterTest {
     RestPermissionsFilter filter = Mockito.spy(RestPermissionsFilter.class);
     HttpServletRequest mockHttpServletRequest = Mockito.spy(HttpServletRequest.class);
     Mockito.when(mockHttpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS);
-    Mockito.when(filter.isAllowAllOptionsRequests()).thenReturn(true);
+    Mockito.when(filter.isCorsEnabled()).thenReturn(true);
 
     boolean allowed = filter.isAccessAllowed(
         mockHttpServletRequest,

--- a/src/server/src/test/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilterTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilterTest.java
@@ -204,7 +204,7 @@ public final class ShiroJwtVerifyingFilterTest {
     ShiroJwtVerifyingFilter filter = Mockito.spy(ShiroJwtVerifyingFilter.class);
     HttpServletRequest mockHttpServletRequest = Mockito.spy(HttpServletRequest.class);
     Mockito.when(mockHttpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS);
-    Mockito.when(filter.isAllowAllOptionsRequests()).thenReturn(true);
+    Mockito.when(filter.isCorsEnabled()).thenReturn(true);
 
     boolean allowed = filter.isAccessAllowed(
         mockHttpServletRequest,

--- a/src/server/src/test/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilterTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/auth/ShiroJwtVerifyingFilterTest.java
@@ -22,6 +22,7 @@ import io.cassandrareaper.AppContext;
 import java.security.Principal;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
 
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.mgt.DefaultSecurityManager;
@@ -30,7 +31,6 @@ import org.apache.shiro.util.ThreadContext;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.Mockito;
-
 
 public final class ShiroJwtVerifyingFilterTest {
 
@@ -199,5 +199,19 @@ public final class ShiroJwtVerifyingFilterTest {
     }
   }
 
+  @Test
+  public void testOptionsRequestWithoutAuthorizationIsAllowed() throws Exception {
+    ShiroJwtVerifyingFilter filter = Mockito.spy(ShiroJwtVerifyingFilter.class);
+    HttpServletRequest mockHttpServletRequest = Mockito.spy(HttpServletRequest.class);
+    Mockito.when(mockHttpServletRequest.getMethod()).thenReturn(HttpMethod.OPTIONS);
+    Mockito.when(filter.isAllowAllOptionsRequests()).thenReturn(true);
+
+    boolean allowed = filter.isAccessAllowed(
+        mockHttpServletRequest,
+        Mockito.mock(ServletResponse.class),
+        Mockito.mock(Object.class)
+    );
+    Assertions.assertThat(allowed).isTrue();
+  }
 
 }


### PR DESCRIPTION
Fixes #1245 

* Browsers do not pass authorization content in OPTIONS requests
* This causes all preflight checks in the browser to fail when making a request to an authenticated endpoint when doing so with CORS enabled
* The change makes it possible to utilize a JWT from within the browser via fetch with CORS -- allowing for the separation of the frontend from the backend
* This also modifies the Shiro configuration such that it properly secures the cookies that it generates for CORS usage.

I think this behavior should probably be considered a bug, so I tied the behavior to the already in-use environment variable `REAPER_ENABLE_CROSS_ORIGIN` which when set to `true` will cause all OPTIONS requests to be allowed without an auth check.