### PR TITLE
Fix docker build

### DIFF
--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -38,10 +38,10 @@ prepare:
 	chmod 755 build/etc/init.d/cassandra-reaper
 
 deb: prepare
-	fpm -s dir -t deb -n reaper -v $(VERSION) --pre-install debian/preinstall.sh --post-install debian/postinstall.sh -C build .
+	fpm -s dir -t deb -a all -n reaper -v $(VERSION) --pre-install debian/preinstall.sh --post-install debian/postinstall.sh -C build .
 
 rpm: prepare
-	fpm -s dir -t rpm -n reaper -v $(VERSION) --pre-install redhat/preinstall.sh --post-install redhat/postinstall.sh --config-files /etc/cassandra-reaper/cassandra-reaper.yaml -C build .
+	fpm -s dir -t rpm -a all -n reaper -v $(VERSION) --pre-install redhat/preinstall.sh --post-install redhat/postinstall.sh --config-files /etc/cassandra-reaper/cassandra-reaper.yaml -C build .
 
 all: package deb rpm
 

--- a/src/packaging/docker-build/Dockerfile
+++ b/src/packaging/docker-build/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
         openjdk-11-jdk \
         maven \
         nodejs \
+        python2 \
         rpm \
         ruby-dev \
     && mvn --version \

--- a/src/packaging/docker-build/docker-entrypoint.sh
+++ b/src/packaging/docker-build/docker-entrypoint.sh
@@ -16,6 +16,8 @@
 
 set -ex
 
+arch=$(dpkg-architecture -q DEB_BUILD_ARCH)
+
 # build jar
 # build web UI
 # build Debian and RPM packages
@@ -30,12 +32,12 @@ javac_path=""
 javadoc_path=""
 if [ "$(cut -d'.' -f1 <<<${VERSION})" -ge 3 ] && [ "$(cut -d'.' -f2 <<<${VERSION})" -ge 1 ]
 then
-  java_home="/usr/lib/jvm/java-11-openjdk-amd64"
+  java_home="/usr/lib/jvm/java-11-openjdk-${arch}"
   java_path="bin/java"
   javac_path="bin/javac"
   javadoc_path="bin/javadoc"
 else
-  java_home="/usr/lib/jvm/java-8-openjdk-amd64"
+  java_home="/usr/lib/jvm/java-8-openjdk-${arch}"
   java_path="jre/bin/java"
   javac_path="bin/javac"
   javadoc_path="bin/javadoc"

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -596,6 +596,21 @@
                         </goals>
                     </execution>
                     <execution>
+                        <id>exec-npm-run-bower</id>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <executable>npm</executable>
+                            <workingDirectory>../ui</workingDirectory>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>bower</argument>
+                            </arguments>
+                        </configuration>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>exec-npm-run</id>
                         <phase>generate-sources</phase>
                         <configuration>

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -48,8 +48,7 @@
     "zip": "zip -jr release.zip build",
     "start": "node server.js --env.project=$REAPER_HOST",
     "navbar": "./build-navbar.sh",
-    "bower": "bower install",
-    "postinstall": "npm run bower"
+    "bower": "bower install"
   },
   "dependencies": {
     "core-js": "^2.6.11",


### PR DESCRIPTION
- Support for different host arch
- Run bower explicitly instead of from npm postinstall hook. Hook requires --unsafe-perm option now.
- Build packages with `-a all` as there is no arch dependent code.