### PR TITLE
Fix running concurrent repairs on different clusters

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -204,10 +204,11 @@ final class RepairRunner implements Runnable {
   public void run() {
     Thread.currentThread().setName(clusterName + ":" + repairRunId);
     Map<UUID, RepairRunner> currentRunners = context.repairManager.repairRunners;
-    // We only want the repair runners that are in RUNNING state.
+    // We only want the repair runners that are in RUNNING state for the same cluster
     List<UUID> repairRunIds
         = new ArrayList<UUID>(currentRunners.entrySet().stream()
           .filter(entry -> entry.getValue().isRunning())
+          .filter(entry -> entry.getValue().clusterName == clusterName)
           .map(Entry::getKey)
           .collect(Collectors.toList()));
 


### PR DESCRIPTION
After #1197 active repairs in one cluster prevent repairs in others. This diff makes repairs in different clusters independent again.

Fixes #1269 