### PR TITLE
Fix mapping of repairProgress metrics

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/metrics/PrometheusMetricsConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/metrics/PrometheusMetricsConfiguration.java
@@ -44,6 +44,8 @@ public final class PrometheusMetricsConfiguration {
     final Map<String,String> millisSinceLastRepairMetricLabels = new HashMap<>();
     millisSinceLastRepairMetricLabels.put("cluster", "${0}");
     millisSinceLastRepairMetricLabels.put("keyspace", "${1}");
+    millisSinceLastRepairMetricLabels.put("repairid", "${2}");
+    // Legacy label replaced with repairid
     millisSinceLastRepairMetricLabels.put("runid", "${2}");
     mapperConfigs.add(new MapperConfig("io.cassandrareaper.service.RepairRunner.millisSinceLastRepair.*.*.*",
         "io.cassandrareaper.service.RepairRunner.millisSinceLastRepair", millisSinceLastRepairMetricLabels));
@@ -58,10 +60,11 @@ public final class PrometheusMetricsConfiguration {
         millisSinceLastScheduleRepairMetricLabels));
 
     final Map<String,String> repairProgressMetricLabels = new HashMap<>();
-    millisSinceLastScheduleRepairMetricLabels.put("cluster", "${0}");
-    millisSinceLastScheduleRepairMetricLabels.put("keyspace", "${1}");
+    repairProgressMetricLabels.put("cluster", "${0}");
+    repairProgressMetricLabels.put("keyspace", "${1}");
+    repairProgressMetricLabels.put("repairid", "${2}");
     mapperConfigs.add(new MapperConfig(
-        "io.cassandrareaper.service.RepairRunner.repairProgress.*.*",
+        "io.cassandrareaper.service.RepairRunner.repairProgress.*.*.*",
         "io.cassandrareaper.service.RepairRunner.repairProgress",
         repairProgressMetricLabels));
 


### PR DESCRIPTION
It has [3 variable segments](https://github.com/thelastpickle/cassandra-reaper/blob/7cc571bbc05f65260aea67012a89c56c803fee66/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java#L130-L135) but MapperConfig was trying to match only 2 of them.