### PR TITLE
[k8s] supporting k8s-style secrets stored in a folder

### DIFF
--- a/src/docs/content/docs/configuration/docker_vars.md
+++ b/src/docs/content/docs/configuration/docker_vars.md
@@ -242,3 +242,16 @@ Some variable names have changed between the release of Docker-support and Reape
 <h4>Pre Reaper 1.0</h4> | <h4>Post Reaper 1.0</h4>
 ---|---
 `REAPER_DB_DRIVER_CLASS` | N/A - The associated parameter has been deprecated
+
+## Using Kubernetes secrets
+
+While it is possible to pass credentials as environment variables, it is also
+possible to use credentials stored on the filesystem, with a typical k8s layout.
+
+More info on [using secrets as files from a pod](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod) and [consuming secret values from volumes](https://kubernetes.io/docs/concepts/configuration/secret/#consuming-secret-values-from-volumes).
+
+<h4>Environment Variable</h4> | <h4>Configuration settings</h4> | <h4>What should it contain</h4> | <h4>Default value</h4>
+---|---|---|---
+<code class="codeLarge">REAPER_JMX_CREDENTIALS_K8S_PATH</code> | [jmxCredentials]({{< relref "reaper_specific.md#jmxcredentials" >}}) | Folder with a subfolder per cluster, containing 2 files named `username` and `password`. | Undef
+<code class="codeLarge">REAPER_JMX_AUTH_K8S_PATH</code> | [username]({{< relref "reaper_specific.md#username" >}}) and [password]({{< relref "reaper_specific.md#password" >}})  | A folder containing 2 files `username` and `password`. | Undef
+<code class="codeLarge">CRYPTO_SYSTEM_PROPERTY_SECRET_K8S_PATH</code> | [cryptograph/systemPropertySecret]({{< relref "reaper_specific.md#cryptograph" >}}) | Folder with a single `password` file. | Undef


### PR DESCRIPTION
Similar to https://github.com/thelastpickle/cassandra-medusa/pull/552 but for Reaper.

Related to issue https://github.com/thelastpickle/cassandra-reaper/issues/1210

Any idea on how to automate tests on this is welcome. On my side, I have crafted a smalls script that looks like this:

```bash
#!/bin/sh

test_override_jmx_auth_k8s() {
    TMP_DIR=$(mktemp -d)
    DOCKER_SCRIPT=../../main/docker/configure-jmx-credentials.sh
    CONF_FILE=/etc/cassandra-reaper/cassandra-reaper.yml
    if [ ! -d "$TMP_DIR" ] ; then echo "$TMP_DIR not found" ; exit 1 ; fi 
    if [ ! -f "$DOCKER_SCRIPT" ] ; then echo "$DOCKER_SCRIPT not found" ; exit 1 ; fi 
    if [ ! -f "$CONF_FILE" ] ; then echo "$CONF_FILE not found" ; exit 1 ; fi 
    echo "Testing jmx_auth_k8s override with $TMP_DIR"
    USERNAME_FILE="$TMP_DIR/username"
    PASSWORD_FILE="$TMP_DIR/password"
    echo "my-cass-username" > "$USERNAME_FILE"
    echo "my-cass-password" > "$PASSWORD_FILE"
    unset CRYPTO_SYSTEM_PROPERTY_SECRET_K8S_PATH
    export REAPER_JMX_AUTH_K8S_PATH="$TMP_DIR"
    . "$DOCKER_SCRIPT"
    if [ "$REAPER_JMX_AUTH_USERNAME" != "my-cass-username" ] ; then
	echo "usernames do not match"
	exit 1
    fi 
    if [ "$REAPER_JMX_AUTH_PASSWORD" != "my-cass-password" ] ; then
	echo "passwords do not match"
	exit 1
    fi
    rm -rf $TMP_DIR || exit 1
    echo "OK"
}

test_override_property_secret_k8s() {
    TMP_DIR=$(mktemp -d)
    DOCKER_SCRIPT=../../main/docker/configure-jmx-credentials.sh
    CONF_FILE=/etc/cassandra-reaper/cassandra-reaper.yml
    if [ ! -d "$TMP_DIR" ] ; then echo "$TMP_DIR not found" ; exit 1 ; fi 
    if [ ! -f "$DOCKER_SCRIPT" ] ; then echo "$DOCKER_SCRIPT not found" ; exit 1 ; fi 
    if [ ! -f "$CONF_FILE" ] ; then echo "$CONF_FILE not found" ; exit 1 ; fi 
    echo "Testing property_secret_k8s override with $TMP_DIR"
    PASSWORD_FILE="$TMP_DIR/password"
    echo "my-system-property-secret" > "$PASSWORD_FILE"
    unset REAPER_JMX_AUTH_K8S_PATH
    export CRYPTO_SYSTEM_PROPERTY_SECRET_K8S_PATH="$TMP_DIR"
    . "$DOCKER_SCRIPT"
    if [ "$CRYPTO_SYSTEM_PROPERTY_SECRET" != "my-system-property-secret" ] ; then
	echo "passwords do not match"
	exit 1
    fi
    rm -rf $TMP_DIR || exit 1
    echo "OK"
}

test_override_jmx_auth_k8s
test_override_property_secret_k8s
```

So I considered calling it from [run-tests](https://github.com/thelastpickle/cassandra-reaper/blob/master/.github/scripts/run-tests.sh) but that still looks a little clumsy. Any idea welcome.


