### PR TITLE
Fixes the release process as we're now building packages for no specific target architecture

### DIFF
--- a/.github/scripts/before_deploy.sh
+++ b/.github/scripts/before_deploy.sh
@@ -30,8 +30,8 @@ then
     sudo gem install --no-document fpm
     cd src/packaging
     make all
-    sudo mv reaper_*_amd64.deb ../packages/
-    sudo mv reaper-*.x86_64.rpm ../packages/
+    sudo mv reaper_*_*.deb ../packages/
+    sudo mv reaper-*.*.rpm ../packages/
     cd ../..
     tar czf cassandra-reaper-${VERSION}.tar.gz cassandra-reaper-master/
     sudo mv cassandra-reaper-${VERSION}.tar.gz src/packages/
@@ -54,8 +54,8 @@ then
     sudo gem install --no-document fpm
     cd src/packaging
     make all
-    sudo mv reaper_*_amd64.deb ../packages/
-    sudo mv reaper-*.x86_64.rpm ../packages/
+    sudo mv reaper_*_*.deb ../packages/
+    sudo mv reaper-*.*.rpm ../packages/
     cd ../..
     tar czf cassandra-reaper-${VERSION}-release.tar.gz cassandra-reaper-${VERSION}/
     sudo mv cassandra-reaper-${VERSION}-release.tar.gz src/packages/


### PR DESCRIPTION
Since #1274 was merged, the release workflow broke due to deb/rpm filenames being different than what they were before (`reaper_3.2.0-SNAPSHOT_all.deb` now vs `reaper_3.2.0-SNAPSHOT_amd64.deb` before).
This PR uses a wildcard for the architecture part of the filename.