### PR TITLE
Further storage refactoring

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/auth/ShiroJwtProvider.java
@@ -19,7 +19,7 @@ package io.cassandrareaper.resources.auth;
 
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.resources.RequestUtils;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -68,7 +68,7 @@ public final class ShiroJwtProvider {
     byte[] key;
     String txt = System.getenv("JWT_SECRET");
     if (null == txt) {
-      if (cxt.storage instanceof CassandraStorage) {
+      if (cxt.storage instanceof CassandraStorageFacade) {
         txt = cxt.config.getCassandraFactory().getClusterName();
       } else {
         txt = AppContext.REAPER_INSTANCE_ADDRESS;

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -70,7 +70,7 @@ public interface IDistributedStorage {
   /**
    * Gets the next free segment from the backend that is both within the parallel range and the local node ranges.
    *
-   * @param runId id of the repair run
+   * @param runId  id of the repair run
    * @param ranges list of ranges we're looking a segment for
    * @return an optional repair segment to process
    */

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -20,6 +20,7 @@ package io.cassandrareaper.storage;
 import io.cassandrareaper.core.GenericMetric;
 import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.service.RingRange;
+import io.cassandrareaper.storage.metrics.IDistributedMetrics;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +31,7 @@ import java.util.UUID;
 /**
  * Definition for a storage that can run in distributed (peer-to-peer) mode. For example Cassandra.
  */
-public interface IDistributedStorage {
+public interface IDistributedStorage extends IDistributedMetrics {
 
   boolean takeLead(UUID leaderId);
 
@@ -76,15 +77,6 @@ public interface IDistributedStorage {
    */
   List<RepairSegment> getNextFreeSegmentsForRanges(
       UUID runId, List<RingRange> ranges);
-
-  List<GenericMetric> getMetrics(
-      String clusterName,
-      Optional<String> host,
-      String metricDomain,
-      String metricType,
-      long since);
-
-  void storeMetrics(List<GenericMetric> metric);
 
   void storeOperations(String clusterName, OpType operationType, String host, String operationsJson);
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -17,13 +17,11 @@
 
 package io.cassandrareaper.storage;
 
-import io.cassandrareaper.core.GenericMetric;
 import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.service.RingRange;
 import io.cassandrareaper.storage.metrics.IDistributedMetrics;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -20,18 +20,16 @@ package io.cassandrareaper.storage;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.DiagEventSubscription;
 import io.cassandrareaper.core.PercentRepairedMetric;
-import io.cassandrareaper.core.RepairSchedule;
-import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Snapshot;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.storage.repairrun.IRepairRun;
+import io.cassandrareaper.storage.repairschedule.IRepairSchedule;
 import io.cassandrareaper.storage.repairsegment.IRepairSegment;
 import io.cassandrareaper.storage.repairunit.IRepairUnit;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import io.dropwizard.lifecycle.Managed;
@@ -39,7 +37,11 @@ import io.dropwizard.lifecycle.Managed;
 /**
  * API definition for cassandra-reaper.
  */
-public interface IStorage extends Managed, IRepairRun, IRepairSegment, IRepairUnit, io.cassandrareaper.storage.repairschedule.IRepairSchedule {
+public interface IStorage extends Managed,
+      IRepairRun,
+      IRepairSegment,
+      IRepairUnit,
+      IRepairSchedule {
 
   boolean isStorageConnected();
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -42,25 +42,8 @@ public interface IStorage extends Managed,
       IRepairSegment,
       IRepairUnit,
       IRepairSchedule,
-      ICluster, IEvents {
+      ICluster, IEvents, io.cassandrareaper.storage.snapshot.ISnapshot, io.cassandrareaper.storage.metrics.IMetrics {
 
   boolean isStorageConnected();
-
-  boolean saveSnapshot(Snapshot snapshot);
-
-  boolean deleteSnapshot(Snapshot snapshot);
-
-  Snapshot getSnapshot(String clusterName, String snapshotName);
-
-  Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit);
-
-  Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName);
-
-  List<PercentRepairedMetric> getPercentRepairedMetrics(
-        String clusterName,
-        UUID repairScheduleId,
-        Long since);
-
-  void storePercentRepairedMetric(PercentRepairedMetric metric);
 
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -20,18 +20,18 @@ package io.cassandrareaper.storage;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.DiagEventSubscription;
 import io.cassandrareaper.core.PercentRepairedMetric;
-import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSchedule;
-import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Snapshot;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
+import io.cassandrareaper.storage.repairrun.IRepairRun;
+import io.cassandrareaper.storage.repairsegment.IRepairSegment;
+import io.cassandrareaper.storage.repairunit.IRepairUnit;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.SortedSet;
 import java.util.UUID;
 
 import io.dropwizard.lifecycle.Managed;
@@ -39,7 +39,7 @@ import io.dropwizard.lifecycle.Managed;
 /**
  * API definition for cassandra-reaper.
  */
-public interface IStorage extends Managed {
+public interface IStorage extends Managed, IRepairRun, IRepairSegment, IRepairUnit, io.cassandrareaper.storage.repairschedule.IRepairSchedule {
 
   boolean isStorageConnected();
 
@@ -59,84 +59,6 @@ public interface IStorage extends Managed {
    * @return The deleted Cluster instance if delete succeeds, with state set to DELETED.
    */
   Cluster deleteCluster(String clusterName);
-
-  RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments);
-
-  boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState);
-
-  boolean updateRepairRun(RepairRun repairRun);
-
-  Optional<RepairRun> getRepairRun(UUID id);
-
-  /** return all the repair runs in a cluster, in reverse chronological order, with default limit is 1000 */
-  Collection<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit);
-
-  Collection<RepairRun> getRepairRunsForClusterPrioritiseRunning(String clusterName, Optional<Integer> limit);
-
-  Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId);
-
-  Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState);
-
-  /**
-   * Delete the RepairRun instance identified by the given id, and delete also all the related repair segments.
-   *
-   * @param id The id of the RepairRun instance to delete, and all segments for it.
-   * @return The deleted RepairRun instance, if delete succeeds, with state set to DELETED.
-   */
-  Optional<RepairRun> deleteRepairRun(UUID id);
-
-  RepairUnit addRepairUnit(RepairUnit.Builder newRepairUnit);
-
-  RepairUnit getRepairUnit(UUID id);
-
-  Optional<RepairUnit> getRepairUnit(RepairUnit.Builder repairUnit);
-
-  void updateRepairUnit(RepairUnit updatedRepairUnit);
-
-  boolean updateRepairSegment(RepairSegment newRepairSegment);
-
-  Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId);
-
-  Collection<RepairSegment> getRepairSegmentsForRun(UUID runId);
-
-  /**
-   * @param runId the run id that the segment belongs to.
-   * @return a segment enclosed by the range with state NOT_STARTED, or nothing.
-   */
-  List<RepairSegment> getNextFreeSegments(UUID runId);
-
-  Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState);
-
-  SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit);
-
-  int getSegmentAmountForRepairRun(UUID runId);
-
-  int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state);
-
-  RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule);
-
-  Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId);
-
-  Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName);
-
-  Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental);
-
-  Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName);
-
-  Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName);
-
-  Collection<RepairSchedule> getAllRepairSchedules();
-
-  boolean updateRepairSchedule(RepairSchedule newRepairSchedule);
-
-  /**
-   * Delete the RepairSchedule instance identified by the given id. Related repair runs or other resources tied to the
-   * schedule will not be deleted.
-   *
-   * @param id The id of the RepairSchedule instance to delete.
-   * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
-   */
-  Optional<RepairSchedule> deleteRepairSchedule(UUID id);
 
   Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit);
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -17,20 +17,12 @@
 
 package io.cassandrareaper.storage;
 
-import io.cassandrareaper.core.PercentRepairedMetric;
-import io.cassandrareaper.core.Snapshot;
-import io.cassandrareaper.resources.view.RepairRunStatus;
-import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.storage.cluster.ICluster;
 import io.cassandrareaper.storage.events.IEvents;
 import io.cassandrareaper.storage.repairrun.IRepairRun;
 import io.cassandrareaper.storage.repairschedule.IRepairSchedule;
 import io.cassandrareaper.storage.repairsegment.IRepairSegment;
 import io.cassandrareaper.storage.repairunit.IRepairUnit;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
 
 import io.dropwizard.lifecycle.Managed;
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorage.java
@@ -17,12 +17,12 @@
 
 package io.cassandrareaper.storage;
 
-import io.cassandrareaper.core.Cluster;
-import io.cassandrareaper.core.DiagEventSubscription;
 import io.cassandrareaper.core.PercentRepairedMetric;
 import io.cassandrareaper.core.Snapshot;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
+import io.cassandrareaper.storage.cluster.ICluster;
+import io.cassandrareaper.storage.events.IEvents;
 import io.cassandrareaper.storage.repairrun.IRepairRun;
 import io.cassandrareaper.storage.repairschedule.IRepairSchedule;
 import io.cassandrareaper.storage.repairsegment.IRepairSegment;
@@ -41,30 +41,10 @@ public interface IStorage extends Managed,
       IRepairRun,
       IRepairSegment,
       IRepairUnit,
-      IRepairSchedule {
+      IRepairSchedule,
+      ICluster, IEvents {
 
   boolean isStorageConnected();
-
-  Collection<Cluster> getClusters();
-
-  boolean addCluster(Cluster cluster);
-
-  boolean updateCluster(Cluster newCluster);
-
-  Cluster getCluster(String clusterName);
-
-  /**
-   * Delete the Cluster instance identified by the given cluster name. Delete succeeds only if there are no repair runs
-   * for the targeted cluster.
-   *
-   * @param clusterName The name of the Cluster instance to delete.
-   * @return The deleted Cluster instance if delete succeeds, with state set to DELETED.
-   */
-  Cluster deleteCluster(String clusterName);
-
-  Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit);
-
-  Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName);
 
   boolean saveSnapshot(Snapshot snapshot);
 
@@ -72,20 +52,15 @@ public interface IStorage extends Managed,
 
   Snapshot getSnapshot(String clusterName, String snapshotName);
 
-  Collection<DiagEventSubscription> getEventSubscriptions();
+  Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit);
 
-  Collection<DiagEventSubscription> getEventSubscriptions(String clusterName);
-
-  DiagEventSubscription getEventSubscription(UUID id);
-
-  DiagEventSubscription addEventSubscription(DiagEventSubscription subscription);
-
-  boolean deleteEventSubscription(UUID id);
+  Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName);
 
   List<PercentRepairedMetric> getPercentRepairedMetrics(
-      String clusterName,
-      UUID repairScheduleId,
-      Long since);
+        String clusterName,
+        UUID repairScheduleId,
+        Long since);
 
   void storePercentRepairedMetric(PercentRepairedMetric metric);
+
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/InitializeStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/InitializeStorage.java
@@ -18,7 +18,7 @@ package io.cassandrareaper.storage;
 
 import io.cassandrareaper.ReaperApplicationConfiguration;
 import io.cassandrareaper.ReaperException;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.util.UUID;
 
@@ -58,12 +58,12 @@ public final class InitializeStorage {
     LOG.info("Initializing the database and performing schema migrations");
 
     if ("memory".equalsIgnoreCase(config.getStorageType())) {
-      storage = new MemoryStorage();
+      storage = new MemoryStorageFacade();
     } else if (Lists.newArrayList("cassandra", "astra").contains(config.getStorageType())) {
-      CassandraStorage.CassandraMode mode = config.getStorageType().equals("cassandra")
-          ? CassandraStorage.CassandraMode.CASSANDRA
-          : CassandraStorage.CassandraMode.ASTRA;
-      storage = new CassandraStorage(reaperInstanceId, config, environment, mode);
+      CassandraStorageFacade.CassandraMode mode = config.getStorageType().equals("cassandra")
+          ? CassandraStorageFacade.CassandraMode.CASSANDRA
+          : CassandraStorageFacade.CassandraMode.ASTRA;
+      storage = new CassandraStorageFacade(reaperInstanceId, config, environment, mode);
     } else {
       LOG.error("invalid storageType: {}", config.getStorageType());
       throw new ReaperException("invalid storage type: " + config.getStorageType());

--- a/src/server/src/main/java/io/cassandrareaper/storage/JsonParseUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/JsonParseUtils.java
@@ -38,10 +38,11 @@ public final class JsonParseUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonParseUtils.class);
 
-  private static final ObjectReader LIST_READER
-      = new ObjectMapper().readerFor(new TypeReference<List<RingRange>>() {});
-  private static final ObjectReader MAP_READER
-      = new ObjectMapper().readerFor(new TypeReference<Map<String, String>>() {});
+  private static final ObjectReader LIST_READER  = new ObjectMapper()
+        .readerFor(new TypeReference<List<RingRange>>() {});
+  private static final ObjectReader MAP_READER = new ObjectMapper()
+        .readerFor(new TypeReference<Map<String, String>>() {
+        });
   private static final ObjectWriter WRITER = new ObjectMapper().writer();
 
   private JsonParseUtils() {

--- a/src/server/src/main/java/io/cassandrareaper/storage/JsonParseUtils.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/JsonParseUtils.java
@@ -38,11 +38,11 @@ public final class JsonParseUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonParseUtils.class);
 
-  private static final ObjectReader LIST_READER  = new ObjectMapper()
-        .readerFor(new TypeReference<List<RingRange>>() {});
-  private static final ObjectReader MAP_READER = new ObjectMapper()
-        .readerFor(new TypeReference<Map<String, String>>() {
-        });
+  private static final ObjectReader LIST_READER
+      = new ObjectMapper().readerFor(new TypeReference<List<RingRange>>() {});
+  private static final ObjectReader MAP_READER
+      = new ObjectMapper().readerFor(new TypeReference<Map<String, String>>() {});
+
   private static final ObjectWriter WRITER = new ObjectMapper().writer();
 
   private JsonParseUtils() {

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
@@ -67,7 +67,7 @@ public final class MemoryStorageFacade implements IStorage {
   private final MemRepairSegment memRepairSegment = new MemRepairSegment(this);
   private final MemRepairUnitDao memRepairUnitDao = new MemRepairUnitDao();
   private final MemRepairRunDao memRepairRunDao = new MemRepairRunDao(memRepairSegment, memRepairUnitDao);
-  private final MemRepairScheduleDao memRepairScheduleDao = new MemRepairScheduleDao(this);
+  private final MemRepairScheduleDao memRepairScheduleDao = new MemRepairScheduleDao(memRepairUnitDao);
 
   @Override
   public boolean isStorageConnected() {

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
@@ -27,28 +27,25 @@ import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Snapshot;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
+import io.cassandrareaper.storage.cluster.MemClusterDao;
+import io.cassandrareaper.storage.events.MemEventsDao;
 import io.cassandrareaper.storage.repairrun.MemRepairRunDao;
 import io.cassandrareaper.storage.repairschedule.MemRepairScheduleDao;
 import io.cassandrareaper.storage.repairsegment.MemRepairSegment;
 import io.cassandrareaper.storage.repairunit.MemRepairUnitDao;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,15 +56,20 @@ import org.slf4j.LoggerFactory;
 public final class MemoryStorageFacade implements IStorage {
 
   private static final Logger LOG = LoggerFactory.getLogger(MemoryStorageFacade.class);
-  private final ConcurrentMap<String, Cluster> clusters = Maps.newConcurrentMap();
   private final ConcurrentMap<String, Snapshot> snapshots = Maps.newConcurrentMap();
-  private final ConcurrentMap<UUID, DiagEventSubscription> subscriptionsById = Maps.newConcurrentMap();
   private final ConcurrentMap<String, Map<String, PercentRepairedMetric>> percentRepairedMetrics
       = Maps.newConcurrentMap();
   private final MemRepairSegment memRepairSegment = new MemRepairSegment(this);
   private final MemRepairUnitDao memRepairUnitDao = new MemRepairUnitDao();
   private final MemRepairRunDao memRepairRunDao = new MemRepairRunDao(memRepairSegment, memRepairUnitDao);
   private final MemRepairScheduleDao memRepairScheduleDao = new MemRepairScheduleDao(memRepairUnitDao);
+  private final MemEventsDao memEventsDao = new MemEventsDao();
+  private final MemClusterDao memClusterDao = new MemClusterDao(
+        memRepairUnitDao,
+        memRepairRunDao,
+        memRepairScheduleDao,
+        memEventsDao
+  );
 
   @Override
   public boolean isStorageConnected() {
@@ -77,79 +79,39 @@ public final class MemoryStorageFacade implements IStorage {
 
   @Override
   public Collection<Cluster> getClusters() {
-    return clusters.values();
+    return memClusterDao.getClusters();
   }
 
   @Override
   public boolean addCluster(Cluster cluster) {
-    assert addClusterAssertions(cluster);
-    Cluster existing = clusters.put(cluster.getName(), cluster);
-    return existing == null;
+    return memClusterDao.addCluster(cluster);
   }
 
   @Override
   public boolean updateCluster(Cluster newCluster) {
-    addCluster(newCluster);
-    return true;
+    return memClusterDao.updateCluster(newCluster);
   }
 
 
   private boolean addClusterAssertions(Cluster cluster) {
-    Preconditions.checkState(
-        Cluster.State.UNKNOWN != cluster.getState(),
-        "Cluster should not be persisted with UNKNOWN state");
 
     // TODO – unit tests need to also always set the paritioner
     //Preconditions.checkState(cluster.getPartitioner().isPresent(), "Cannot store cluster with no partitioner.");
 
     // assert we're not overwriting a cluster with the same name but different node list
-    Set<String> previousNodes;
-    try {
-      previousNodes = getCluster(cluster.getName()).getSeedHosts();
-    } catch (IllegalArgumentException ignore) {
-      // there is no previous cluster with same name
-      previousNodes = cluster.getSeedHosts();
-    }
-    Set<String> addedNodes = cluster.getSeedHosts();
 
-    Preconditions.checkArgument(
-        !Collections.disjoint(previousNodes, addedNodes),
-        "Trying to add/update cluster using an existing name: %s. No nodes overlap between %s and %s",
-        cluster.getName(), StringUtils.join(previousNodes, ','), StringUtils.join(addedNodes, ','));
-
-    return true;
+    return memClusterDao.addClusterAssertions(cluster);
   }
 
   @Override
   public Cluster getCluster(String clusterName) {
-    Preconditions.checkArgument(clusters.containsKey(clusterName), "no such cluster: %s", clusterName);
-    return clusters.get(clusterName);
+    return memClusterDao.getCluster(clusterName);
   }
 
   @Override
   public Cluster deleteCluster(String clusterName) {
-    memRepairScheduleDao.getRepairSchedulesForCluster(clusterName).forEach(
-        schedule -> memRepairScheduleDao.deleteRepairSchedule(schedule.getId())
-    );
-    memRepairRunDao.getRepairRunIdsForCluster(clusterName, Optional.empty())
-        .forEach(runId -> memRepairRunDao.deleteRepairRun(runId));
 
-    getEventSubscriptions(clusterName)
-        .stream()
-        .filter(subscription -> subscription.getId().isPresent())
-        .forEach(subscription -> deleteEventSubscription(subscription.getId().get()));
-
-    memRepairUnitDao.repairUnits.values().stream()
-        .filter((unit) -> unit.getClusterName().equals(clusterName))
-        .forEach((unit) -> {
-          assert memRepairRunDao.getRepairRunsForUnit(
-              unit.getId()).isEmpty() : StringUtils.join(memRepairRunDao.getRepairRunsForUnit(unit.getId())
-          );
-          memRepairUnitDao.repairUnits.remove(unit.getId());
-          memRepairUnitDao.repairUnitsByKey.remove(unit.with());
-        });
-
-    return clusters.remove(clusterName);
+    return memClusterDao.deleteCluster(clusterName);
   }
 
   @Override
@@ -371,39 +333,27 @@ public final class MemoryStorageFacade implements IStorage {
 
   @Override
   public Collection<DiagEventSubscription> getEventSubscriptions() {
-    return subscriptionsById.values();
+    return memEventsDao.getEventSubscriptions();
   }
 
   @Override
   public Collection<DiagEventSubscription> getEventSubscriptions(String clusterName) {
-    Preconditions.checkNotNull(clusterName);
-    Collection<DiagEventSubscription> ret = new ArrayList<>();
-    for (DiagEventSubscription sub : subscriptionsById.values()) {
-      if (sub.getCluster().equals(clusterName)) {
-        ret.add(sub);
-      }
-    }
-    return ret;
+    return memEventsDao.getEventSubscriptions(clusterName);
   }
 
   @Override
   public DiagEventSubscription getEventSubscription(UUID id) {
-    if (subscriptionsById.containsKey(id)) {
-      return subscriptionsById.get(id);
-    }
-    throw new IllegalArgumentException("No event subscription with id " + id);
+    return memEventsDao.getEventSubscription(id);
   }
 
   @Override
   public DiagEventSubscription addEventSubscription(DiagEventSubscription subscription) {
-    Preconditions.checkArgument(subscription.getId().isPresent());
-    subscriptionsById.put(subscription.getId().get(), subscription);
-    return subscription;
+    return memEventsDao.addEventSubscription(subscription);
   }
 
   @Override
   public boolean deleteEventSubscription(UUID id) {
-    return subscriptionsById.remove(id) != null;
+    return memEventsDao.deleteEventSubscription(id);
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
@@ -267,13 +267,7 @@ public final class MemoryStorageFacade implements IStorage {
 
   @Override
   public Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName) {
-    List<RepairScheduleStatus> scheduleStatuses = Lists.newArrayList();
-    Collection<RepairSchedule> schedules = memRepairScheduleDao.getRepairSchedulesForCluster(clusterName);
-    for (RepairSchedule schedule : schedules) {
-      RepairUnit unit = memRepairUnitDao.getRepairUnit(schedule.getRepairUnitId());
-      scheduleStatuses.add(new RepairScheduleStatus(schedule, unit));
-    }
-    return scheduleStatuses;
+    return memRepairScheduleDao.getClusterScheduleStatuses(clusterName);
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
@@ -42,7 +42,6 @@ import java.util.Optional;
 import java.util.SortedSet;
 import java.util.UUID;
 
-import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
@@ -89,12 +89,6 @@ public final class MemoryStorageFacade implements IStorage {
 
 
   private boolean addClusterAssertions(Cluster cluster) {
-
-    // TODO – unit tests need to also always set the paritioner
-    //Preconditions.checkState(cluster.getPartitioner().isPresent(), "Cannot store cluster with no partitioner.");
-
-    // assert we're not overwriting a cluster with the same name but different node list
-
     return memClusterDao.addClusterAssertions(cluster);
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraStorageFacade.java
@@ -66,7 +66,6 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.QueryLogger;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
@@ -330,22 +329,10 @@ public final class CassandraStorageFacade implements IStorage, IDistributedStora
    * Create a collection of RepairRun objects out of a list of ResultSetFuture. Used to handle async queries on the
    * repair_run table with a list of ids.
    */
-  private Collection<RepairRun> getRepairRunsAsync(List<ResultSetFuture> repairRunFutures) {
-
-    return cassRepairRunDao.getRepairRunsAsync(repairRunFutures);
-  }
-
   @Override
   public Collection<RepairRun> getRepairRunsWithState(RunState runState) {
 
     return cassRepairRunDao.getRepairRunsWithState(runState);
-  }
-
-  private Collection<? extends RepairRun> getRepairRunsWithStateForCluster(
-      Collection<UUID> clusterRepairRunsId,
-      RunState runState) {
-
-    return cassRepairRunDao.getRepairRunsWithStateForCluster(clusterRepairRunsId, runState);
   }
 
   @Override
@@ -362,10 +349,6 @@ public final class CassandraStorageFacade implements IStorage, IDistributedStora
   @Override
   public void updateRepairUnit(RepairUnit updatedRepairUnit) {
     cassRepairUnitDao.updateRepairUnit(updatedRepairUnit);
-  }
-
-  private RepairUnit getRepairUnitImpl(UUID id) {
-    return cassRepairUnitDao.getRepairUnitImpl(id);
   }
 
   @Override
@@ -440,12 +423,6 @@ public final class CassandraStorageFacade implements IStorage, IDistributedStora
     return cassRepairRunDao.getRepairRunIdsForCluster(clusterName, limit);
   }
 
-  private SortedSet<UUID> getRepairRunIdsForClusterWithState(String clusterName, RunState runState) {
-
-
-    return cassRepairRunDao.getRepairRunIdsForClusterWithState(clusterName, runState);
-  }
-
   @Override
   public RepairSchedule addRepairSchedule(io.cassandrareaper.core.RepairSchedule.Builder repairSchedule) {
 
@@ -456,10 +433,6 @@ public final class CassandraStorageFacade implements IStorage, IDistributedStora
   public Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId) {
 
     return cassRepairScheduleDao.getRepairSchedule(repairScheduleId);
-  }
-
-  private RepairSchedule createRepairScheduleFromRow(Row repairScheduleRow) {
-    return cassRepairScheduleDao.createRepairScheduleFromRow(repairScheduleRow);
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraStorageFacade.java
@@ -59,7 +59,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ConsistencyLevel;
@@ -78,7 +77,6 @@ import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.joda.time.DateTime;

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Concurrency.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/Concurrency.java
@@ -161,11 +161,11 @@ public class Concurrency {
     }
   }
 
-  boolean hasLeadOnSegment(RepairSegment segment) {
+  public boolean hasLeadOnSegment(RepairSegment segment) {
     return renewRunningRepairsForNodes(segment.getRunId(), segment.getId(), segment.getReplicas().keySet());
   }
 
-  boolean hasLeadOnSegment(UUID leaderId) {
+  public boolean hasLeadOnSegment(UUID leaderId) {
     ResultSet lwtResult = session.execute(
         renewLeadPrepStmt.bind(
             LEAD_DURATION,

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MigrationManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MigrationManager.java
@@ -151,7 +151,8 @@ final class MigrationManager {
 
     for (int i = dbVersion + 1; i <= repository.getLatestVersion(); ++i) {
       final int nextVersion = i;
-      String migrationRepoPath = mode.equals(CassandraStorageFacade.CassandraMode.CASSANDRA) ? "db/cassandra" : "db/astra";
+      String migrationRepoPath = mode
+            .equals(CassandraStorageFacade.CassandraMode.CASSANDRA) ? "db/cassandra" : "db/astra";
       // perform the migrations one at a time, so the MigrationXXX classes can be executed alongside the scripts
       MigrationRepository migrationRepo = new MigrationRepository(migrationRepoPath) {
         @Override

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/FixRepairRunTimestamps.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/FixRepairRunTimestamps.java
@@ -46,7 +46,7 @@ public final class FixRepairRunTimestamps {
 
     Statement getRepairRunPrepStmt
         = new SimpleStatement("SELECT id,state,start_time,pause_time,end_time FROM repair_run")
-            .setConsistencyLevel(ConsistencyLevel.QUORUM);
+        .setConsistencyLevel(ConsistencyLevel.QUORUM);
 
     PreparedStatement updateRepairRunPrepStmt = session
         .prepare("INSERT INTO repair_run (id,start_time,pause_time,end_time) VALUES(?, ?, ?, ?)")

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/FixRepairSegmentTimestamps.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/FixRepairSegmentTimestamps.java
@@ -46,7 +46,7 @@ public final class FixRepairSegmentTimestamps {
 
     Statement getRepairSegmentsPrepStmt
         = new SimpleStatement("SELECT id,segment_id,segment_state,segment_start_time,segment_end_time FROM repair_run")
-            .setConsistencyLevel(ConsistencyLevel.QUORUM);
+        .setConsistencyLevel(ConsistencyLevel.QUORUM);
 
     PreparedStatement updateRepairSegmentPrepStmt = session
         .prepare("INSERT INTO repair_run (id,segment_id,segment_start_time,segment_end_time)  VALUES(?, ?, ?, ?)")

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/Migration016.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/Migration016.java
@@ -31,7 +31,7 @@ public final class Migration016 {
 
   /**
    * if Cassandra is running version less than 4.0
-   *  alter every table to set `dclocal_read_repair_chance` to zero
+   * alter every table to set `dclocal_read_repair_chance` to zero
    */
   public static void migrate(Session session, String keyspace) {
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/Migration021.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/Migration021.java
@@ -49,17 +49,17 @@ public final class Migration021 {
         if (!isUsingTwcs(session, keyspace)) {
           LOG.info("Altering {} to use TWCS...", METRICS_V1_TABLE);
           session.execute(
-                  "ALTER TABLE " + METRICS_V1_TABLE + " WITH compaction = {'class': 'TimeWindowCompactionStrategy', "
-                      + "'unchecked_tombstone_compaction': 'true', "
-                      + "'compaction_window_size': '2', "
-                      + "'compaction_window_unit': 'MINUTES'}");
+              "ALTER TABLE " + METRICS_V1_TABLE + " WITH compaction = {'class': 'TimeWindowCompactionStrategy', "
+                  + "'unchecked_tombstone_compaction': 'true', "
+                  + "'compaction_window_size': '2', "
+                  + "'compaction_window_unit': 'MINUTES'}");
 
           LOG.info("Altering {} to use TWCS...", OPERATIONS_TABLE);
           session.execute(
-                  "ALTER TABLE " + OPERATIONS_TABLE + " WITH compaction = {'class': 'TimeWindowCompactionStrategy', "
-                      + "'unchecked_tombstone_compaction': 'true', "
-                      + "'compaction_window_size': '30', "
-                      + "'compaction_window_unit': 'MINUTES'}");
+              "ALTER TABLE " + OPERATIONS_TABLE + " WITH compaction = {'class': 'TimeWindowCompactionStrategy', "
+                  + "'unchecked_tombstone_compaction': 'true', "
+                  + "'compaction_window_size': '30', "
+                  + "'compaction_window_unit': 'MINUTES'}");
 
           LOG.info("{} was successfully altered to use TWCS.", OPERATIONS_TABLE);
         }

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/Migration024.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/Migration024.java
@@ -48,10 +48,10 @@ public final class Migration024 {
         if (!isUsingTwcs(session, keyspace)) {
           LOG.info("Altering {} to use TWCS...", METRICS_V3_TABLE);
           session.execute(
-                  "ALTER TABLE " + METRICS_V3_TABLE + " WITH compaction = {'class': 'TimeWindowCompactionStrategy', "
-                      + "'unchecked_tombstone_compaction': 'true', "
-                      + "'compaction_window_size': '10', "
-                      + "'compaction_window_unit': 'MINUTES'}");
+              "ALTER TABLE " + METRICS_V3_TABLE + " WITH compaction = {'class': 'TimeWindowCompactionStrategy', "
+                  + "'unchecked_tombstone_compaction': 'true', "
+                  + "'compaction_window_size': '10', "
+                  + "'compaction_window_unit': 'MINUTES'}");
 
           LOG.info("{} was successfully altered to use TWCS.", METRICS_V3_TABLE);
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/Migration025.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/migrations/Migration025.java
@@ -45,10 +45,10 @@ public final class Migration025 {
             "INSERT INTO " + V2_TABLE + "(cluster_name, id, repair_run_state) values (?, ?, ?)");
         LOG.info("Converting {} table...", V1_TABLE);
         ResultSet results = session.execute("SELECT * FROM " + V1_TABLE);
-        for (Row row:results) {
+        for (Row row : results) {
           ResultSet runResults = session.execute(
               "SELECT distinct state from repair_run where id = " + row.getUUID("id"));
-          for (Row runRow:runResults) {
+          for (Row runRow : runResults) {
             String state = runRow.getString("state");
             session.execute(v2_insert.bind(row.getString("cluster_name"), row.getUUID("id"), state));
           }

--- a/src/server/src/main/java/io/cassandrareaper/storage/cluster/CassClusterDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cluster/CassClusterDao.java
@@ -97,6 +97,7 @@ public class CassClusterDao implements ICluster {
         "DELETE FROM repair_run_by_cluster_v2 WHERE cluster_name = ?");
   }
 
+  @Override
   public Collection<Cluster> getClusters() {
     // cache the clusters list for ten seconds
     if (System.currentTimeMillis() - clustersCacheAge.get() > TimeUnit.SECONDS.toMillis(10)) {
@@ -114,7 +115,7 @@ public class CassClusterDao implements ICluster {
     return clustersCache.get();
   }
 
-
+  @Override
   public boolean addCluster(Cluster cluster) {
     assert addClusterAssertions(cluster);
     try {
@@ -133,7 +134,7 @@ public class CassClusterDao implements ICluster {
     return true;
   }
 
-
+  @Override
   public boolean updateCluster(Cluster newCluster) {
     return addCluster(newCluster);
   }
@@ -162,7 +163,7 @@ public class CassClusterDao implements ICluster {
     return true;
   }
 
-
+  @Override
   public Cluster getCluster(String clusterName) {
     Row row = session.execute(getClusterPrepStmt.bind(clusterName)).one();
     if (null != row) {
@@ -205,7 +206,7 @@ public class CassClusterDao implements ICluster {
     return builder.build();
   }
 
-
+  @Override
   public Cluster deleteCluster(String clusterName) {
     cassRepairScheduleDao.getRepairSchedulesForCluster(clusterName)
         .forEach(schedule -> cassRepairScheduleDao.deleteRepairSchedule(schedule.getId()));

--- a/src/server/src/main/java/io/cassandrareaper/storage/cluster/ICluster.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cluster/ICluster.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cluster;
+
+import io.cassandrareaper.core.Cluster;
+
+import java.util.Collection;
+
+public interface ICluster {
+  Collection<Cluster> getClusters();
+
+  boolean addCluster(Cluster cluster);
+
+  boolean updateCluster(Cluster newCluster);
+
+  Cluster getCluster(String clusterName);
+
+  /**
+   * Delete the Cluster instance identified by the given cluster name. Delete succeeds only if there are no repair runs
+   * for the targeted cluster.
+   *
+   * @param clusterName The name of the Cluster instance to delete.
+   * @return The deleted Cluster instance if delete succeeds, with state set to DELETED.
+   */
+  Cluster deleteCluster(String clusterName);
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/cluster/MemClusterDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cluster/MemClusterDao.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cluster;
+
+import io.cassandrareaper.core.Cluster;
+import io.cassandrareaper.storage.events.MemEventsDao;
+import io.cassandrareaper.storage.repairrun.MemRepairRunDao;
+import io.cassandrareaper.storage.repairschedule.MemRepairScheduleDao;
+import io.cassandrareaper.storage.repairunit.MemRepairUnitDao;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.StringUtils;
+
+public class MemClusterDao implements ICluster {
+  public final ConcurrentMap<String, Cluster> clusters = Maps.newConcurrentMap();
+  private final MemRepairUnitDao memRepairUnitDao;
+  private final MemRepairRunDao memRepairRunDao;
+  private final MemRepairScheduleDao memRepairScheduleDao;
+
+  private final MemEventsDao memEventsDao;
+
+  public MemClusterDao(MemRepairUnitDao memRepairUnitDao,
+                       MemRepairRunDao memRepairRunDao,
+                       MemRepairScheduleDao memRepairScheduleDao,
+                       MemEventsDao memEventsDao) {
+    this.memRepairUnitDao = memRepairUnitDao;
+    this.memRepairRunDao = memRepairRunDao;
+    this.memRepairScheduleDao = memRepairScheduleDao;
+    this.memEventsDao = memEventsDao;
+  }
+
+  @Override
+  public Collection<Cluster> getClusters() {
+    return clusters.values();
+  }
+
+  @Override
+  public boolean addCluster(Cluster cluster) {
+    assert addClusterAssertions(cluster);
+    Cluster existing = clusters.put(cluster.getName(), cluster);
+    return existing == null;
+  }
+
+  @Override
+  public boolean updateCluster(Cluster newCluster) {
+    addCluster(newCluster);
+    return true;
+  }
+
+  public boolean addClusterAssertions(Cluster cluster) {
+    Preconditions.checkState(
+          Cluster.State.UNKNOWN != cluster.getState(),
+          "Cluster should not be persisted with UNKNOWN state");
+
+    // TODO – unit tests need to also always set the paritioner
+    //Preconditions.checkState(cluster.getPartitioner().isPresent(), "Cannot store cluster with no partitioner.");
+
+    // assert we're not overwriting a cluster with the same name but different node list
+    Set<String> previousNodes;
+    try {
+      previousNodes = getCluster(cluster.getName()).getSeedHosts();
+    } catch (IllegalArgumentException ignore) {
+      // there is no previous cluster with same name
+      previousNodes = cluster.getSeedHosts();
+    }
+    Set<String> addedNodes = cluster.getSeedHosts();
+
+    Preconditions.checkArgument(
+          !Collections.disjoint(previousNodes, addedNodes),
+          "Trying to add/update cluster using an existing name: %s. No nodes overlap between %s and %s",
+          cluster.getName(), StringUtils.join(previousNodes, ','), StringUtils.join(addedNodes, ','));
+
+    return true;
+  }
+
+  @Override
+  public Cluster getCluster(String clusterName) {
+    Preconditions.checkArgument(clusters.containsKey(clusterName), "no such cluster: %s", clusterName);
+    return clusters.get(clusterName);
+  }
+
+  @Override
+  public Cluster deleteCluster(String clusterName) {
+    memRepairScheduleDao.getRepairSchedulesForCluster(clusterName).forEach(
+        schedule -> memRepairScheduleDao.deleteRepairSchedule(schedule.getId())
+    );
+    memRepairRunDao.getRepairRunIdsForCluster(clusterName, Optional.empty())
+          .forEach(runId -> memRepairRunDao.deleteRepairRun(runId));
+
+    memEventsDao.getEventSubscriptions(clusterName)
+          .stream()
+          .filter(subscription -> subscription.getId().isPresent())
+          .forEach(subscription -> memEventsDao.deleteEventSubscription(subscription.getId().get()));
+
+    memRepairUnitDao.repairUnits.values().stream()
+          .filter((unit) -> unit.getClusterName().equals(clusterName))
+          .forEach((unit) -> {
+            assert memRepairRunDao.getRepairRunsForUnit(
+                  unit.getId()).isEmpty() : StringUtils.join(memRepairRunDao.getRepairRunsForUnit(unit.getId())
+            );
+            memRepairUnitDao.repairUnits.remove(unit.getId());
+            memRepairUnitDao.repairUnitsByKey.remove(unit.with());
+          });
+
+    return clusters.remove(clusterName);
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/events/CassEventsDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/events/CassEventsDao.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package io.cassandrareaper.storage.cassandra;
+package io.cassandrareaper.storage.events;
 
 import io.cassandrareaper.core.DiagEventSubscription;
 
@@ -30,14 +30,14 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.google.common.base.Preconditions;
 
-public class EventsDao {
+public class CassEventsDao implements IEvents {
   PreparedStatement getDiagnosticEventsPrepStmt;
   PreparedStatement getDiagnosticEventPrepStmt;
   PreparedStatement deleteDiagnosticEventPrepStmt;
   PreparedStatement saveDiagnosticEventPrepStmt;
   private final Session session;
 
-  public EventsDao(Session session) {
+  public CassEventsDao(Session session) {
     this.session = session;
     prepareStatements();
   }

--- a/src/server/src/main/java/io/cassandrareaper/storage/events/CassEventsDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/events/CassEventsDao.java
@@ -65,13 +65,14 @@ public class CassEventsDao implements IEvents {
   }
 
 
+  @Override
   public Collection<DiagEventSubscription> getEventSubscriptions() {
     return session.execute(getDiagnosticEventsPrepStmt.bind()).all().stream()
         .map((row) -> createDiagEventSubscription(row))
         .collect(Collectors.toList());
   }
 
-
+  @Override
   public Collection<DiagEventSubscription> getEventSubscriptions(String clusterName) {
     Preconditions.checkNotNull(clusterName);
 
@@ -81,7 +82,7 @@ public class CassEventsDao implements IEvents {
         .collect(Collectors.toList());
   }
 
-
+  @Override
   public DiagEventSubscription getEventSubscription(UUID id) {
     Row row = session.execute(getDiagnosticEventPrepStmt.bind(id)).one();
     if (null != row) {
@@ -90,7 +91,7 @@ public class CassEventsDao implements IEvents {
     throw new IllegalArgumentException("No event subscription with id " + id);
   }
 
-
+  @Override
   public DiagEventSubscription addEventSubscription(DiagEventSubscription subscription) {
     Preconditions.checkArgument(subscription.getId().isPresent());
 
@@ -107,7 +108,7 @@ public class CassEventsDao implements IEvents {
     return subscription;
   }
 
-
+  @Override
   public boolean deleteEventSubscription(UUID id) {
     session.execute(deleteDiagnosticEventPrepStmt.bind(id));
     return true;

--- a/src/server/src/main/java/io/cassandrareaper/storage/events/IEvents.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/events/IEvents.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.events;
+
+import io.cassandrareaper.core.DiagEventSubscription;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public interface IEvents {
+  Collection<DiagEventSubscription> getEventSubscriptions();
+
+  Collection<DiagEventSubscription> getEventSubscriptions(String clusterName);
+
+  DiagEventSubscription getEventSubscription(UUID id);
+
+  DiagEventSubscription addEventSubscription(DiagEventSubscription subscription);
+
+  boolean deleteEventSubscription(UUID id);
+
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/events/MemEventsDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/events/MemEventsDao.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.events;
+
+import io.cassandrareaper.core.DiagEventSubscription;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
+public class MemEventsDao implements IEvents {
+  private final ConcurrentMap<UUID, DiagEventSubscription> subscriptionsById = Maps.newConcurrentMap();
+
+  public MemEventsDao() {
+
+  }
+
+  @Override
+  public Collection<DiagEventSubscription> getEventSubscriptions() {
+    return subscriptionsById.values();
+  }
+
+  @Override
+  public Collection<DiagEventSubscription> getEventSubscriptions(String clusterName) {
+    Preconditions.checkNotNull(clusterName);
+    Collection<DiagEventSubscription> ret = new ArrayList<DiagEventSubscription>();
+    for (DiagEventSubscription sub : subscriptionsById.values()) {
+      if (sub.getCluster().equals(clusterName)) {
+        ret.add(sub);
+      }
+    }
+    return ret;
+  }
+
+  @Override
+  public DiagEventSubscription getEventSubscription(UUID id) {
+    if (subscriptionsById.containsKey(id)) {
+      return subscriptionsById.get(id);
+    }
+    throw new IllegalArgumentException("No event subscription with id " + id);
+  }
+
+  @Override
+  public DiagEventSubscription addEventSubscription(DiagEventSubscription subscription) {
+    Preconditions.checkArgument(subscription.getId().isPresent());
+    subscriptionsById.put(subscription.getId().get(), subscription);
+    return subscription;
+  }
+
+  @Override
+  public boolean deleteEventSubscription(UUID id) {
+    return subscriptionsById.remove(id) != null;
+  }
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/metrics/CassMetricsDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/metrics/CassMetricsDao.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package io.cassandrareaper.storage.cassandra;
+package io.cassandrareaper.storage.metrics;
 
 import io.cassandrareaper.core.GenericMetric;
 import io.cassandrareaper.core.PercentRepairedMetric;
@@ -38,7 +38,7 @@ import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public class MetricsDao {
+public class CassMetricsDao implements IMetrics {
 
   static final int METRICS_PARTITIONING_TIME_MINS = 10;
   private static final DateTimeFormatter TIME_BUCKET_FORMATTER = DateTimeFormat.forPattern("yyyyMMddHHmm");
@@ -52,7 +52,7 @@ public class MetricsDao {
   private PreparedStatement storePercentRepairedForSchedulePrepStmt;
   private PreparedStatement getPercentRepairedForSchedulePrepStmt;
 
-  public MetricsDao(Session session) {
+  public CassMetricsDao(Session session) {
 
     this.session = session;
     prepareMetricStatements();
@@ -189,7 +189,7 @@ public class MetricsDao {
    * @param metricTime the time of the metric
    * @return the time truncated to the closest partition
    */
-  DateTime computeMetricsPartition(DateTime metricTime) {
+  public DateTime computeMetricsPartition(DateTime metricTime) {
     return metricTime
         .withMinuteOfHour(
             (metricTime.getMinuteOfHour() / METRICS_PARTITIONING_TIME_MINS)
@@ -264,4 +264,5 @@ public class MetricsDao {
         DateTime.now().toDate())
     );
   }
+
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/metrics/CassMetricsDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/metrics/CassMetricsDao.java
@@ -38,7 +38,7 @@ import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public class CassMetricsDao implements IMetrics {
+public class CassMetricsDao implements IMetrics, IDistributedMetrics {
 
   static final int METRICS_PARTITIONING_TIME_MINS = 10;
   private static final DateTimeFormatter TIME_BUCKET_FORMATTER = DateTimeFormat.forPattern("yyyyMMddHHmm");
@@ -101,6 +101,7 @@ public class CassMetricsDao implements IMetrics {
   }
 
 
+  @Override
   public List<GenericMetric> getMetrics(
       String clusterName,
       Optional<String> host,
@@ -153,6 +154,7 @@ public class CassMetricsDao implements IMetrics {
   }
 
 
+  @Override
   public void storeMetrics(List<GenericMetric> metrics) {
     Map<String, List<GenericMetric>> metricsPerPartition = metrics.stream()
         .collect(Collectors.groupingBy(metric ->
@@ -203,6 +205,7 @@ public class CassMetricsDao implements IMetrics {
   }
 
 
+  @Override
   public List<PercentRepairedMetric> getPercentRepairedMetrics(String clusterName, UUID repairScheduleId, Long since) {
     List<PercentRepairedMetric> metrics = Lists.newArrayList();
     List<ResultSetFuture> futures = Lists.newArrayList();
@@ -251,7 +254,7 @@ public class CassMetricsDao implements IMetrics {
     return metrics;
   }
 
-
+  @Override
   public void storePercentRepairedMetric(PercentRepairedMetric metric) {
     session.execute(storePercentRepairedForSchedulePrepStmt.bind(
         metric.getCluster(),

--- a/src/server/src/main/java/io/cassandrareaper/storage/metrics/IDistributedMetrics.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/metrics/IDistributedMetrics.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.metrics;
 
 import io.cassandrareaper.core.GenericMetric;

--- a/src/server/src/main/java/io/cassandrareaper/storage/metrics/IDistributedMetrics.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/metrics/IDistributedMetrics.java
@@ -1,0 +1,17 @@
+package io.cassandrareaper.storage.metrics;
+
+import io.cassandrareaper.core.GenericMetric;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface IDistributedMetrics {
+  List<GenericMetric> getMetrics(
+        String clusterName,
+        Optional<String> host,
+        String metricDomain,
+        String metricType,
+        long since);
+
+  void storeMetrics(List<GenericMetric> metric);
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/metrics/IMetrics.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/metrics/IMetrics.java
@@ -1,0 +1,19 @@
+package io.cassandrareaper.storage.metrics;
+
+import io.cassandrareaper.core.PercentRepairedMetric;
+import io.cassandrareaper.resources.view.RepairRunStatus;
+import io.cassandrareaper.resources.view.RepairScheduleStatus;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public interface IMetrics {
+
+  List<PercentRepairedMetric> getPercentRepairedMetrics(
+        String clusterName,
+        UUID repairScheduleId,
+        Long since);
+
+  void storePercentRepairedMetric(PercentRepairedMetric metric);
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/metrics/IMetrics.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/metrics/IMetrics.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.metrics;
 
 import io.cassandrareaper.core.PercentRepairedMetric;
-import io.cassandrareaper.resources.view.RepairRunStatus;
-import io.cassandrareaper.resources.view.RepairScheduleStatus;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/metrics/MemMetricsDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/metrics/MemMetricsDao.java
@@ -1,0 +1,51 @@
+package io.cassandrareaper.storage.metrics;
+
+import io.cassandrareaper.core.PercentRepairedMetric;
+import io.cassandrareaper.core.RepairRun;
+import io.cassandrareaper.core.RepairSegment;
+import io.cassandrareaper.core.RepairUnit;
+import io.cassandrareaper.resources.view.RepairRunStatus;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+public class MemMetricsDao implements IMetrics {
+  public final ConcurrentMap<String, Map<String, PercentRepairedMetric>> percentRepairedMetrics
+        = Maps.newConcurrentMap();
+
+  public MemMetricsDao() {
+  }
+
+  @Override
+  public List<PercentRepairedMetric> getPercentRepairedMetrics(String clusterName, UUID repairScheduleId, Long since) {
+    return percentRepairedMetrics.entrySet().stream()
+          .filter(entry -> entry.getKey().equals(clusterName + "-" + repairScheduleId))
+          .map(entry -> entry.getValue().entrySet())
+          .flatMap(Collection::stream)
+          .map(Map.Entry::getValue)
+          .collect(Collectors.toList());
+  }
+
+
+  @Override
+  public void storePercentRepairedMetric(PercentRepairedMetric metric) {
+    synchronized (MemMetricsDao.class) {
+      String metricKey = metric.getCluster() + "-" + metric.getRepairScheduleId();
+      Map<String, PercentRepairedMetric> newValue = Maps.newHashMap();
+      if (percentRepairedMetrics.containsKey(metricKey)) {
+        newValue.putAll(percentRepairedMetrics.get(metricKey));
+      }
+      newValue.put(metric.getNode(), metric);
+      percentRepairedMetrics.put(metricKey, newValue);
+    }
+  }
+
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/metrics/MemMetricsDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/metrics/MemMetricsDao.java
@@ -1,20 +1,31 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.metrics;
 
 import io.cassandrareaper.core.PercentRepairedMetric;
-import io.cassandrareaper.core.RepairRun;
-import io.cassandrareaper.core.RepairSegment;
-import io.cassandrareaper.core.RepairUnit;
-import io.cassandrareaper.resources.view.RepairRunStatus;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 public class MemMetricsDao implements IMetrics {

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/CassRepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/CassRepairRunDao.java
@@ -80,7 +80,7 @@ public class CassRepairRunDao implements IRepairRun {
                           ClusterDao clusterDao,
                           CassRepairSegmentDao cassRepairSegmentDao,
                           Session session,
-                          ObjectMapper objectMapper ) {
+                          ObjectMapper objectMapper) {
     this.session = session;
     this.cassRepairSegmentDao = cassRepairSegmentDao;
     this.cassRepairUnitDao = cassRepairUnitDao;
@@ -365,8 +365,7 @@ public class CassRepairRunDao implements IRepairRun {
       idResSetFuture
           .getUninterruptibly()
           .forEach(
-              row -> flattenedUuids.add(row.getUUID("id"))
-        );
+              row -> flattenedUuids.add(row.getUUID("id")));
     }
     // Merge the two lists and trim.
     repairUuidFuturesNoState.getUninterruptibly().forEach(row -> {

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/CassRepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/CassRepairRunDao.java
@@ -20,7 +20,7 @@ package io.cassandrareaper.storage.repairrun;
 
 import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSegment;
-import io.cassandrareaper.storage.cassandra.ClusterDao;
+import io.cassandrareaper.storage.cluster.CassClusterDao;
 import io.cassandrareaper.storage.repairsegment.CassRepairSegmentDao;
 import io.cassandrareaper.storage.repairunit.CassRepairUnitDao;
 
@@ -71,20 +71,20 @@ public class CassRepairRunDao implements IRepairRun {
   PreparedStatement deleteRepairRunByClusterByIdPrepStmt;
   PreparedStatement deleteRepairRunByUnitPrepStmt;
   private final CassRepairUnitDao cassRepairUnitDao;
-  private final ClusterDao clusterDao;
+  private final CassClusterDao cassClusterDao;
 
   private final CassRepairSegmentDao cassRepairSegmentDao;
   private final Session session;
 
   public CassRepairRunDao(CassRepairUnitDao cassRepairUnitDao,
-                          ClusterDao clusterDao,
+                          CassClusterDao cassClusterDao,
                           CassRepairSegmentDao cassRepairSegmentDao,
                           Session session,
                           ObjectMapper objectMapper) {
     this.session = session;
     this.cassRepairSegmentDao = cassRepairSegmentDao;
     this.cassRepairUnitDao = cassRepairUnitDao;
-    this.clusterDao = clusterDao;
+    this.cassClusterDao = cassClusterDao;
     this.objectMapper = objectMapper;
     prepareStatements();
   }
@@ -434,7 +434,7 @@ public class CassRepairRunDao implements IRepairRun {
   public Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState) {
     Set<RepairRun> repairRunsWithState = Sets.newHashSet();
 
-    List<Collection<UUID>> repairRunIds = clusterDao.getClusters()
+    List<Collection<UUID>> repairRunIds = cassClusterDao.getClusters()
         .stream()
         // Grab all ids for the given cluster name
         .map(cluster -> getRepairRunIdsForClusterWithState(cluster.getName(), runState))

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/IRepairRun.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/IRepairRun.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2016-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ * Copyright 2020-2020 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.repairrun;
 
 import io.cassandrareaper.core.RepairRun;
@@ -9,32 +27,32 @@ import java.util.SortedSet;
 import java.util.UUID;
 
 public interface IRepairRun {
-    RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments);
+  RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments);
 
-    boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState);
+  boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState);
 
-    boolean updateRepairRun(RepairRun repairRun);
+  boolean updateRepairRun(RepairRun repairRun);
 
-    Optional<RepairRun> getRepairRun(UUID id);
+  Optional<RepairRun> getRepairRun(UUID id);
 
-    /**
-     * return all the repair runs in a cluster, in reverse chronological order, with default limit is 1000
-     */
-    Collection<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit);
+  /**
+   * return all the repair runs in a cluster, in reverse chronological order, with default limit is 1000
+   */
+  Collection<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit);
 
-    Collection<RepairRun> getRepairRunsForClusterPrioritiseRunning(String clusterName, Optional<Integer> limit);
+  Collection<RepairRun> getRepairRunsForClusterPrioritiseRunning(String clusterName, Optional<Integer> limit);
 
-    Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId);
+  Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId);
 
-    Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState);
+  Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState);
 
-    SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit);
+  SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit);
 
-    /**
-     * Delete the RepairRun instance identified by the given id, and delete also all the related repair segments.
-     *
-     * @param id The id of the RepairRun instance to delete, and all segments for it.
-     * @return The deleted RepairRun instance, if delete succeeds, with state set to DELETED.
-     */
-    Optional<RepairRun> deleteRepairRun(UUID id);
+  /**
+   * Delete the RepairRun instance identified by the given id, and delete also all the related repair segments.
+   *
+   * @param id The id of the RepairRun instance to delete, and all segments for it.
+   * @return The deleted RepairRun instance, if delete succeeds, with state set to DELETED.
+   */
+  Optional<RepairRun> deleteRepairRun(UUID id);
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/IRepairRun.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/IRepairRun.java
@@ -1,0 +1,40 @@
+package io.cassandrareaper.storage.repairrun;
+
+import io.cassandrareaper.core.RepairRun;
+import io.cassandrareaper.core.RepairSegment;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.UUID;
+
+public interface IRepairRun {
+    RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments);
+
+    boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState);
+
+    boolean updateRepairRun(RepairRun repairRun);
+
+    Optional<RepairRun> getRepairRun(UUID id);
+
+    /**
+     * return all the repair runs in a cluster, in reverse chronological order, with default limit is 1000
+     */
+    Collection<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit);
+
+    Collection<RepairRun> getRepairRunsForClusterPrioritiseRunning(String clusterName, Optional<Integer> limit);
+
+    Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId);
+
+    Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState);
+
+    SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit);
+
+    /**
+     * Delete the RepairRun instance identified by the given id, and delete also all the related repair segments.
+     *
+     * @param id The id of the RepairRun instance to delete, and all segments for it.
+     * @return The deleted RepairRun instance, if delete succeeds, with state set to DELETED.
+     */
+    Optional<RepairRun> deleteRepairRun(UUID id);
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/IRepairRun.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/IRepairRun.java
@@ -20,6 +20,7 @@ package io.cassandrareaper.storage.repairrun;
 
 import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairSegment;
+import io.cassandrareaper.resources.view.RepairRunStatus;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -55,4 +56,6 @@ public interface IRepairRun {
    * @return The deleted RepairRun instance, if delete succeeds, with state set to DELETED.
    */
   Optional<RepairRun> deleteRepairRun(UUID id);
+
+  Collection<RepairRunStatus> getClusterRunStatuses(String clusterName, int limit);
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/MemRepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/MemRepairRunDao.java
@@ -53,6 +53,8 @@ public class MemRepairRunDao implements IRepairRun {
   }
 
 
+
+  @Override
   public RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments) {
     RepairRun newRepairRun = repairRun.build(UUIDs.timeBased());
     repairRuns.put(newRepairRun.getId(), newRepairRun);

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/MemRepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/MemRepairRunDao.java
@@ -135,7 +135,6 @@ public class MemRepairRunDao implements IRepairRun {
     RepairRun deletedRun = repairRuns.remove(id);
     if (deletedRun != null) {
       if (memRepairSegment.getSegmentAmountForRepairRunWithState(id, RepairSegment.State.RUNNING) == 0) {
-        memRepairUnitDao.deleteRepairUnit(deletedRun.getRepairUnitId());
         memRepairSegment.deleteRepairSegmentsForRun(id);
 
         deletedRun = deletedRun.with()

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/MemRepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/MemRepairRunDao.java
@@ -1,0 +1,134 @@
+package io.cassandrareaper.storage.repairrun;
+
+import io.cassandrareaper.core.RepairRun;
+import io.cassandrareaper.core.RepairSegment;
+import io.cassandrareaper.service.RepairRunService;
+import io.cassandrareaper.storage.repairsegment.MemRepairSegment;
+import io.cassandrareaper.storage.repairunit.MemRepairUnitDao;
+
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.joda.time.DateTime;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+public class MemRepairRunDao implements IRepairRun {
+    public final ConcurrentMap<UUID, RepairRun> repairRuns = Maps.newConcurrentMap();
+    private final MemRepairSegment memRepairSegment;
+    private final MemRepairUnitDao memRepairUnitDao;
+
+
+    public MemRepairRunDao(MemRepairSegment memRepairSegment, MemRepairUnitDao memRepairUnitDao) {
+        this.memRepairSegment = memRepairSegment;
+        this.memRepairUnitDao = memRepairUnitDao;
+    }
+
+    
+    public RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments) {
+        RepairRun newRepairRun = repairRun.build(UUIDs.timeBased());
+        repairRuns.put(newRepairRun.getId(), newRepairRun);
+        memRepairSegment.addRepairSegments(newSegments, newRepairRun.getId());
+        return newRepairRun;
+    }
+
+    
+    public boolean updateRepairRun(RepairRun repairRun) {
+        return updateRepairRun(repairRun, Optional.of(true));
+    }
+
+    
+    public boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState) {
+        if (!getRepairRun(repairRun.getId()).isPresent()) {
+            return false;
+        } else {
+            repairRuns.put(repairRun.getId(), repairRun);
+            return true;
+        }
+    }
+
+    
+    public Optional<RepairRun> getRepairRun(UUID id) {
+        return Optional.ofNullable(repairRuns.get(id));
+    }
+
+    
+    public List<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit) {
+        List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
+        TreeMap<UUID, RepairRun> reverseOrder = new TreeMap<UUID, RepairRun>(Collections.reverseOrder());
+        reverseOrder.putAll(repairRuns);
+        for (RepairRun repairRun : reverseOrder.values()) {
+            if (repairRun.getClusterName().equalsIgnoreCase(clusterName)) {
+                foundRepairRuns.add(repairRun);
+                if (foundRepairRuns.size() == limit.orElse(1000)) {
+                    break;
+                }
+            }
+        }
+        return foundRepairRuns;
+    }
+
+    
+    public List<RepairRun> getRepairRunsForClusterPrioritiseRunning(String clusterName, Optional<Integer> limit) {
+        List<RepairRun> foundRepairRuns = repairRuns
+                .values()
+                .stream()
+                .filter(
+                        row -> row.getClusterName().equals(clusterName.toLowerCase(Locale.ROOT))).collect(Collectors.toList()
+                );
+        RepairRunService.sortByRunState(foundRepairRuns);
+        return foundRepairRuns.subList(0, Math.min(foundRepairRuns.size(), limit.orElse(1000)));
+    }
+
+    
+    public Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId) {
+        List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
+        for (RepairRun repairRun : repairRuns.values()) {
+            if (repairRun.getRepairUnitId().equals(repairUnitId)) {
+                foundRepairRuns.add(repairRun);
+            }
+        }
+        return foundRepairRuns;
+    }
+
+    
+    public Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState) {
+        List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
+        for (RepairRun repairRun : repairRuns.values()) {
+            if (repairRun.getRunState() == runState) {
+                foundRepairRuns.add(repairRun);
+            }
+        }
+        return foundRepairRuns;
+    }
+
+    
+    public Optional<RepairRun> deleteRepairRun(UUID id) {
+        RepairRun deletedRun = repairRuns.remove(id);
+        if (deletedRun != null) {
+            if (memRepairSegment.getSegmentAmountForRepairRunWithState(id, RepairSegment.State.RUNNING) == 0) {
+                memRepairUnitDao.deleteRepairUnit(deletedRun.getRepairUnitId());
+                memRepairSegment.deleteRepairSegmentsForRun(id);
+
+                deletedRun = deletedRun.with()
+                        .runState(RepairRun.RunState.DELETED)
+                        .endTime(DateTime.now())
+                        .build(id);
+            }
+        }
+        return Optional.ofNullable(deletedRun);
+    }
+
+    
+    public SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit) {
+        SortedSet<UUID> repairRunIds = Sets.newTreeSet((u0, u1) -> (int) (u0.timestamp() - u1.timestamp()));
+        for (RepairRun repairRun : repairRuns.values()) {
+            if (repairRun.getClusterName().equalsIgnoreCase(clusterName)) {
+                repairRunIds.add(repairRun.getId());
+            }
+        }
+        return repairRunIds;
+    }
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/MemRepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/MemRepairRunDao.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2016-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ * Copyright 2020-2020 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.repairrun;
 
 import io.cassandrareaper.core.RepairRun;
@@ -6,129 +24,137 @@ import io.cassandrareaper.service.RepairRunService;
 import io.cassandrareaper.storage.repairsegment.MemRepairSegment;
 import io.cassandrareaper.storage.repairunit.MemRepairUnitDao;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
-
 public class MemRepairRunDao implements IRepairRun {
-    public final ConcurrentMap<UUID, RepairRun> repairRuns = Maps.newConcurrentMap();
-    private final MemRepairSegment memRepairSegment;
-    private final MemRepairUnitDao memRepairUnitDao;
+  public final ConcurrentMap<UUID, RepairRun> repairRuns = Maps.newConcurrentMap();
+  private final MemRepairSegment memRepairSegment;
+  private final MemRepairUnitDao memRepairUnitDao;
 
 
-    public MemRepairRunDao(MemRepairSegment memRepairSegment, MemRepairUnitDao memRepairUnitDao) {
-        this.memRepairSegment = memRepairSegment;
-        this.memRepairUnitDao = memRepairUnitDao;
+  public MemRepairRunDao(MemRepairSegment memRepairSegment, MemRepairUnitDao memRepairUnitDao) {
+    this.memRepairSegment = memRepairSegment;
+    this.memRepairUnitDao = memRepairUnitDao;
+  }
+
+
+  public RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments) {
+    RepairRun newRepairRun = repairRun.build(UUIDs.timeBased());
+    repairRuns.put(newRepairRun.getId(), newRepairRun);
+    memRepairSegment.addRepairSegments(newSegments, newRepairRun.getId());
+    return newRepairRun;
+  }
+
+
+  public boolean updateRepairRun(RepairRun repairRun) {
+    return updateRepairRun(repairRun, Optional.of(true));
+  }
+
+
+  public boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState) {
+    if (!getRepairRun(repairRun.getId()).isPresent()) {
+      return false;
+    } else {
+      repairRuns.put(repairRun.getId(), repairRun);
+      return true;
     }
+  }
 
-    
-    public RepairRun addRepairRun(RepairRun.Builder repairRun, Collection<RepairSegment.Builder> newSegments) {
-        RepairRun newRepairRun = repairRun.build(UUIDs.timeBased());
-        repairRuns.put(newRepairRun.getId(), newRepairRun);
-        memRepairSegment.addRepairSegments(newSegments, newRepairRun.getId());
-        return newRepairRun;
-    }
 
-    
-    public boolean updateRepairRun(RepairRun repairRun) {
-        return updateRepairRun(repairRun, Optional.of(true));
-    }
+  public Optional<RepairRun> getRepairRun(UUID id) {
+    return Optional.ofNullable(repairRuns.get(id));
+  }
 
-    
-    public boolean updateRepairRun(RepairRun repairRun, Optional<Boolean> updateRepairState) {
-        if (!getRepairRun(repairRun.getId()).isPresent()) {
-            return false;
-        } else {
-            repairRuns.put(repairRun.getId(), repairRun);
-            return true;
+
+  public List<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit) {
+    List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
+    TreeMap<UUID, RepairRun> reverseOrder = new TreeMap<UUID, RepairRun>(Collections.reverseOrder());
+    reverseOrder.putAll(repairRuns);
+    for (RepairRun repairRun : reverseOrder.values()) {
+      if (repairRun.getClusterName().equalsIgnoreCase(clusterName)) {
+        foundRepairRuns.add(repairRun);
+        if (foundRepairRuns.size() == limit.orElse(1000)) {
+          break;
         }
+      }
     }
+    return foundRepairRuns;
+  }
 
-    
-    public Optional<RepairRun> getRepairRun(UUID id) {
-        return Optional.ofNullable(repairRuns.get(id));
+
+  public List<RepairRun> getRepairRunsForClusterPrioritiseRunning(String clusterName, Optional<Integer> limit) {
+    List<RepairRun> foundRepairRuns = repairRuns
+        .values()
+        .stream()
+        .filter(
+            row -> row.getClusterName().equals(clusterName.toLowerCase(Locale.ROOT))).collect(Collectors.toList()
+        );
+    RepairRunService.sortByRunState(foundRepairRuns);
+    return foundRepairRuns.subList(0, Math.min(foundRepairRuns.size(), limit.orElse(1000)));
+  }
+
+
+  public Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId) {
+    List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
+    for (RepairRun repairRun : repairRuns.values()) {
+      if (repairRun.getRepairUnitId().equals(repairUnitId)) {
+        foundRepairRuns.add(repairRun);
+      }
     }
+    return foundRepairRuns;
+  }
 
-    
-    public List<RepairRun> getRepairRunsForCluster(String clusterName, Optional<Integer> limit) {
-        List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
-        TreeMap<UUID, RepairRun> reverseOrder = new TreeMap<UUID, RepairRun>(Collections.reverseOrder());
-        reverseOrder.putAll(repairRuns);
-        for (RepairRun repairRun : reverseOrder.values()) {
-            if (repairRun.getClusterName().equalsIgnoreCase(clusterName)) {
-                foundRepairRuns.add(repairRun);
-                if (foundRepairRuns.size() == limit.orElse(1000)) {
-                    break;
-                }
-            }
-        }
-        return foundRepairRuns;
+
+  public Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState) {
+    List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
+    for (RepairRun repairRun : repairRuns.values()) {
+      if (repairRun.getRunState() == runState) {
+        foundRepairRuns.add(repairRun);
+      }
     }
+    return foundRepairRuns;
+  }
 
-    
-    public List<RepairRun> getRepairRunsForClusterPrioritiseRunning(String clusterName, Optional<Integer> limit) {
-        List<RepairRun> foundRepairRuns = repairRuns
-                .values()
-                .stream()
-                .filter(
-                        row -> row.getClusterName().equals(clusterName.toLowerCase(Locale.ROOT))).collect(Collectors.toList()
-                );
-        RepairRunService.sortByRunState(foundRepairRuns);
-        return foundRepairRuns.subList(0, Math.min(foundRepairRuns.size(), limit.orElse(1000)));
+
+  public Optional<RepairRun> deleteRepairRun(UUID id) {
+    RepairRun deletedRun = repairRuns.remove(id);
+    if (deletedRun != null) {
+      if (memRepairSegment.getSegmentAmountForRepairRunWithState(id, RepairSegment.State.RUNNING) == 0) {
+        memRepairUnitDao.deleteRepairUnit(deletedRun.getRepairUnitId());
+        memRepairSegment.deleteRepairSegmentsForRun(id);
+
+        deletedRun = deletedRun.with()
+            .runState(RepairRun.RunState.DELETED)
+            .endTime(DateTime.now())
+            .build(id);
+      }
     }
+    return Optional.ofNullable(deletedRun);
+  }
 
-    
-    public Collection<RepairRun> getRepairRunsForUnit(UUID repairUnitId) {
-        List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
-        for (RepairRun repairRun : repairRuns.values()) {
-            if (repairRun.getRepairUnitId().equals(repairUnitId)) {
-                foundRepairRuns.add(repairRun);
-            }
-        }
-        return foundRepairRuns;
+
+  public SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit) {
+    SortedSet<UUID> repairRunIds = Sets.newTreeSet((u0, u1) -> (int) (u0.timestamp() - u1.timestamp()));
+    for (RepairRun repairRun : repairRuns.values()) {
+      if (repairRun.getClusterName().equalsIgnoreCase(clusterName)) {
+        repairRunIds.add(repairRun.getId());
+      }
     }
-
-    
-    public Collection<RepairRun> getRepairRunsWithState(RepairRun.RunState runState) {
-        List<RepairRun> foundRepairRuns = new ArrayList<RepairRun>();
-        for (RepairRun repairRun : repairRuns.values()) {
-            if (repairRun.getRunState() == runState) {
-                foundRepairRuns.add(repairRun);
-            }
-        }
-        return foundRepairRuns;
-    }
-
-    
-    public Optional<RepairRun> deleteRepairRun(UUID id) {
-        RepairRun deletedRun = repairRuns.remove(id);
-        if (deletedRun != null) {
-            if (memRepairSegment.getSegmentAmountForRepairRunWithState(id, RepairSegment.State.RUNNING) == 0) {
-                memRepairUnitDao.deleteRepairUnit(deletedRun.getRepairUnitId());
-                memRepairSegment.deleteRepairSegmentsForRun(id);
-
-                deletedRun = deletedRun.with()
-                        .runState(RepairRun.RunState.DELETED)
-                        .endTime(DateTime.now())
-                        .build(id);
-            }
-        }
-        return Optional.ofNullable(deletedRun);
-    }
-
-    
-    public SortedSet<UUID> getRepairRunIdsForCluster(String clusterName, Optional<Integer> limit) {
-        SortedSet<UUID> repairRunIds = Sets.newTreeSet((u0, u1) -> (int) (u0.timestamp() - u1.timestamp()));
-        for (RepairRun repairRun : repairRuns.values()) {
-            if (repairRun.getClusterName().equalsIgnoreCase(clusterName)) {
-                repairRunIds.add(repairRun.getId());
-            }
-        }
-        return repairRunIds;
-    }
+    return repairRunIds;
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/CassRepairScheduleDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/CassRepairScheduleDao.java
@@ -20,6 +20,7 @@ package io.cassandrareaper.storage.repairschedule;
 
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
+import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.storage.repairunit.CassRepairUnitDao;
 
 import java.util.Collection;
@@ -268,5 +269,17 @@ public class CassRepairScheduleDao implements IRepairSchedule {
     }
 
     return repairSchedule;
+  }
+
+  @Override
+  public Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName) {
+    Collection<RepairSchedule> repairSchedules = getRepairSchedulesForCluster(clusterName);
+
+    Collection<RepairScheduleStatus> repairScheduleStatuses = repairSchedules
+          .stream()
+          .map(sched -> new RepairScheduleStatus(sched, cassRepairUnitDao.getRepairUnit(sched.getRepairUnitId())))
+          .collect(Collectors.toList());
+
+    return repairScheduleStatuses;
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/CassRepairScheduleDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/CassRepairScheduleDao.java
@@ -92,7 +92,7 @@ public class CassRepairScheduleDao implements IRepairSchedule {
             + "WHERE cluster_name = ? and keyspace_name = ? and repair_schedule_id = ?");
   }
 
-
+  @Override
   public RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule) {
     RepairSchedule schedule = repairSchedule.build(UUIDs.timeBased());
     updateRepairSchedule(schedule);
@@ -100,14 +100,14 @@ public class CassRepairScheduleDao implements IRepairSchedule {
     return schedule;
   }
 
-
+  @Override
   public Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId) {
     Row sched = session.execute(getRepairSchedulePrepStmt.bind(repairScheduleId)).one();
 
     return sched != null ? Optional.ofNullable(createRepairScheduleFromRow(sched)) : Optional.empty();
   }
 
-  public RepairSchedule createRepairScheduleFromRow(Row repairScheduleRow) {
+  private RepairSchedule createRepairScheduleFromRow(Row repairScheduleRow) {
     return RepairSchedule.builder(repairScheduleRow.getUUID("repair_unit_id"))
         .state(RepairSchedule.State.valueOf(repairScheduleRow.getString("state")))
         .daysBetween(repairScheduleRow.getInt("days_between"))
@@ -128,6 +128,7 @@ public class CassRepairScheduleDao implements IRepairSchedule {
   }
 
 
+  @Override
   public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName) {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
     ResultSet scheduleIds = session.execute(getRepairScheduleByClusterAndKsPrepStmt.bind(clusterName, " "));
@@ -142,6 +143,7 @@ public class CassRepairScheduleDao implements IRepairSchedule {
   }
 
 
+  @Override
   public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental) {
     return getRepairSchedulesForCluster(clusterName).stream()
         .filter(schedule -> cassRepairUnitDao.getRepairUnit(
@@ -151,6 +153,7 @@ public class CassRepairScheduleDao implements IRepairSchedule {
   }
 
 
+  @Override
   public Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName) {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
     ResultSet scheduleIds = session.execute(getRepairScheduleByClusterAndKsPrepStmt.bind(" ", keyspaceName));
@@ -165,6 +168,7 @@ public class CassRepairScheduleDao implements IRepairSchedule {
   }
 
 
+  @Override
   public Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName) {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
     ResultSet scheduleIds = session.execute(getRepairScheduleByClusterAndKsPrepStmt.bind(clusterName, keyspaceName));
@@ -179,6 +183,7 @@ public class CassRepairScheduleDao implements IRepairSchedule {
   }
 
 
+  @Override
   public Collection<RepairSchedule> getAllRepairSchedules() {
     Collection<RepairSchedule> schedules = Lists.<RepairSchedule>newArrayList();
     Statement stmt = new SimpleStatement(SELECT_REPAIR_SCHEDULE);
@@ -191,7 +196,7 @@ public class CassRepairScheduleDao implements IRepairSchedule {
     return schedules;
   }
 
-
+  @Override
   public boolean updateRepairSchedule(RepairSchedule newRepairSchedule) {
     final Set<UUID> repairHistory = Sets.newHashSet();
     repairHistory.addAll(newRepairSchedule.getRunHistory());
@@ -241,6 +246,7 @@ public class CassRepairScheduleDao implements IRepairSchedule {
   }
 
 
+  @Override
   public Optional<RepairSchedule> deleteRepairSchedule(UUID id) {
     Optional<RepairSchedule> repairSchedule = getRepairSchedule(id);
     if (repairSchedule.isPresent()) {

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/IRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/IRepairSchedule.java
@@ -41,14 +41,15 @@ public interface IRepairSchedule {
   Collection<RepairSchedule> getAllRepairSchedules();
 
   boolean updateRepairSchedule(RepairSchedule newRepairSchedule);
+
   Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName);
 
-    /**
-     * Delete the RepairSchedule instance identified by the given id. Related repair runs or other resources tied to the
-     * schedule will not be deleted.
-     *
-     * @param id The id of the RepairSchedule instance to delete.
-     * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
-     */
+  /**
+   * Delete the RepairSchedule instance identified by the given id. Related repair runs or other resources tied to the
+   * schedule will not be deleted.
+   *
+   * @param id The id of the RepairSchedule instance to delete.
+   * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
+   */
   Optional<RepairSchedule> deleteRepairSchedule(UUID id);
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/IRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/IRepairSchedule.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2016-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ * Copyright 2020-2020 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.repairschedule;
 
 import io.cassandrareaper.core.RepairSchedule;
@@ -7,28 +25,28 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface IRepairSchedule {
-    RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule);
+  RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule);
 
-    Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId);
+  Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId);
 
-    Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName);
+  Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName);
 
-    Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental);
+  Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental);
 
-    Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName);
+  Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName);
 
-    Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName);
+  Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName);
 
-    Collection<RepairSchedule> getAllRepairSchedules();
+  Collection<RepairSchedule> getAllRepairSchedules();
 
-    boolean updateRepairSchedule(RepairSchedule newRepairSchedule);
+  boolean updateRepairSchedule(RepairSchedule newRepairSchedule);
 
-    /**
-     * Delete the RepairSchedule instance identified by the given id. Related repair runs or other resources tied to the
-     * schedule will not be deleted.
-     *
-     * @param id The id of the RepairSchedule instance to delete.
-     * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
-     */
-    Optional<RepairSchedule> deleteRepairSchedule(UUID id);
+  /**
+   * Delete the RepairSchedule instance identified by the given id. Related repair runs or other resources tied to the
+   * schedule will not be deleted.
+   *
+   * @param id The id of the RepairSchedule instance to delete.
+   * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
+   */
+  Optional<RepairSchedule> deleteRepairSchedule(UUID id);
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/IRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/IRepairSchedule.java
@@ -1,0 +1,34 @@
+package io.cassandrareaper.storage.repairschedule;
+
+import io.cassandrareaper.core.RepairSchedule;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface IRepairSchedule {
+    RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule);
+
+    Optional<RepairSchedule> getRepairSchedule(UUID repairScheduleId);
+
+    Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName);
+
+    Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental);
+
+    Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName);
+
+    Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName);
+
+    Collection<RepairSchedule> getAllRepairSchedules();
+
+    boolean updateRepairSchedule(RepairSchedule newRepairSchedule);
+
+    /**
+     * Delete the RepairSchedule instance identified by the given id. Related repair runs or other resources tied to the
+     * schedule will not be deleted.
+     *
+     * @param id The id of the RepairSchedule instance to delete.
+     * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
+     */
+    Optional<RepairSchedule> deleteRepairSchedule(UUID id);
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/IRepairSchedule.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/IRepairSchedule.java
@@ -19,6 +19,7 @@
 package io.cassandrareaper.storage.repairschedule;
 
 import io.cassandrareaper.core.RepairSchedule;
+import io.cassandrareaper.resources.view.RepairScheduleStatus;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -40,13 +41,14 @@ public interface IRepairSchedule {
   Collection<RepairSchedule> getAllRepairSchedules();
 
   boolean updateRepairSchedule(RepairSchedule newRepairSchedule);
+  Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName);
 
-  /**
-   * Delete the RepairSchedule instance identified by the given id. Related repair runs or other resources tied to the
-   * schedule will not be deleted.
-   *
-   * @param id The id of the RepairSchedule instance to delete.
-   * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
-   */
+    /**
+     * Delete the RepairSchedule instance identified by the given id. Related repair runs or other resources tied to the
+     * schedule will not be deleted.
+     *
+     * @param id The id of the RepairSchedule instance to delete.
+     * @return The deleted RepairSchedule instance, if delete succeeds, with state set to DELETED.
+     */
   Optional<RepairSchedule> deleteRepairSchedule(UUID id);
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/MemRepairScheduleDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/MemRepairScheduleDao.java
@@ -20,6 +20,7 @@ package io.cassandrareaper.storage.repairschedule;
 
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
+import io.cassandrareaper.storage.repairunit.MemRepairUnitDao;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,7 +35,10 @@ import com.google.common.collect.Maps;
 public class MemRepairScheduleDao implements IRepairSchedule {
   public final ConcurrentMap<UUID, RepairSchedule> repairSchedules = Maps.newConcurrentMap();
 
-  public MemRepairScheduleDao() {
+  private final MemRepairUnitDao memRepairUnitDao;
+
+  public MemRepairScheduleDao(MemRepairUnitDao memRepairUnitDao) {
+    this.memRepairUnitDao = memRepairUnitDao;
   }
 
   @Override
@@ -53,7 +57,7 @@ public class MemRepairScheduleDao implements IRepairSchedule {
   public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName) {
     Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
     for (RepairSchedule repairSchedule : repairSchedules.values()) {
-      RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+      RepairUnit repairUnit = memRepairUnitDao.getRepairUnit(repairSchedule.getRepairUnitId());
       if (repairUnit.getClusterName().equals(clusterName)) {
         foundRepairSchedules.add(repairSchedule);
       }
@@ -63,9 +67,8 @@ public class MemRepairScheduleDao implements IRepairSchedule {
 
   @Override
   public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental) {
-    return memoryStorageFacade.getRepairSchedulesForCluster(clusterName).stream()
-        .filter(schedule -> memoryStorageFacade
-              .getMemRepairUnit()
+    return getRepairSchedulesForCluster(clusterName).stream()
+        .filter(schedule -> memRepairUnitDao
               .getRepairUnit(schedule.getRepairUnitId())
               .getIncrementalRepair() == incremental)
         .collect(Collectors.toList());
@@ -75,7 +78,7 @@ public class MemRepairScheduleDao implements IRepairSchedule {
   public Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName) {
     Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
     for (RepairSchedule repairSchedule : repairSchedules.values()) {
-      RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+      RepairUnit repairUnit = memRepairUnitDao.getRepairUnit(repairSchedule.getRepairUnitId());
       if (repairUnit.getKeyspaceName().equals(keyspaceName)) {
         foundRepairSchedules.add(repairSchedule);
       }
@@ -87,7 +90,7 @@ public class MemRepairScheduleDao implements IRepairSchedule {
   public Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName) {
     Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
     for (RepairSchedule repairSchedule : repairSchedules.values()) {
-      RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+      RepairUnit repairUnit = memRepairUnitDao.getRepairUnit(repairSchedule.getRepairUnitId());
       if (repairUnit.getClusterName().equals(clusterName) && repairUnit.getKeyspaceName().equals(keyspaceName)) {
         foundRepairSchedules.add(repairSchedule);
       }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/MemRepairScheduleDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/MemRepairScheduleDao.java
@@ -1,0 +1,103 @@
+package io.cassandrareaper.storage.repairschedule;
+
+import io.cassandrareaper.core.RepairSchedule;
+import io.cassandrareaper.core.RepairUnit;
+import io.cassandrareaper.storage.MemoryStorageFacade;
+
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.Maps;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+public class MemRepairScheduleDao {
+    private final MemoryStorageFacade memoryStorageFacade;
+    public final ConcurrentMap<UUID, RepairSchedule> repairSchedules = Maps.newConcurrentMap();
+
+    public MemRepairScheduleDao(MemoryStorageFacade memoryStorageFacade) {
+        this.memoryStorageFacade = memoryStorageFacade;
+    }
+
+    @Override
+    public RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule) {
+        RepairSchedule newRepairSchedule = repairSchedule.build(UUIDs.timeBased());
+        repairSchedules.put(newRepairSchedule.getId(), newRepairSchedule);
+        return newRepairSchedule;
+    }
+
+    @Override
+    public Optional<RepairSchedule> getRepairSchedule(UUID id) {
+        return Optional.ofNullable(repairSchedules.get(id));
+    }
+
+    @Override
+    public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName) {
+        Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
+        for (RepairSchedule repairSchedule : repairSchedules.values()) {
+            RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+            if (repairUnit.getClusterName().equals(clusterName)) {
+                foundRepairSchedules.add(repairSchedule);
+            }
+        }
+        return foundRepairSchedules;
+    }
+
+    @Override
+    public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental) {
+        return memoryStorageFacade.getRepairSchedulesForCluster(clusterName).stream()
+                .filter(schedule -> memoryStorageFacade.getMemRepairUnit().getRepairUnit(schedule.getRepairUnitId()).getIncrementalRepair() == incremental)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName) {
+        Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
+        for (RepairSchedule repairSchedule : repairSchedules.values()) {
+            RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+            if (repairUnit.getKeyspaceName().equals(keyspaceName)) {
+                foundRepairSchedules.add(repairSchedule);
+            }
+        }
+        return foundRepairSchedules;
+    }
+
+    @Override
+    public Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName) {
+        Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
+        for (RepairSchedule repairSchedule : repairSchedules.values()) {
+            RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+            if (repairUnit.getClusterName().equals(clusterName) && repairUnit.getKeyspaceName().equals(keyspaceName)) {
+                foundRepairSchedules.add(repairSchedule);
+            }
+        }
+        return foundRepairSchedules;
+    }
+
+    @Override
+    public Collection<RepairSchedule> getAllRepairSchedules() {
+        return repairSchedules.values();
+    }
+
+    @Override
+    public boolean updateRepairSchedule(RepairSchedule newRepairSchedule) {
+        if (repairSchedules.get(newRepairSchedule.getId()) == null) {
+            return false;
+        } else {
+            repairSchedules.put(newRepairSchedule.getId(), newRepairSchedule);
+            return true;
+        }
+    }
+
+    @Override
+    public Optional<RepairSchedule> deleteRepairSchedule(UUID id) {
+        RepairSchedule deletedSchedule = repairSchedules.remove(id);
+        if (deletedSchedule != null) {
+            deletedSchedule = deletedSchedule.with().state(RepairSchedule.State.DELETED).build(id);
+        }
+        return Optional.ofNullable(deletedSchedule);
+    }
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/MemRepairScheduleDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/MemRepairScheduleDao.java
@@ -20,16 +20,19 @@ package io.cassandrareaper.storage.repairschedule;
 
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
+import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.storage.repairunit.MemRepairUnitDao;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
 import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 public class MemRepairScheduleDao implements IRepairSchedule {
@@ -111,6 +114,17 @@ public class MemRepairScheduleDao implements IRepairSchedule {
       repairSchedules.put(newRepairSchedule.getId(), newRepairSchedule);
       return true;
     }
+  }
+
+  @Override
+  public Collection<RepairScheduleStatus> getClusterScheduleStatuses(String clusterName) {
+    List<RepairScheduleStatus> scheduleStatuses = Lists.newArrayList();
+    Collection<RepairSchedule> schedules = getRepairSchedulesForCluster(clusterName);
+    for (RepairSchedule schedule : schedules) {
+      RepairUnit unit = memRepairUnitDao.getRepairUnit(schedule.getRepairUnitId());
+      scheduleStatuses.add(new RepairScheduleStatus(schedule, unit));
+    }
+    return scheduleStatuses;
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/MemRepairScheduleDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairschedule/MemRepairScheduleDao.java
@@ -1,11 +1,25 @@
+/*
+ * Copyright 2016-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ * Copyright 2020-2020 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.repairschedule;
 
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
-import io.cassandrareaper.storage.MemoryStorageFacade;
-
-import com.datastax.driver.core.utils.UUIDs;
-import com.google.common.collect.Maps;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -14,90 +28,94 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
-public class MemRepairScheduleDao {
-    private final MemoryStorageFacade memoryStorageFacade;
-    public final ConcurrentMap<UUID, RepairSchedule> repairSchedules = Maps.newConcurrentMap();
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.Maps;
 
-    public MemRepairScheduleDao(MemoryStorageFacade memoryStorageFacade) {
-        this.memoryStorageFacade = memoryStorageFacade;
-    }
+public class MemRepairScheduleDao implements IRepairSchedule {
+  public final ConcurrentMap<UUID, RepairSchedule> repairSchedules = Maps.newConcurrentMap();
 
-    @Override
-    public RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule) {
-        RepairSchedule newRepairSchedule = repairSchedule.build(UUIDs.timeBased());
-        repairSchedules.put(newRepairSchedule.getId(), newRepairSchedule);
-        return newRepairSchedule;
-    }
+  public MemRepairScheduleDao() {
+  }
 
-    @Override
-    public Optional<RepairSchedule> getRepairSchedule(UUID id) {
-        return Optional.ofNullable(repairSchedules.get(id));
-    }
+  @Override
+  public RepairSchedule addRepairSchedule(RepairSchedule.Builder repairSchedule) {
+    RepairSchedule newRepairSchedule = repairSchedule.build(UUIDs.timeBased());
+    repairSchedules.put(newRepairSchedule.getId(), newRepairSchedule);
+    return newRepairSchedule;
+  }
 
-    @Override
-    public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName) {
-        Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
-        for (RepairSchedule repairSchedule : repairSchedules.values()) {
-            RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
-            if (repairUnit.getClusterName().equals(clusterName)) {
-                foundRepairSchedules.add(repairSchedule);
-            }
-        }
-        return foundRepairSchedules;
-    }
+  @Override
+  public Optional<RepairSchedule> getRepairSchedule(UUID id) {
+    return Optional.ofNullable(repairSchedules.get(id));
+  }
 
-    @Override
-    public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental) {
-        return memoryStorageFacade.getRepairSchedulesForCluster(clusterName).stream()
-                .filter(schedule -> memoryStorageFacade.getMemRepairUnit().getRepairUnit(schedule.getRepairUnitId()).getIncrementalRepair() == incremental)
-                .collect(Collectors.toList());
+  @Override
+  public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName) {
+    Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
+    for (RepairSchedule repairSchedule : repairSchedules.values()) {
+      RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+      if (repairUnit.getClusterName().equals(clusterName)) {
+        foundRepairSchedules.add(repairSchedule);
+      }
     }
+    return foundRepairSchedules;
+  }
 
-    @Override
-    public Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName) {
-        Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
-        for (RepairSchedule repairSchedule : repairSchedules.values()) {
-            RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
-            if (repairUnit.getKeyspaceName().equals(keyspaceName)) {
-                foundRepairSchedules.add(repairSchedule);
-            }
-        }
-        return foundRepairSchedules;
-    }
+  @Override
+  public Collection<RepairSchedule> getRepairSchedulesForCluster(String clusterName, boolean incremental) {
+    return memoryStorageFacade.getRepairSchedulesForCluster(clusterName).stream()
+        .filter(schedule -> memoryStorageFacade
+              .getMemRepairUnit()
+              .getRepairUnit(schedule.getRepairUnitId())
+              .getIncrementalRepair() == incremental)
+        .collect(Collectors.toList());
+  }
 
-    @Override
-    public Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName) {
-        Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
-        for (RepairSchedule repairSchedule : repairSchedules.values()) {
-            RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
-            if (repairUnit.getClusterName().equals(clusterName) && repairUnit.getKeyspaceName().equals(keyspaceName)) {
-                foundRepairSchedules.add(repairSchedule);
-            }
-        }
-        return foundRepairSchedules;
+  @Override
+  public Collection<RepairSchedule> getRepairSchedulesForKeyspace(String keyspaceName) {
+    Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
+    for (RepairSchedule repairSchedule : repairSchedules.values()) {
+      RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+      if (repairUnit.getKeyspaceName().equals(keyspaceName)) {
+        foundRepairSchedules.add(repairSchedule);
+      }
     }
+    return foundRepairSchedules;
+  }
 
-    @Override
-    public Collection<RepairSchedule> getAllRepairSchedules() {
-        return repairSchedules.values();
+  @Override
+  public Collection<RepairSchedule> getRepairSchedulesForClusterAndKeyspace(String clusterName, String keyspaceName) {
+    Collection<RepairSchedule> foundRepairSchedules = new ArrayList<RepairSchedule>();
+    for (RepairSchedule repairSchedule : repairSchedules.values()) {
+      RepairUnit repairUnit = memoryStorageFacade.getMemRepairUnit().getRepairUnit(repairSchedule.getRepairUnitId());
+      if (repairUnit.getClusterName().equals(clusterName) && repairUnit.getKeyspaceName().equals(keyspaceName)) {
+        foundRepairSchedules.add(repairSchedule);
+      }
     }
+    return foundRepairSchedules;
+  }
 
-    @Override
-    public boolean updateRepairSchedule(RepairSchedule newRepairSchedule) {
-        if (repairSchedules.get(newRepairSchedule.getId()) == null) {
-            return false;
-        } else {
-            repairSchedules.put(newRepairSchedule.getId(), newRepairSchedule);
-            return true;
-        }
-    }
+  @Override
+  public Collection<RepairSchedule> getAllRepairSchedules() {
+    return repairSchedules.values();
+  }
 
-    @Override
-    public Optional<RepairSchedule> deleteRepairSchedule(UUID id) {
-        RepairSchedule deletedSchedule = repairSchedules.remove(id);
-        if (deletedSchedule != null) {
-            deletedSchedule = deletedSchedule.with().state(RepairSchedule.State.DELETED).build(id);
-        }
-        return Optional.ofNullable(deletedSchedule);
+  @Override
+  public boolean updateRepairSchedule(RepairSchedule newRepairSchedule) {
+    if (repairSchedules.get(newRepairSchedule.getId()) == null) {
+      return false;
+    } else {
+      repairSchedules.put(newRepairSchedule.getId(), newRepairSchedule);
+      return true;
     }
+  }
+
+  @Override
+  public Optional<RepairSchedule> deleteRepairSchedule(UUID id) {
+    RepairSchedule deletedSchedule = repairSchedules.remove(id);
+    if (deletedSchedule != null) {
+      deletedSchedule = deletedSchedule.with().state(RepairSchedule.State.DELETED).build(id);
+    }
+    return Optional.ofNullable(deletedSchedule);
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/CassRepairSegmentDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/CassRepairSegmentDao.java
@@ -175,6 +175,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
 
   }
 
+  @Override
   public int getSegmentAmountForRepairRun(UUID runId) {
     return (int) session
         .execute(getRepairSegmentCountByRunIdPrepStmt.bind(runId))
@@ -182,6 +183,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
         .getLong(0);
   }
 
+  @Override
   public int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state) {
     if (null != getRepairSegmentCountByRunIdAndStatePrepStmt) {
       return (int) session
@@ -194,6 +196,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
     }
   }
 
+  @Override
   public boolean updateRepairSegment(RepairSegment segment) {
 
     assert concurrency.hasLeadOnSegment(segment)
@@ -246,6 +249,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
     return true;
   }
 
+  @Override
   public Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId) {
     RepairSegment segment = null;
     Row segmentRow = session.execute(getRepairSegmentPrepStmt.bind(runId, segmentId)).one();
@@ -256,6 +260,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
     return Optional.ofNullable(segment);
   }
 
+  @Override
   public Collection<RepairSegment> getRepairSegmentsForRun(UUID runId) {
     Collection<RepairSegment> segments = Lists.newArrayList();
     // First gather segments ids
@@ -267,6 +272,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
     return segments;
   }
 
+  @Override
   public List<RepairSegment> getNextFreeSegments(UUID runId) {
     List<RepairSegment> segments = Lists.<RepairSegment>newArrayList(getRepairSegmentsForRun(runId));
     Collections.shuffle(segments);
@@ -278,7 +284,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
     return candidates;
   }
 
-
+  // TODO: this comes from IDistributed storage and probably shouldn't be here, despite being segment related.
   public List<RepairSegment> getNextFreeSegmentsForRanges(
       UUID runId,
       List<RingRange> ranges) {
@@ -293,6 +299,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
 
     return candidates;
   }
+
 
   public boolean segmentIsWithinRanges(RepairSegment seg, List<RingRange> ranges) {
     for (RingRange range : ranges) {
@@ -309,7 +316,7 @@ public class CassRepairSegmentDao implements IRepairSegment {
         && Sets.intersection(lockedNodes, seg.getReplicas().keySet()).isEmpty();
   }
 
-
+  @Override
   public Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState) {
     Collection<RepairSegment> segments = Lists.newArrayList();
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/IRepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/IRepairSegment.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2016-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ * Copyright 2020-2020 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package io.cassandrareaper.storage.repairsegment;
 
 import io.cassandrareaper.core.RepairSegment;
@@ -8,21 +27,21 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface IRepairSegment {
-    boolean updateRepairSegment(RepairSegment newRepairSegment);
+  boolean updateRepairSegment(RepairSegment newRepairSegment);
 
-    Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId);
+  Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId);
 
-    Collection<RepairSegment> getRepairSegmentsForRun(UUID runId);
+  Collection<RepairSegment> getRepairSegmentsForRun(UUID runId);
 
-    /**
-     * @param runId the run id that the segment belongs to.
-     * @return a segment enclosed by the range with state NOT_STARTED, or nothing.
-     */
-    List<RepairSegment> getNextFreeSegments(UUID runId);
+  /**
+   * @param runId the run id that the segment belongs to.
+   * @return a segment enclosed by the range with state NOT_STARTED, or nothing.
+   */
+  List<RepairSegment> getNextFreeSegments(UUID runId);
 
-    Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState);
+  Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState);
 
-    int getSegmentAmountForRepairRun(UUID runId);
+  int getSegmentAmountForRepairRun(UUID runId);
 
-    int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state);
+  int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state);
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/IRepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/IRepairSegment.java
@@ -1,0 +1,28 @@
+package io.cassandrareaper.storage.repairsegment;
+
+import io.cassandrareaper.core.RepairSegment;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface IRepairSegment {
+    boolean updateRepairSegment(RepairSegment newRepairSegment);
+
+    Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId);
+
+    Collection<RepairSegment> getRepairSegmentsForRun(UUID runId);
+
+    /**
+     * @param runId the run id that the segment belongs to.
+     * @return a segment enclosed by the range with state NOT_STARTED, or nothing.
+     */
+    List<RepairSegment> getNextFreeSegments(UUID runId);
+
+    Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState);
+
+    int getSegmentAmountForRepairRun(UUID runId);
+
+    int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state);
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/MemRepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/MemRepairSegment.java
@@ -1,103 +1,127 @@
+/*
+ * Copyright 2016-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ * Copyright 2020-2020 DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.repairsegment;
 
 import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.storage.MemoryStorageFacade;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
 import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
-
 public class MemRepairSegment implements IRepairSegment {
-    private final MemoryStorageFacade memoryStorageFacade;
-    private final ConcurrentMap<UUID, RepairSegment> repairSegments = Maps.newConcurrentMap();
-    public final ConcurrentMap<UUID, LinkedHashMap<UUID, RepairSegment>> repairSegmentsByRunId = Maps.newConcurrentMap();
 
-    public MemRepairSegment(MemoryStorageFacade memoryStorageFacade) {
-        this.memoryStorageFacade = memoryStorageFacade;
+  public final ConcurrentMap<UUID, LinkedHashMap<UUID, RepairSegment>> repairSegmentsByRunId = Maps.newConcurrentMap();
+  private final MemoryStorageFacade memoryStorageFacade;
+  private final ConcurrentMap<UUID, RepairSegment> repairSegments = Maps.newConcurrentMap();
+
+  public MemRepairSegment(MemoryStorageFacade memoryStorageFacade) {
+    this.memoryStorageFacade = memoryStorageFacade;
+  }
+
+  public int deleteRepairSegmentsForRun(UUID runId) {
+    Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.remove(runId);
+    if (null != segmentsMap) {
+      for (RepairSegment segment : segmentsMap.values()) {
+        this.repairSegments.remove(segment.getId());
+      }
     }
+    return segmentsMap != null ? segmentsMap.size() : 0;
+  }
 
-    public int deleteRepairSegmentsForRun(UUID runId) {
-        Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.remove(runId);
-        if (null != segmentsMap) {
-            for (RepairSegment segment : segmentsMap.values()) {
-                this.repairSegments.remove(segment.getId());
-            }
+  public void addRepairSegments(Collection<RepairSegment.Builder> segments, UUID runId) {
+    LinkedHashMap<UUID, RepairSegment> newSegments = Maps.newLinkedHashMap();
+    for (RepairSegment.Builder segment : segments) {
+      RepairSegment newRepairSegment = segment.withRunId(runId).withId(UUIDs.timeBased()).build();
+      this.repairSegments.put(newRepairSegment.getId(), newRepairSegment);
+      newSegments.put(newRepairSegment.getId(), newRepairSegment);
+    }
+    repairSegmentsByRunId.put(runId, newSegments);
+
+  }
+
+  @Override
+  public boolean updateRepairSegment(RepairSegment newRepairSegment) {
+    if (memoryStorageFacade.getRepairSegment(newRepairSegment.getRunId(), newRepairSegment.getId()) == null) {
+      return false;
+    } else {
+      this.repairSegments.put(newRepairSegment.getId(), newRepairSegment);
+      LinkedHashMap<UUID, RepairSegment> updatedSegment = repairSegmentsByRunId.get(newRepairSegment.getRunId());
+      updatedSegment.put(newRepairSegment.getId(), newRepairSegment);
+      return true;
+    }
+  }
+
+  @Override
+  public Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId) {
+    return Optional.ofNullable(repairSegments.get(segmentId));
+  }
+
+  @Override
+  public Collection<RepairSegment> getRepairSegmentsForRun(UUID runId) {
+    return repairSegmentsByRunId.get(runId).values();
+  }
+
+  @Override
+  public List<RepairSegment> getNextFreeSegments(UUID runId) {
+    return repairSegmentsByRunId.get(runId).values().stream()
+        .filter(seg -> seg.getState() == RepairSegment.State.NOT_STARTED)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState) {
+    List<RepairSegment> segments = Lists.newArrayList();
+    for (RepairSegment segment : repairSegmentsByRunId.get(runId).values()) {
+      if (segment.getState() == segmentState) {
+        segments.add(segment);
+      }
+    }
+    return segments;
+  }
+
+  @Override
+  public int getSegmentAmountForRepairRun(UUID runId) {
+    Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.get(runId);
+    return segmentsMap == null ? 0 : segmentsMap.size();
+  }
+
+  @Override
+  public int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state) {
+    Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.get(runId);
+    int amount = 0;
+    if (null != segmentsMap) {
+      for (RepairSegment segment : segmentsMap.values()) {
+        if (segment.getState() == state) {
+          amount += 1;
         }
-        return segmentsMap != null ? segmentsMap.size() : 0;
+      }
     }
-
-    public void addRepairSegments(Collection<RepairSegment.Builder> segments, UUID runId) {
-        LinkedHashMap<UUID, RepairSegment> newSegments = Maps.newLinkedHashMap();
-        for (RepairSegment.Builder segment : segments) {
-            RepairSegment newRepairSegment = segment.withRunId(runId).withId(UUIDs.timeBased()).build();
-            this.repairSegments.put(newRepairSegment.getId(), newRepairSegment);
-            newSegments.put(newRepairSegment.getId(), newRepairSegment);
-        }
-        repairSegmentsByRunId.put(runId, newSegments);
-
-    }
-
-    @Override
-    public boolean updateRepairSegment(RepairSegment newRepairSegment) {
-        if (memoryStorageFacade.getRepairSegment(newRepairSegment.getRunId(), newRepairSegment.getId()) == null) {
-            return false;
-        } else {
-            this.repairSegments.put(newRepairSegment.getId(), newRepairSegment);
-            LinkedHashMap<UUID, RepairSegment> updatedSegment = repairSegmentsByRunId.get(newRepairSegment.getRunId());
-            updatedSegment.put(newRepairSegment.getId(), newRepairSegment);
-            return true;
-        }
-    }
-
-    @Override
-    public Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId) {
-        return Optional.ofNullable(repairSegments.get(segmentId));
-    }
-
-    @Override
-    public Collection<RepairSegment> getRepairSegmentsForRun(UUID runId) {
-        return repairSegmentsByRunId.get(runId).values();
-    }
-
-    @Override
-    public List<RepairSegment> getNextFreeSegments(UUID runId) {
-        return repairSegmentsByRunId.get(runId).values().stream()
-                .filter(seg -> seg.getState() == RepairSegment.State.NOT_STARTED)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState) {
-        List<RepairSegment> segments = Lists.newArrayList();
-        for (RepairSegment segment : repairSegmentsByRunId.get(runId).values()) {
-            if (segment.getState() == segmentState) {
-                segments.add(segment);
-            }
-        }
-        return segments;
-    }
-
-    @Override
-    public int getSegmentAmountForRepairRun(UUID runId) {
-        Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.get(runId);
-        return segmentsMap == null ? 0 : segmentsMap.size();
-    }
-
-    @Override
-    public int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state) {
-        Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.get(runId);
-        int amount = 0;
-        if (null != segmentsMap) {
-            for (RepairSegment segment : segmentsMap.values()) {
-                if (segment.getState() == state) {
-                    amount += 1;
-                }
-            }
-        }
-        return amount;
-    }
+    return amount;
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/MemRepairSegment.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairsegment/MemRepairSegment.java
@@ -1,0 +1,103 @@
+package io.cassandrareaper.storage.repairsegment;
+
+import io.cassandrareaper.core.RepairSegment;
+import io.cassandrareaper.storage.MemoryStorageFacade;
+
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+public class MemRepairSegment implements IRepairSegment {
+    private final MemoryStorageFacade memoryStorageFacade;
+    private final ConcurrentMap<UUID, RepairSegment> repairSegments = Maps.newConcurrentMap();
+    public final ConcurrentMap<UUID, LinkedHashMap<UUID, RepairSegment>> repairSegmentsByRunId = Maps.newConcurrentMap();
+
+    public MemRepairSegment(MemoryStorageFacade memoryStorageFacade) {
+        this.memoryStorageFacade = memoryStorageFacade;
+    }
+
+    public int deleteRepairSegmentsForRun(UUID runId) {
+        Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.remove(runId);
+        if (null != segmentsMap) {
+            for (RepairSegment segment : segmentsMap.values()) {
+                this.repairSegments.remove(segment.getId());
+            }
+        }
+        return segmentsMap != null ? segmentsMap.size() : 0;
+    }
+
+    public void addRepairSegments(Collection<RepairSegment.Builder> segments, UUID runId) {
+        LinkedHashMap<UUID, RepairSegment> newSegments = Maps.newLinkedHashMap();
+        for (RepairSegment.Builder segment : segments) {
+            RepairSegment newRepairSegment = segment.withRunId(runId).withId(UUIDs.timeBased()).build();
+            this.repairSegments.put(newRepairSegment.getId(), newRepairSegment);
+            newSegments.put(newRepairSegment.getId(), newRepairSegment);
+        }
+        repairSegmentsByRunId.put(runId, newSegments);
+
+    }
+
+    @Override
+    public boolean updateRepairSegment(RepairSegment newRepairSegment) {
+        if (memoryStorageFacade.getRepairSegment(newRepairSegment.getRunId(), newRepairSegment.getId()) == null) {
+            return false;
+        } else {
+            this.repairSegments.put(newRepairSegment.getId(), newRepairSegment);
+            LinkedHashMap<UUID, RepairSegment> updatedSegment = repairSegmentsByRunId.get(newRepairSegment.getRunId());
+            updatedSegment.put(newRepairSegment.getId(), newRepairSegment);
+            return true;
+        }
+    }
+
+    @Override
+    public Optional<RepairSegment> getRepairSegment(UUID runId, UUID segmentId) {
+        return Optional.ofNullable(repairSegments.get(segmentId));
+    }
+
+    @Override
+    public Collection<RepairSegment> getRepairSegmentsForRun(UUID runId) {
+        return repairSegmentsByRunId.get(runId).values();
+    }
+
+    @Override
+    public List<RepairSegment> getNextFreeSegments(UUID runId) {
+        return repairSegmentsByRunId.get(runId).values().stream()
+                .filter(seg -> seg.getState() == RepairSegment.State.NOT_STARTED)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<RepairSegment> getSegmentsWithState(UUID runId, RepairSegment.State segmentState) {
+        List<RepairSegment> segments = Lists.newArrayList();
+        for (RepairSegment segment : repairSegmentsByRunId.get(runId).values()) {
+            if (segment.getState() == segmentState) {
+                segments.add(segment);
+            }
+        }
+        return segments;
+    }
+
+    @Override
+    public int getSegmentAmountForRepairRun(UUID runId) {
+        Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.get(runId);
+        return segmentsMap == null ? 0 : segmentsMap.size();
+    }
+
+    @Override
+    public int getSegmentAmountForRepairRunWithState(UUID runId, RepairSegment.State state) {
+        Map<UUID, RepairSegment> segmentsMap = repairSegmentsByRunId.get(runId);
+        int amount = 0;
+        if (null != segmentsMap) {
+            for (RepairSegment segment : segmentsMap.values()) {
+                if (segment.getState() == state) {
+                    amount += 1;
+                }
+            }
+        }
+        return amount;
+    }
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairunit/CassRepairUnitDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairunit/CassRepairUnitDao.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package io.cassandrareaper.storage.cassandra;
+package io.cassandrareaper.storage.repairunit;
 
 import io.cassandrareaper.core.RepairUnit;
 
@@ -37,12 +37,12 @@ import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RepairUnitDao {
+public class CassRepairUnitDao implements IRepairUnit{
   static final String SELECT_REPAIR_UNIT = "SELECT * FROM repair_unit_v1";
-  private static final Logger LOG = LoggerFactory.getLogger(RepairUnitDao.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CassRepairUnitDao.class);
   PreparedStatement insertRepairUnitPrepStmt;
   PreparedStatement getRepairUnitPrepStmt;
-  PreparedStatement deleteRepairUnitPrepStmt;
+  public PreparedStatement deleteRepairUnitPrepStmt;
 
   final LoadingCache<UUID, RepairUnit> repairUnits = CacheBuilder
       .newBuilder()
@@ -54,7 +54,7 @@ public class RepairUnitDao {
   private final int defaultTimeout;
   private final Session session;
 
-  public RepairUnitDao(int defaultTimeout, Session session) {
+  public CassRepairUnitDao(int defaultTimeout, Session session) {
     this.defaultTimeout = defaultTimeout;
     this.session = session;
     prepareStatements();
@@ -96,7 +96,7 @@ public class RepairUnitDao {
             updatedRepairUnit.getTimeout()));
   }
 
-  RepairUnit getRepairUnitImpl(UUID id) {
+  public RepairUnit getRepairUnitImpl(UUID id) {
     Row repairUnitRow = session.execute(getRepairUnitPrepStmt.bind(id)).one();
     if (repairUnitRow != null) {
       return RepairUnit.builder()

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairunit/CassRepairUnitDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairunit/CassRepairUnitDao.java
@@ -73,6 +73,7 @@ public class CassRepairUnitDao implements IRepairUnit {
     deleteRepairUnitPrepStmt = session.prepare("DELETE FROM repair_unit_v1 WHERE id = ?");
   }
 
+  @Override
   public RepairUnit addRepairUnit(RepairUnit.Builder newRepairUnit) {
     RepairUnit repairUnit = newRepairUnit.build(UUIDs.timeBased());
     updateRepairUnit(repairUnit);
@@ -81,6 +82,7 @@ public class CassRepairUnitDao implements IRepairUnit {
     return repairUnit;
   }
 
+  @Override
   public void updateRepairUnit(RepairUnit updatedRepairUnit) {
     session.execute(
         insertRepairUnitPrepStmt.bind(
@@ -96,7 +98,7 @@ public class CassRepairUnitDao implements IRepairUnit {
             updatedRepairUnit.getTimeout()));
   }
 
-  public RepairUnit getRepairUnitImpl(UUID id) {
+  private RepairUnit getRepairUnitImpl(UUID id) {
     Row repairUnitRow = session.execute(getRepairUnitPrepStmt.bind(id)).one();
     if (repairUnitRow != null) {
       return RepairUnit.builder()
@@ -114,11 +116,12 @@ public class CassRepairUnitDao implements IRepairUnit {
     throw new IllegalArgumentException("No repair unit exists for " + id);
   }
 
-
+  @Override
   public RepairUnit getRepairUnit(UUID id) {
     return repairUnits.getUnchecked(id);
   }
 
+  @Override
   public Optional<RepairUnit> getRepairUnit(RepairUnit.Builder params) {
     // brute force again
     RepairUnit repairUnit = null;

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairunit/CassRepairUnitDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairunit/CassRepairUnitDao.java
@@ -37,20 +37,20 @@ import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CassRepairUnitDao implements IRepairUnit{
+public class CassRepairUnitDao implements IRepairUnit {
   static final String SELECT_REPAIR_UNIT = "SELECT * FROM repair_unit_v1";
   private static final Logger LOG = LoggerFactory.getLogger(CassRepairUnitDao.class);
+  public PreparedStatement deleteRepairUnitPrepStmt;
   PreparedStatement insertRepairUnitPrepStmt;
   PreparedStatement getRepairUnitPrepStmt;
-  public PreparedStatement deleteRepairUnitPrepStmt;
 
   final LoadingCache<UUID, RepairUnit> repairUnits = CacheBuilder
-      .newBuilder()
-      .build(new CacheLoader<UUID, RepairUnit>() {
-        public RepairUnit load(UUID repairUnitId) throws Exception {
-          return getRepairUnitImpl(repairUnitId);
-        }
-      });
+        .newBuilder()
+        .build(new CacheLoader<UUID, RepairUnit>() {
+          public RepairUnit load(UUID repairUnitId) throws Exception {
+            return getRepairUnitImpl(repairUnitId);
+          }
+        });
   private final int defaultTimeout;
   private final Session session;
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairunit/CassRepairUnitDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairunit/CassRepairUnitDao.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CassRepairUnitDao implements IRepairUnit {
-  static final String SELECT_REPAIR_UNIT = "SELECT * FROM repair_unit_v1";
+  public static final String SELECT_REPAIR_UNIT = "SELECT * FROM repair_unit_v1";
   private static final Logger LOG = LoggerFactory.getLogger(CassRepairUnitDao.class);
   public PreparedStatement deleteRepairUnitPrepStmt;
   PreparedStatement insertRepairUnitPrepStmt;

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairunit/IRepairUnit.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairunit/IRepairUnit.java
@@ -1,0 +1,16 @@
+package io.cassandrareaper.storage.repairunit;
+
+import io.cassandrareaper.core.RepairUnit;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface IRepairUnit {
+    RepairUnit addRepairUnit(RepairUnit.Builder newRepairUnit);
+
+    RepairUnit getRepairUnit(UUID id);
+
+    void updateRepairUnit(RepairUnit updatedRepairUnit);
+
+    Optional<RepairUnit> getRepairUnit(RepairUnit.Builder repairUnit);
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairunit/IRepairUnit.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairunit/IRepairUnit.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.repairunit;
 
 import io.cassandrareaper.core.RepairUnit;
@@ -6,11 +23,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface IRepairUnit {
-    RepairUnit addRepairUnit(RepairUnit.Builder newRepairUnit);
+  RepairUnit addRepairUnit(RepairUnit.Builder newRepairUnit);
 
-    RepairUnit getRepairUnit(UUID id);
+  RepairUnit getRepairUnit(UUID id);
 
-    void updateRepairUnit(RepairUnit updatedRepairUnit);
+  Optional<RepairUnit> getRepairUnit(RepairUnit.Builder repairUnit);
 
-    Optional<RepairUnit> getRepairUnit(RepairUnit.Builder repairUnit);
+  void updateRepairUnit(RepairUnit updatedRepairUnit);
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairunit/MemRepairUnitDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairunit/MemRepairUnitDao.java
@@ -1,81 +1,74 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.repairunit;
 
-import io.cassandrareaper.core.RepairRun;
-import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
-
-import com.datastax.driver.core.utils.UUIDs;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
 public class MemRepairUnitDao implements IRepairUnit {
-    public final ConcurrentMap<UUID, RepairUnit> repairUnits = Maps.newConcurrentMap();
-    public final ConcurrentMap<RepairUnit.Builder, RepairUnit> repairUnitsByKey = Maps.newConcurrentMap();
+  public final ConcurrentMap<UUID, RepairUnit> repairUnits = Maps.newConcurrentMap();
+  public final ConcurrentMap<RepairUnit.Builder, RepairUnit> repairUnitsByKey = Maps.newConcurrentMap();
 
-    public MemRepairUnitDao() {}
+  public MemRepairUnitDao() {
+  }
 
-    /**
-     * Delete a RepairUnit instance from Storage, but only if no run or schedule is referencing it.
-     *
-     * @param repairUnitId The RepairUnit instance id to delete.
-     * @return The deleted RepairUnit instance, if delete succeeded.
-     */
-    public Optional<RepairUnit> deleteRepairUnit(UUID repairUnitId) {
-        RepairUnit deletedUnit = null;
-        boolean canDelete = true;
-        for (RepairRun repairRun : this.memRepairRunDao.repairRuns.values()) {
-            if (repairRun.getRepairUnitId().equals(repairUnitId)) {
-                canDelete = false;
-                break;
-            }
-        }
-        if (canDelete) {
-            for (RepairSchedule schedule : this.memRepairSchedules.getRepairSchedules().values()) {
-                if (schedule.getRepairUnitId().equals(repairUnitId)) {
-                    canDelete = false;
-                    break;
-                }
-            }
-        }
-        if (canDelete) {
-            deletedUnit = repairUnits.remove(repairUnitId);
-            repairUnitsByKey.remove(deletedUnit.with());
-        }
-        return Optional.ofNullable(deletedUnit);
+  /**
+   * Delete a RepairUnit instance from Storage, but only if no run or schedule is referencing it.
+   *
+   * @param repairUnitId The RepairUnit instance id to delete.
+   * @return The deleted RepairUnit instance, if delete succeeded.
+   */
+
+  @Override
+  public RepairUnit addRepairUnit(RepairUnit.Builder repairUnit) {
+    Optional<RepairUnit> existing = getRepairUnit(repairUnit);
+    if (existing.isPresent() && repairUnit.incrementalRepair == existing.get().getIncrementalRepair()) {
+      return existing.get();
+    } else {
+      RepairUnit newRepairUnit = repairUnit.build(UUIDs.timeBased());
+      repairUnits.put(newRepairUnit.getId(), newRepairUnit);
+      repairUnitsByKey.put(repairUnit, newRepairUnit);
+      return newRepairUnit;
     }
+  }
 
-    @Override
-    public RepairUnit addRepairUnit(RepairUnit.Builder repairUnit) {
-        Optional<RepairUnit> existing = getRepairUnit(repairUnit);
-        if (existing.isPresent() && repairUnit.incrementalRepair == existing.get().getIncrementalRepair()) {
-            return existing.get();
-        } else {
-            RepairUnit newRepairUnit = repairUnit.build(UUIDs.timeBased());
-            repairUnits.put(newRepairUnit.getId(), newRepairUnit);
-            repairUnitsByKey.put(repairUnit, newRepairUnit);
-            return newRepairUnit;
-        }
-    }
+  @Override
+  public void updateRepairUnit(RepairUnit updatedRepairUnit) {
+    repairUnits.put(updatedRepairUnit.getId(), updatedRepairUnit);
+    repairUnitsByKey.put(updatedRepairUnit.with(), updatedRepairUnit);
+  }
 
-    @Override
-    public void updateRepairUnit(RepairUnit updatedRepairUnit) {
-        repairUnits.put(updatedRepairUnit.getId(), updatedRepairUnit);
-        repairUnitsByKey.put(updatedRepairUnit.with(), updatedRepairUnit);
-    }
+  @Override
+  public RepairUnit getRepairUnit(UUID id) {
+    RepairUnit unit = repairUnits.get(id);
+    Preconditions.checkArgument(null != unit);
+    return unit;
+  }
 
-    @Override
-    public RepairUnit getRepairUnit(UUID id) {
-        RepairUnit unit = repairUnits.get(id);
-        Preconditions.checkArgument(null != unit);
-        return unit;
-    }
-
-    @Override
-    public Optional<RepairUnit> getRepairUnit(RepairUnit.Builder params) {
-        return Optional.ofNullable(repairUnitsByKey.get(params));
-    }
+  @Override
+  public Optional<RepairUnit> getRepairUnit(RepairUnit.Builder params) {
+    return Optional.ofNullable(repairUnitsByKey.get(params));
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairunit/MemRepairUnitDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairunit/MemRepairUnitDao.java
@@ -1,0 +1,81 @@
+package io.cassandrareaper.storage.repairunit;
+
+import io.cassandrareaper.core.RepairRun;
+import io.cassandrareaper.core.RepairSchedule;
+import io.cassandrareaper.core.RepairUnit;
+
+import com.datastax.driver.core.utils.UUIDs;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+
+public class MemRepairUnitDao implements IRepairUnit {
+    public final ConcurrentMap<UUID, RepairUnit> repairUnits = Maps.newConcurrentMap();
+    public final ConcurrentMap<RepairUnit.Builder, RepairUnit> repairUnitsByKey = Maps.newConcurrentMap();
+
+    public MemRepairUnitDao() {}
+
+    /**
+     * Delete a RepairUnit instance from Storage, but only if no run or schedule is referencing it.
+     *
+     * @param repairUnitId The RepairUnit instance id to delete.
+     * @return The deleted RepairUnit instance, if delete succeeded.
+     */
+    public Optional<RepairUnit> deleteRepairUnit(UUID repairUnitId) {
+        RepairUnit deletedUnit = null;
+        boolean canDelete = true;
+        for (RepairRun repairRun : this.memRepairRunDao.repairRuns.values()) {
+            if (repairRun.getRepairUnitId().equals(repairUnitId)) {
+                canDelete = false;
+                break;
+            }
+        }
+        if (canDelete) {
+            for (RepairSchedule schedule : this.memRepairSchedules.getRepairSchedules().values()) {
+                if (schedule.getRepairUnitId().equals(repairUnitId)) {
+                    canDelete = false;
+                    break;
+                }
+            }
+        }
+        if (canDelete) {
+            deletedUnit = repairUnits.remove(repairUnitId);
+            repairUnitsByKey.remove(deletedUnit.with());
+        }
+        return Optional.ofNullable(deletedUnit);
+    }
+
+    @Override
+    public RepairUnit addRepairUnit(RepairUnit.Builder repairUnit) {
+        Optional<RepairUnit> existing = getRepairUnit(repairUnit);
+        if (existing.isPresent() && repairUnit.incrementalRepair == existing.get().getIncrementalRepair()) {
+            return existing.get();
+        } else {
+            RepairUnit newRepairUnit = repairUnit.build(UUIDs.timeBased());
+            repairUnits.put(newRepairUnit.getId(), newRepairUnit);
+            repairUnitsByKey.put(repairUnit, newRepairUnit);
+            return newRepairUnit;
+        }
+    }
+
+    @Override
+    public void updateRepairUnit(RepairUnit updatedRepairUnit) {
+        repairUnits.put(updatedRepairUnit.getId(), updatedRepairUnit);
+        repairUnitsByKey.put(updatedRepairUnit.with(), updatedRepairUnit);
+    }
+
+    @Override
+    public RepairUnit getRepairUnit(UUID id) {
+        RepairUnit unit = repairUnits.get(id);
+        Preconditions.checkArgument(null != unit);
+        return unit;
+    }
+
+    @Override
+    public Optional<RepairUnit> getRepairUnit(RepairUnit.Builder params) {
+        return Optional.ofNullable(repairUnitsByKey.get(params));
+    }
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/snapshot/CassSnapshotDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/snapshot/CassSnapshotDao.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package io.cassandrareaper.storage.cassandra;
+package io.cassandrareaper.storage.snapshot;
 
 import io.cassandrareaper.core.Snapshot;
 
@@ -26,14 +26,14 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import org.joda.time.DateTime;
 
-public class SnapshotDao {
+public class CassSnapshotDao implements ISnapshot {
 
   PreparedStatement getSnapshotPrepStmt;
   PreparedStatement deleteSnapshotPrepStmt;
   PreparedStatement saveSnapshotPrepStmt;
   private final Session session;
 
-  public SnapshotDao(Session session) {
+  public CassSnapshotDao(Session session) {
     this.session = session;
     prepareStatements();
   }
@@ -47,7 +47,7 @@ public class SnapshotDao {
 
   }
 
-
+  @Override
   public boolean saveSnapshot(Snapshot snapshot) {
     session.execute(
         saveSnapshotPrepStmt.bind(
@@ -60,13 +60,13 @@ public class SnapshotDao {
     return true;
   }
 
-
+  @Override
   public boolean deleteSnapshot(Snapshot snapshot) {
     session.execute(deleteSnapshotPrepStmt.bind(snapshot.getClusterName(), snapshot.getName()));
     return false;
   }
 
-
+  @Override
   public Snapshot getSnapshot(String clusterName, String snapshotName) {
     Snapshot.Builder snapshotBuilder = Snapshot.builder().withClusterName(clusterName).withName(snapshotName);
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/snapshot/ISnapshot.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/snapshot/ISnapshot.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.snapshot;
 
 import io.cassandrareaper.core.Snapshot;

--- a/src/server/src/main/java/io/cassandrareaper/storage/snapshot/ISnapshot.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/snapshot/ISnapshot.java
@@ -1,0 +1,11 @@
+package io.cassandrareaper.storage.snapshot;
+
+import io.cassandrareaper.core.Snapshot;
+
+public interface ISnapshot {
+  boolean saveSnapshot(Snapshot snapshot);
+
+  boolean deleteSnapshot(Snapshot snapshot);
+
+  Snapshot getSnapshot(String clusterName, String snapshotName);
+}

--- a/src/server/src/main/java/io/cassandrareaper/storage/snapshot/MemSnapshotDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/snapshot/MemSnapshotDao.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.storage.snapshot;
 
 import io.cassandrareaper.core.Snapshot;
@@ -6,7 +23,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import com.google.common.collect.Maps;
 
-public class MemSnapshotDao implements ISnapshot{
+public class MemSnapshotDao implements ISnapshot {
   public final ConcurrentMap<String, Snapshot> snapshots = Maps.newConcurrentMap();
 
   public MemSnapshotDao() {

--- a/src/server/src/main/java/io/cassandrareaper/storage/snapshot/MemSnapshotDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/snapshot/MemSnapshotDao.java
@@ -1,0 +1,32 @@
+package io.cassandrareaper.storage.snapshot;
+
+import io.cassandrareaper.core.Snapshot;
+
+import java.util.concurrent.ConcurrentMap;
+
+import com.google.common.collect.Maps;
+
+public class MemSnapshotDao implements ISnapshot{
+  public final ConcurrentMap<String, Snapshot> snapshots = Maps.newConcurrentMap();
+
+  public MemSnapshotDao() {
+  }
+
+  @Override
+  public boolean saveSnapshot(Snapshot snapshot) {
+    snapshots.put(snapshot.getClusterName() + "-" + snapshot.getName(), snapshot);
+    return true;
+  }
+
+  @Override
+  public boolean deleteSnapshot(Snapshot snapshot) {
+    snapshots.remove(snapshot.getClusterName() + "-" + snapshot.getName());
+    return true;
+  }
+
+  @Override
+  public Snapshot getSnapshot(String clusterName, String snapshotName) {
+    Snapshot snapshot = snapshots.get(clusterName + "-" + snapshotName);
+    return snapshot;
+  }
+}

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -29,7 +29,7 @@ import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.service.RepairRunService;
 import io.cassandrareaper.storage.DiagEventSubscriptionMapper;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -2440,7 +2440,7 @@ public final class BasicSteps {
   }
 
   private static boolean isInstanceOfDistributedStorage(String storageClassname) {
-    String csCls = CassandraStorage.class.getName();
+    String csCls = CassandraStorageFacade.class.getName();
     return csCls.equals(storageClassname);
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/jmx/JmxConnectionsInitializerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/JmxConnectionsInitializerTest.java
@@ -24,7 +24,7 @@ import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.crypto.Cryptograph;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -62,7 +62,7 @@ public class JmxConnectionsInitializerTest {
 
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(DatacenterAvailability.EACH);
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
 
     Cluster cluster = Cluster.builder()
             .withName("test")
@@ -100,7 +100,7 @@ public class JmxConnectionsInitializerTest {
 
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(DatacenterAvailability.LOCAL);
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
 
     Cluster cluster = Cluster.builder()
             .withName("test")
@@ -138,7 +138,7 @@ public class JmxConnectionsInitializerTest {
 
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(DatacenterAvailability.ALL);
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
 
     Cluster cluster = Cluster.builder()
             .withName("test")

--- a/src/server/src/test/java/io/cassandrareaper/jmx/JmxCustomPortTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/jmx/JmxCustomPortTest.java
@@ -23,7 +23,7 @@ import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.crypto.Cryptograph;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
@@ -69,7 +69,7 @@ public final class JmxCustomPortTest {
         };
 
     context.config = new ReaperApplicationConfiguration();
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
 
     Cluster cluster = Cluster.builder()
             .withName("test")

--- a/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
@@ -27,7 +27,7 @@ import io.cassandrareaper.jmx.ClusterFacade;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.service.TestRepairConfiguration;
-import io.cassandrareaper.storage.MemoryStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
 
 import java.net.URI;
 import java.time.Duration;
@@ -607,7 +607,7 @@ public final class ClusterResourceTest {
 
   private MockObjects initMocks() throws ReaperException {
     AppContext context = new AppContext();
-    context.storage = new MemoryStorage();
+    context.storage = new MemoryStorageFacade();
     context.config = TestRepairConfiguration.defaultConfig();
 
     UriInfo uriInfo = mock(UriInfo.class);

--- a/src/server/src/test/java/io/cassandrareaper/resources/ReaperResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ReaperResourceTest.java
@@ -20,7 +20,7 @@ package io.cassandrareaper.resources;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperApplicationConfiguration.DatacenterAvailability;
 import io.cassandrareaper.service.TestRepairConfiguration;
-import io.cassandrareaper.storage.MemoryStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
 
 import javax.ws.rs.core.Response;
 
@@ -46,7 +46,7 @@ public class ReaperResourceTest extends TestCase {
 
   private MockObjects initMocks() {
     AppContext context = new AppContext();
-    context.storage = new MemoryStorage();
+    context.storage = new MemoryStorageFacade();
     context.config = TestRepairConfiguration.defaultConfig();
     context.config.setDatacenterAvailability(DatacenterAvailability.EACH);
 

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -31,7 +31,7 @@ import io.cassandrareaper.jmx.JmxProxyTest;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.service.RepairManager;
 import io.cassandrareaper.service.RepairRunnerTest;
-import io.cassandrareaper.storage.MemoryStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
 
 import java.math.BigInteger;
 import java.net.URI;
@@ -124,7 +124,7 @@ public final class RepairRunResourceTest {
         TimeUnit.SECONDS,
         1);
 
-    context.storage = new MemoryStorage();
+    context.storage = new MemoryStorageFacade();
 
     Cluster cluster = Cluster.builder()
         .withName(clustername)
@@ -441,7 +441,7 @@ public final class RepairRunResourceTest {
 
   @Test
   public void testAddRunClusterNotInStorage() {
-    context.storage = new MemoryStorage();
+    context.storage = new MemoryStorageFacade();
     RepairRunResource resource = new RepairRunResource(context);
     Response response = addDefaultRepairRun(resource);
     assertEquals(404, response.getStatus());

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairScheduleResourceTest.java
@@ -23,7 +23,7 @@ import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.resources.view.RepairScheduleStatus;
 import io.cassandrareaper.service.TestRepairConfiguration;
 import io.cassandrareaper.storage.IStorage;
-import io.cassandrareaper.storage.MemoryStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
 
 import java.net.URI;
 import java.util.Optional;
@@ -292,7 +292,7 @@ public class RepairScheduleResourceTest {
     MockObjects mockObjects = new MockObjects();
 
     AppContext context = new AppContext();
-    context.storage = new MemoryStorage();
+    context.storage = new MemoryStorageFacade();
     context.config = TestRepairConfiguration.defaultConfig();
     mockObjects.setContext(context);
 

--- a/src/server/src/test/java/io/cassandrareaper/service/AutoSchedulingManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/AutoSchedulingManagerTest.java
@@ -20,9 +20,7 @@ package io.cassandrareaper.service;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
-import io.cassandrareaper.service.AutoSchedulingManager;
-import io.cassandrareaper.service.ClusterRepairScheduler;
-import io.cassandrareaper.storage.MemoryStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
@@ -53,7 +51,7 @@ public final class AutoSchedulingManagerTest {
   @Before
   public void setup() throws ReaperException {
     context = new AppContext();
-    context.storage = new MemoryStorage();
+    context.storage = new MemoryStorageFacade();
     context.config = TestRepairConfiguration.defaultConfig();
     clusterRepairScheduler = mock(ClusterRepairScheduler.class);
     repairAutoSchedulingManager = new AutoSchedulingManager(context, clusterRepairScheduler);

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -26,7 +26,7 @@ import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Table;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
-import io.cassandrareaper.storage.MemoryStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -68,7 +68,7 @@ public final class ClusterRepairSchedulerTest {
         .build();
 
     context = new AppContext();
-    context.storage = new MemoryStorage();
+    context.storage = new MemoryStorageFacade();
 
     context.config = TestRepairConfiguration.defaultConfigBuilder()
         .withAutoScheduling(TestRepairConfiguration.defaultAutoSchedulingConfigBuilder()

--- a/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
@@ -25,8 +25,8 @@ import io.cassandrareaper.core.Cluster.State;
 import io.cassandrareaper.crypto.NoopCrypotograph;
 import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
-import io.cassandrareaper.storage.MemoryStorage;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,7 +54,7 @@ public final class HeartTest {
   public void testBeat_memoryStorage() throws ReaperException, InterruptedException {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
-    context.storage = Mockito.mock(MemoryStorage.class);
+    context.storage = Mockito.mock(MemoryStorageFacade.class);
     Cluster cluster = Cluster.builder()
         .withName("test")
         .withSeedHosts(Sets.newSet("127.0.0.1"))
@@ -75,7 +75,7 @@ public final class HeartTest {
 
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     Cluster cluster = Cluster.builder()
         .withName("test")
         .withSeedHosts(Sets.newSet("127.0.0.1"))
@@ -91,7 +91,7 @@ public final class HeartTest {
       heart.beat();
       Awaitility.await().until(() -> {
         try {
-          Mockito.verify((CassandraStorage)context.storage, Mockito.times(1)).saveHeartbeat();
+          Mockito.verify((CassandraStorageFacade)context.storage, Mockito.times(1)).saveHeartbeat();
           return true;
         } catch (AssertionError ex) {
           return false;
@@ -111,7 +111,7 @@ public final class HeartTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.ALL);
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     Cluster cluster = Cluster.builder()
         .withName("test")
         .withSeedHosts(Sets.newSet("127.0.0.1"))
@@ -126,7 +126,7 @@ public final class HeartTest {
       heart.beat();
       Awaitility.await().until(() -> {
         try {
-          Mockito.verify((CassandraStorage)context.storage, Mockito.times(1)).saveHeartbeat();
+          Mockito.verify((CassandraStorageFacade)context.storage, Mockito.times(1)).saveHeartbeat();
           return true;
         } catch (AssertionError ex) {
           return false;
@@ -135,7 +135,7 @@ public final class HeartTest {
       Assertions.assertThat(heart.isCurrentlyUpdatingNodeMetrics().get()).isFalse();
       Thread.sleep(500);
     }
-    Mockito.verify((CassandraStorage)context.storage, Mockito.times(1)).saveHeartbeat();
+    Mockito.verify((CassandraStorageFacade)context.storage, Mockito.times(1)).saveHeartbeat();
     Mockito.verify(context.storage, Mockito.times(1)).getClusters();
   }
 
@@ -145,7 +145,7 @@ public final class HeartTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.EACH);
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     context.jmxConnectionFactory = new JmxConnectionFactory(context, new NoopCrypotograph());
     Mockito.when(context.storage.getRepairSchedulesForCluster(any(), anyBoolean())).thenReturn(Collections.emptyList());
 
@@ -154,7 +154,7 @@ public final class HeartTest {
       heart.beat();
       Thread.sleep(500);
     }
-    Mockito.verify((CassandraStorage)context.storage, Mockito.times(1)).saveHeartbeat();
+    Mockito.verify((CassandraStorageFacade)context.storage, Mockito.times(1)).saveHeartbeat();
   }
 
   @Test
@@ -175,7 +175,7 @@ public final class HeartTest {
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     context.jmxConnectionFactory = new JmxConnectionFactory(context, new NoopCrypotograph());
 
     try (Heart heart = Heart.create(context)) {
@@ -183,7 +183,7 @@ public final class HeartTest {
       heart.beat();
       Thread.sleep(500);
     }
-    Mockito.verify((CassandraStorage)context.storage, Mockito.times(1)).saveHeartbeat();
+    Mockito.verify((CassandraStorageFacade)context.storage, Mockito.times(1)).saveHeartbeat();
   }
 
   @Test
@@ -204,7 +204,7 @@ public final class HeartTest {
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     context.jmxConnectionFactory = Mockito.mock(JmxConnectionFactory.class);
 
     try (Heart heart = Heart.create(context)) {
@@ -213,7 +213,7 @@ public final class HeartTest {
       Thread.sleep(500);
     }
 
-    Mockito.verify((CassandraStorage)context.storage, Mockito.times(1)).saveHeartbeat();
+    Mockito.verify((CassandraStorageFacade)context.storage, Mockito.times(1)).saveHeartbeat();
     Mockito.verify(context.jmxConnectionFactory, Mockito.times(0)).connectAny(any(Collection.class));
   }
 
@@ -224,7 +224,7 @@ public final class HeartTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.EACH);
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
 
     context.repairManager = RepairManager.create(
         context,
@@ -236,7 +236,7 @@ public final class HeartTest {
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     context.jmxConnectionFactory = Mockito.mock(JmxConnectionFactory.class);
 
     JmxProxy nodeProxy = Mockito.mock(JmxProxy.class);
@@ -249,7 +249,7 @@ public final class HeartTest {
       Thread.sleep(500);
     }
 
-    Mockito.verify((CassandraStorage)context.storage, Mockito.times(1)).saveHeartbeat();
+    Mockito.verify((CassandraStorageFacade)context.storage, Mockito.times(1)).saveHeartbeat();
     Mockito.verify(context.jmxConnectionFactory, Mockito.times(0)).connectAny(any(Collection.class));
   }
 
@@ -260,7 +260,7 @@ public final class HeartTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     context.config.setDatacenterAvailability(ReaperApplicationConfiguration.DatacenterAvailability.EACH);
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
 
     context.repairManager = RepairManager.create(
         context,
@@ -272,10 +272,10 @@ public final class HeartTest {
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
     context.repairManager.repairRunners.put(UUID.randomUUID(), Mockito.mock(RepairRunner.class));
 
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     context.jmxConnectionFactory = Mockito.mock(JmxConnectionFactory.class);
 
-    Mockito.when(((CassandraStorage) context.storage).getCluster(any()))
+    Mockito.when(((CassandraStorageFacade) context.storage).getCluster(any()))
         .thenReturn(
           Cluster.builder()
               .withName("cluster1")
@@ -293,6 +293,6 @@ public final class HeartTest {
       Thread.sleep(500);
     }
 
-    Mockito.verify((CassandraStorage)context.storage, Mockito.times(1)).saveHeartbeat();
+    Mockito.verify((CassandraStorageFacade)context.storage, Mockito.times(1)).saveHeartbeat();
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -28,7 +28,7 @@ import io.cassandrareaper.core.Segment;
 import io.cassandrareaper.jmx.ClusterFacade;
 import io.cassandrareaper.storage.IDistributedStorage;
 import io.cassandrareaper.storage.IStorage;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -85,7 +85,7 @@ public final class RepairManagerTest {
     final int segmentTimeout = 30;
 
     // use CassandraStorage so we get both IStorage and IDistributedStorage
-    final IStorage storage = mock(CassandraStorage.class);
+    final IStorage storage = mock(CassandraStorageFacade.class);
 
     storage.addCluster(Cluster.builder().withName(clusterName).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
 
@@ -162,7 +162,7 @@ public final class RepairManagerTest {
     final int segmentTimeout = 30;
 
     // use CassandraStorage so we get both IStorage and IDistributedStorage
-    final IStorage storage = mock(CassandraStorage.class);
+    final IStorage storage = mock(CassandraStorageFacade.class);
 
     storage.addCluster(Cluster.builder().withName(clusterName).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
 
@@ -380,7 +380,7 @@ public final class RepairManagerTest {
 
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
 
     context.storage
         .addCluster(Cluster.builder().withName(clusterName).withSeedHosts(ImmutableSet.of("127.0.0.1")).build());
@@ -434,7 +434,7 @@ public final class RepairManagerTest {
   public void countRepairRunnersPerClusterTest() throws ReaperException, InterruptedException {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
     doReturn(true).when(context.storage).updateRepairRun(any());
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     String cluster1 = "cluster1";

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -32,7 +32,8 @@ import io.cassandrareaper.jmx.JmxConnectionFactory;
 import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.jmx.JmxProxyTest;
 import io.cassandrareaper.storage.IStorage;
-import io.cassandrareaper.storage.MemoryStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
+import io.cassandrareaper.storage.repairsegment.IRepairSegment;
 
 import java.math.BigInteger;
 import java.net.UnknownHostException;
@@ -245,7 +246,7 @@ public final class RepairRunServiceTest {
         BigInteger.valueOf(0L),
         BigInteger.valueOf(100L),
         BigInteger.valueOf(200L));
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
 
     storage.addCluster(cluster);
 
@@ -332,7 +333,7 @@ public final class RepairRunServiceTest {
         BigInteger.valueOf(0L),
         BigInteger.valueOf(100L),
         BigInteger.valueOf(200L));
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
 
     storage.addCluster(cluster);
 
@@ -788,7 +789,7 @@ public final class RepairRunServiceTest {
 
   @Test
   public void getDatacentersToRepairBasedOnParamTest() throws ReaperException {
-    final IStorage storage = mock(IStorage.class);
+    final IRepairSegment storage = mock(IStorage.class);
     Set<String> datacenters = RepairRunService.getDatacentersToRepairBasedOnParam(Optional.of("dc1,dc2"));
     assertEquals("Datacenters were not parsed correctly", 2, datacenters.size());
   }
@@ -815,7 +816,7 @@ public final class RepairRunServiceTest {
             BigInteger.valueOf(0L),
             BigInteger.valueOf(100L),
             BigInteger.valueOf(200L));
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
 
     storage.addCluster(cluster);
 

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -37,8 +37,8 @@ import io.cassandrareaper.jmx.JmxProxyTest;
 import io.cassandrareaper.jmx.RepairStatusHandler;
 import io.cassandrareaper.storage.IDistributedStorage;
 import io.cassandrareaper.storage.IStorage;
-import io.cassandrareaper.storage.MemoryStorage;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -140,7 +140,7 @@ public final class RepairRunnerTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 1;
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     storage.addCluster(cluster);
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -294,7 +294,7 @@ public final class RepairRunnerTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 1;
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     storage.addCluster(cluster);
     DateTimeUtils.setCurrentMillisFixed(timeRun);
     RepairUnit cf = storage.addRepairUnit(
@@ -449,7 +449,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -578,7 +578,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -837,7 +837,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -1035,7 +1035,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -1178,7 +1178,7 @@ public final class RepairRunnerTest {
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     RepairUnit repairUnit = RepairUnit.builder()
           .clusterName(cluster.getName())
           .keyspaceName(ksName)
@@ -1198,8 +1198,8 @@ public final class RepairRunnerTest {
           .tables(TABLES).build(UUID.randomUUID());
 
     Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
-    Mockito.when(((CassandraStorage) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
-    Mockito.when(((CassandraStorage) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
 
     Mockito.when(context.storage.getCluster(any())).thenReturn(cluster);
     JmxConnectionFactory jmxConnectionFactory = mock(JmxConnectionFactory.class);
@@ -1248,7 +1248,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -1332,7 +1332,7 @@ public final class RepairRunnerTest {
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     RepairUnit repairUnit = RepairUnit.builder()
           .clusterName(cluster.getName())
           .keyspaceName(ksName)
@@ -1366,10 +1366,10 @@ public final class RepairRunnerTest {
 
     List<RepairSegment> segments = generateRepairSegments(10, 0, 1, repairUnit.getId());
     Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
-    Mockito.when(((CassandraStorage) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
-    Mockito.when(((CassandraStorage) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
-    Mockito.when(((CassandraStorage) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
-    Mockito.when((((CassandraStorage) context.storage).getRepairSchedulesForClusterAndKeyspace(any(), any())))
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
+    Mockito.when(((CassandraStorageFacade) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
+    Mockito.when((((CassandraStorageFacade) context.storage).getRepairSchedulesForClusterAndKeyspace(any(), any())))
         .thenReturn(schedules);
 
     Mockito.when(context.storage.getCluster(any())).thenReturn(cluster);
@@ -1417,7 +1417,7 @@ public final class RepairRunnerTest {
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     RepairUnit repairUnit = RepairUnit.builder()
           .clusterName(cluster.getName())
           .keyspaceName(ksName)
@@ -1451,10 +1451,10 @@ public final class RepairRunnerTest {
 
     List<RepairSegment> segments = generateRepairSegments(100, 35, 10, repairUnit.getId());
     Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
-    Mockito.when(((CassandraStorage) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
-    Mockito.when(((CassandraStorage) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
-    Mockito.when(((CassandraStorage) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
-    Mockito.when((((CassandraStorage) context.storage).getRepairSchedulesForClusterAndKeyspace(any(), any())))
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
+    Mockito.when(((CassandraStorageFacade) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
+    Mockito.when((((CassandraStorageFacade) context.storage).getRepairSchedulesForClusterAndKeyspace(any(), any())))
         .thenReturn(schedules);
 
     Mockito.when(context.storage.getCluster(any())).thenReturn(cluster);
@@ -1503,7 +1503,7 @@ public final class RepairRunnerTest {
     final int maxDuration = 10;
     final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     RepairUnit repairUnit = RepairUnit.builder()
           .clusterName(cluster.getName())
           .keyspaceName(ksName)
@@ -1537,10 +1537,10 @@ public final class RepairRunnerTest {
 
     List<RepairSegment> segments = generateRepairSegments(100, 10, maxDuration, repairUnit.getId());
     Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
-    Mockito.when(((CassandraStorage) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
-    Mockito.when(((CassandraStorage) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
-    Mockito.when(((CassandraStorage) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
-    Mockito.when((((CassandraStorage) context.storage).getRepairSchedulesForClusterAndKeyspace(any(), any())))
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
+    Mockito.when(((CassandraStorageFacade) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
+    Mockito.when((((CassandraStorageFacade) context.storage).getRepairSchedulesForClusterAndKeyspace(any(), any())))
         .thenReturn(schedules);
 
     Mockito.when(context.storage.getCluster(any())).thenReturn(cluster);
@@ -1589,7 +1589,7 @@ public final class RepairRunnerTest {
     final int maxDuration = 10;
     final List<BigInteger> tokens = THREE_TOKENS;
     final AppContext context = new AppContext();
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     RepairUnit repairUnit = RepairUnit.builder()
           .clusterName(cluster.getName())
           .keyspaceName(ksName)
@@ -1611,9 +1611,9 @@ public final class RepairRunnerTest {
 
     List<RepairSegment> segments = generateRepairSegments(100, 30, maxDuration, repairUnit.getId());
     Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
-    Mockito.when(((CassandraStorage) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
-    Mockito.when(((CassandraStorage) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
-    Mockito.when(((CassandraStorage) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
+    Mockito.when(((CassandraStorageFacade) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
 
     Mockito.when(context.storage.getCluster(any())).thenReturn(cluster);
     JmxConnectionFactory jmxConnectionFactory = mock(JmxConnectionFactory.class);
@@ -1681,7 +1681,7 @@ public final class RepairRunnerTest {
     final int segmentTimeout = 30;
     final int maxDuration = 10;
     final AppContext context = new AppContext();
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     context.config = new ReaperApplicationConfiguration();
     context.config.setMaxParallelRepairs(3);
     Mockito.when(context.storage.getCluster(any())).thenReturn(cluster);
@@ -1709,9 +1709,9 @@ public final class RepairRunnerTest {
 
     List<RepairSegment> segments = generateRepairSegments(100, 30, maxDuration, repairUnit.getId());
     Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
-    Mockito.when(((CassandraStorage) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
-    Mockito.when(((CassandraStorage) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
-    Mockito.when(((CassandraStorage) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
+    Mockito.when(((CassandraStorageFacade) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
 
     List<UUID> runningRepairs = Lists.newArrayList();
     for (int i = 0; i < 3; i++) {
@@ -1744,7 +1744,7 @@ public final class RepairRunnerTest {
     final int segmentTimeout = 30;
     final int maxDuration = 10;
     final AppContext context = new AppContext();
-    context.storage = Mockito.mock(CassandraStorage.class);
+    context.storage = Mockito.mock(CassandraStorageFacade.class);
     context.config = new ReaperApplicationConfiguration();
     context.config.setMaxParallelRepairs(3);
     Mockito.when(context.storage.getCluster(any())).thenReturn(cluster);
@@ -1763,8 +1763,8 @@ public final class RepairRunnerTest {
 
     List<RepairSegment> segments = generateRepairSegments(100, 30, maxDuration, repairUnit.getId());
     Mockito.when(((IDistributedStorage) context.storage).countRunningReapers()).thenReturn(1);
-    Mockito.when(((CassandraStorage) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
-    Mockito.when(((CassandraStorage) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnit(any(UUID.class))).thenReturn(repairUnit);
+    Mockito.when(((CassandraStorageFacade) context.storage).getSegmentsWithState(any(), any())).thenReturn(segments);
 
     List<UUID> runningRepairs = Lists.newArrayList();
     for (int i = 0; i < 3; i++) {
@@ -1778,7 +1778,7 @@ public final class RepairRunnerTest {
           .repairParallelism(RepairParallelism.PARALLEL)
           .adaptiveSchedule(false)
           .tables(TABLES).build(unallowedRun);
-    Mockito.when(((CassandraStorage) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
+    Mockito.when(((CassandraStorageFacade) context.storage).getRepairRun(any())).thenReturn(Optional.of(run));
     runningRepairs.add(unallowedRun);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);

--- a/src/server/src/test/java/io/cassandrareaper/service/SchedulingManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SchedulingManagerTest.java
@@ -25,7 +25,7 @@ import io.cassandrareaper.core.RepairRun;
 import io.cassandrareaper.core.RepairRun.RunState;
 import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
-import io.cassandrareaper.storage.cassandra.CassandraStorage;
+import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -71,8 +71,8 @@ public final class SchedulingManagerTest {
     IntStream.range(0,5).forEach(i -> reaperInstances.add(UUIDs.timeBased()));
     // Add the current reaper instance id to the list
     reaperInstances.add(context.reaperInstanceId);
-    context.storage = mock(CassandraStorage.class);
-    when(((CassandraStorage)context.storage).getRunningReapers()).thenReturn(reaperInstances);
+    context.storage = mock(CassandraStorageFacade.class);
+    when(((CassandraStorageFacade)context.storage).getRunningReapers()).thenReturn(reaperInstances);
     SchedulingManager schedulingManager = SchedulingManager.create(context);
     assertTrue("The eldest Reaper instance should be the scheduling leader",
         schedulingManager.currentReaperIsSchedulingLeader());
@@ -87,8 +87,8 @@ public final class SchedulingManagerTest {
     context.isDistributed.set(true);
     // Add the current reaper instance id to the list
     reaperInstances.add(context.reaperInstanceId);
-    context.storage = mock(CassandraStorage.class);
-    when(((CassandraStorage)context.storage).getRunningReapers()).thenReturn(reaperInstances);
+    context.storage = mock(CassandraStorageFacade.class);
+    when(((CassandraStorageFacade)context.storage).getRunningReapers()).thenReturn(reaperInstances);
     SchedulingManager schedulingManager = SchedulingManager.create(context);
     assertFalse("The eldest Reaper instance should be the scheduling leader",
         schedulingManager.currentReaperIsSchedulingLeader());
@@ -103,8 +103,8 @@ public final class SchedulingManagerTest {
     IntStream.range(0,5).forEach(i -> reaperInstances.add(UUIDs.timeBased()));
     // Add the current reaper instance id to the list
     reaperInstances.add(context.reaperInstanceId);
-    context.storage = mock(CassandraStorage.class);
-    when(((CassandraStorage)context.storage).getRunningReapers()).thenReturn(Collections.emptyList());
+    context.storage = mock(CassandraStorageFacade.class);
+    when(((CassandraStorageFacade)context.storage).getRunningReapers()).thenReturn(Collections.emptyList());
     SchedulingManager schedulingManager = SchedulingManager.create(context);
     assertFalse("If we cannot get the list of running reapers, none should be scheduling leader",
         schedulingManager.currentReaperIsSchedulingLeader());
@@ -123,8 +123,8 @@ public final class SchedulingManagerTest {
         .build(UUIDs.timeBased());
 
     AppContext context = new AppContext();
-    context.storage = mock(CassandraStorage.class);
-    when(((CassandraStorage)context.storage).getRepairRun(any())).thenReturn(Optional.of(repairRun));
+    context.storage = mock(CassandraStorageFacade.class);
+    when(((CassandraStorageFacade)context.storage).getRepairRun(any())).thenReturn(Optional.of(repairRun));
 
     context.config = new ReaperApplicationConfiguration();
     context.config.setPercentRepairedCheckIntervalMinutes(1);
@@ -155,10 +155,10 @@ public final class SchedulingManagerTest {
         .build(UUIDs.timeBased());
 
     AppContext context = new AppContext();
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
     RepairManager repairManager = mock(RepairManager.class);
     context.repairManager = repairManager;
-    when(((CassandraStorage)context.storage).getRepairRun(any())).thenReturn(Optional.of(repairRun));
+    when(((CassandraStorageFacade)context.storage).getRepairRun(any())).thenReturn(Optional.of(repairRun));
 
     context.config = new ReaperApplicationConfiguration();
     context.config.setPercentRepairedCheckIntervalMinutes(10);
@@ -179,7 +179,7 @@ public final class SchedulingManagerTest {
   @Test
   public void manageIncRepairAbovePercentThresholdSchedule() throws ReaperException {
     AppContext context = new AppContext();
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
     RepairManager repairManager = mock(RepairManager.class);
     context.repairManager = repairManager;
 
@@ -252,7 +252,7 @@ public final class SchedulingManagerTest {
   @Test
   public void manageIncRepairBelowPercentThresholdSchedule() throws ReaperException {
     AppContext context = new AppContext();
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
     RepairManager repairManager = mock(RepairManager.class);
     context.repairManager = repairManager;
 
@@ -273,7 +273,7 @@ public final class SchedulingManagerTest {
         .startTime(DateTime.now().minusMinutes(10))
         .endTime(DateTime.now().minusMinutes(5))
         .build(UUIDs.timeBased());
-    when(((CassandraStorage)context.storage).getRepairRun(any())).thenReturn(Optional.of(repairRun));
+    when(((CassandraStorageFacade)context.storage).getRepairRun(any())).thenReturn(Optional.of(repairRun));
 
     RepairSchedule repairSchedule = RepairSchedule.builder(repairUnit.getId())
         .daysBetween(1)
@@ -323,7 +323,7 @@ public final class SchedulingManagerTest {
   @Test
   public void managePausedRepairSchedule() throws ReaperException {
     AppContext context = new AppContext();
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
     RepairManager repairManager = mock(RepairManager.class);
     context.repairManager = repairManager;
 
@@ -344,7 +344,7 @@ public final class SchedulingManagerTest {
         .startTime(DateTime.now().minusMinutes(10))
         .endTime(DateTime.now().minusMinutes(5))
         .build(UUIDs.timeBased());
-    when(((CassandraStorage)context.storage).getRepairRun(any())).thenReturn(Optional.of(repairRun));
+    when(((CassandraStorageFacade)context.storage).getRepairRun(any())).thenReturn(Optional.of(repairRun));
 
     RepairSchedule repairSchedule = RepairSchedule.builder(repairUnit.getId())
         .daysBetween(1)
@@ -370,7 +370,7 @@ public final class SchedulingManagerTest {
   @Test
   public void cleanupMetricsRegistryTest() {
     AppContext context = new AppContext();
-    context.storage = mock(CassandraStorage.class);
+    context.storage = mock(CassandraStorageFacade.class);
     context.config = new ReaperApplicationConfiguration();
     context.config.setPercentRepairedCheckIntervalMinutes(10);
     context.metricRegistry = mock(MetricRegistry.class);

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -35,7 +35,7 @@ import io.cassandrareaper.jmx.JmxProxy;
 import io.cassandrareaper.jmx.JmxProxyTest;
 import io.cassandrareaper.jmx.RepairStatusHandler;
 import io.cassandrareaper.storage.IStorage;
-import io.cassandrareaper.storage.MemoryStorage;
+import io.cassandrareaper.storage.MemoryStorageFacade;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -98,7 +98,7 @@ public final class SegmentRunnerTest {
     context.config = Mockito.mock(ReaperApplicationConfiguration.class);
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
-    context.storage = new MemoryStorage();
+    context.storage = new MemoryStorageFacade();
 
     RepairUnit cf = context.storage.addRepairUnit(
             RepairUnit.builder()
@@ -219,7 +219,7 @@ public final class SegmentRunnerTest {
   @Test
   public void successTest() throws InterruptedException, ReaperException, ExecutionException,
         MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
@@ -372,7 +372,7 @@ public final class SegmentRunnerTest {
   @Test
   public void failureTest() throws InterruptedException, ReaperException, ExecutionException,
         MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
@@ -520,7 +520,7 @@ public final class SegmentRunnerTest {
   public void outOfOrderSuccessCass21Test()
       throws InterruptedException, ReaperException, ExecutionException,
       MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
 
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -663,7 +663,7 @@ public final class SegmentRunnerTest {
   public void outOfOrderSuccessCass22Test()
       throws InterruptedException, ReaperException, ExecutionException,
       MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
 
     RepairUnit cf = storage.addRepairUnit(
             RepairUnit.builder()
@@ -807,7 +807,7 @@ public final class SegmentRunnerTest {
   public void outOfOrderFailureCass21Test()
       throws InterruptedException, ReaperException, ExecutionException,
       MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
@@ -953,7 +953,7 @@ public final class SegmentRunnerTest {
   public void outOfOrderFailureTestCass22()
       throws InterruptedException, ReaperException, ExecutionException,
       MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
@@ -1130,7 +1130,7 @@ public final class SegmentRunnerTest {
   @Test
   public void triggerFailureTest() throws InterruptedException, ReaperException, ExecutionException,
         MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
@@ -1224,7 +1224,7 @@ public final class SegmentRunnerTest {
   @Test
   public void nothingToRepairTest() throws InterruptedException, ReaperException, ExecutionException,
         MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
@@ -1342,7 +1342,7 @@ public final class SegmentRunnerTest {
   @Test
   public void clearSnapshotTest() throws InterruptedException, ReaperException, ExecutionException,
         MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(
@@ -1425,7 +1425,7 @@ public final class SegmentRunnerTest {
   @Test
   public void clearSnapshotFailTest() throws InterruptedException, ReaperException, ExecutionException,
         MalformedObjectNameException, ReflectionException, IOException {
-    final IStorage storage = new MemoryStorage();
+    final IStorage storage = new MemoryStorageFacade();
     final int segmentTimeout = 30;
 
     RepairUnit cf = storage.addRepairUnit(

--- a/src/server/src/test/java/io/cassandrareaper/storage/CassandraStorageFacadeTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/storage/CassandraStorageFacadeTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 
 
-public final class CassandraStorageTest {
+public final class CassandraStorageFacadeTest {
 
   @Test
   public void testMigrationRepository() {


### PR DESCRIPTION
This PR continues refactoring the storage classes. It breaks the MemoryStorage class out into delegated classes, turning MemoryStorage into MemoryStorageFacade. CassandraStorage is likewise renamed CassandraStorageFacade since most of its methods are now also delegates (there are some residual ones that we will deal with in the next round of refactoring).

The DAOs are now lined up on the domain model from `core`, with each sitting in its own package containing:

1. An interface.
2. A Cassandra DAO class implementing the interface.
3. A memory based DAO implementing the interface

IStorage has been substantially broken down and now extends a variety of smaller interfaces again adhering to the domain model from the `core` package.

To preserve the existing semantics for callers, I have retained MemoryStorageFacade and CassandraStorageFacade, which we will attempt to now completely eliminate in the next round of refactoring. Several methods have been eliminated from these classes where they were only required internally within the DAO.

We also fix a bug where the implementation of `deleteRepairRun` differed between the memory and Cassandra implementations.

Still to do:

1. This PR does not touch anything from IDistributedStorage, that needs to be straightened out as some methods listed there have made their way into CassRepairSegmentDao.
2. Eliminate the use of CassandraStorageFacade and MemoryStorageFacade, and replace IStorage uses with the smaller interfaces which map to the domain model. This will mostly affect the classes in `resources`.