### PR TITLE
Properly expire shiro sessions after timeout

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -233,6 +233,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     if (config.isAccessControlEnabled()) {
       SessionHandler sessionHandler = new SessionHandler();
       sessionHandler.setMaxInactiveInterval((int) config.getAccessControl().getSessionTimeout().getSeconds());
+      RequestUtils.setSessionTimeout(config.getAccessControl().getSessionTimeout());
       environment.getApplicationContext().setSessionHandler(sessionHandler);
       environment.servlets().setSessionHandler(sessionHandler);
       environment.jersey().register(new ShiroExceptionMapper());

--- a/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RequestUtils.java
@@ -17,12 +17,15 @@
 
 package io.cassandrareaper.resources;
 
+import java.time.Duration;
+
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
 
 public final class RequestUtils {
   private static boolean isCorsEnabled = false;
+  private static Duration sessionTimeout = Duration.ofMinutes(-1);
 
   private RequestUtils() {}
 
@@ -32,6 +35,14 @@ public final class RequestUtils {
 
   public static boolean isCorsEnabled() {
     return isCorsEnabled;
+  }
+
+  public static void setSessionTimeout(Duration configSessionTimeout) {
+    RequestUtils.sessionTimeout = configSessionTimeout;
+  }
+
+  public static Duration getSessionTimeout() {
+    return sessionTimeout;
   }
 
   public static boolean isOptionsRequest(ServletRequest request) {


### PR DESCRIPTION
Fixes #1225

Logs out after the configured session timeout, despite the session refresh that the UI does in the background.
I've also added an expiry date to the JWTs which uses the session timeout. So far, the JWTs we were generating never expired.