### PR TITLE
Fix issues when listing repair runs using state priorities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build Reaper
         run: |
-          MAVEN_OPTS="-Xmx384m" mvn -B org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:prepare-agent install org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:report
+          MAVEN_OPTS="-Xmx384m" mvn -B org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:prepare-agent clean install org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:report
           mv src/server/target/site/jacoco src/server/target/site/jacoco_ut    
           mvn -B org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:prepare-agent surefire:test org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:report -Dtest=ReaperShiroIT
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build Reaper
         run: |
-          MAVEN_OPTS="-Xmx384m" mvn -B org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:prepare-agent clean install org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:report
+          MAVEN_OPTS="-Xmx384m" mvn -B org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:prepare-agent install org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:report
           mv src/server/target/site/jacoco src/server/target/site/jacoco_ut    
           mvn -B org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:prepare-agent surefire:test org.jacoco:jacoco-maven-plugin:${{ env.JACOCO_VERSION }}:report -Dtest=ReaperShiroIT
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .m2-repository/
 pom.xml.versionsBackup
 target/
+target-ide/
 dependency-reduced-pom.xml
 
 # Stuff from various IDE's and editors

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -356,6 +356,10 @@
           <directory>src/test/resources</directory>
           <filtering>true</filtering>
         </testResource>
+        <testResource>
+          <directory>src/main/resources</directory>
+          <filtering>true</filtering>
+        </testResource>
       </testResources>
         <plugins>
             <plugin>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -356,10 +356,6 @@
           <directory>src/test/resources</directory>
           <filtering>true</filtering>
         </testResource>
-        <testResource>
-          <directory>src/main/resources</directory>
-          <filtering>true</filtering>
-        </testResource>
       </testResources>
         <plugins>
             <plugin>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -53,6 +53,7 @@
     |           |
         </cucumber.no-versions-to-test>
         <cucumber.upgrade-versions>${cucumber.no-versions-to-test}</cucumber.upgrade-versions>
+        <build.output>target</build.output>
     </properties>
 
     <dependencies>
@@ -351,6 +352,7 @@
     </dependencies>
 
     <build>
+      <directory>${build.output}</directory>
       <testResources>
         <testResource>
           <directory>src/test/resources</directory>
@@ -714,6 +716,14 @@
         </plugins>
     </build>
     <profiles>
+      <profile>
+        <activation>
+          <property><name>m2e.version</name></property>
+        </activation>
+        <properties>
+          <build.output>target-ide</build.output>
+        </properties>
+      </profile>
       <profile>
         <id>integration-upgrade-tests</id>
         <properties>

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -655,7 +655,7 @@ public final class RepairRunResource {
       @QueryParam("limit") Optional<Integer> limit) {
 
     try {
-      final Set desiredStates = splitStateParam(state);
+      final Set<String> desiredStates = splitStateParam(state);
       if (desiredStates == null) {
         return Response.status(Response.Status.BAD_REQUEST).build();
       }
@@ -664,14 +664,14 @@ public final class RepairRunResource {
             ? Collections.singleton(context.storage.getCluster(cluster.get()))
             : context.storage.getClusters();
 
-      List<RepairRunStatus> runStatuses = Lists.newArrayList();
       List<RepairRun> repairRuns = Lists.newArrayList();
       clusters.forEach(clstr -> repairRuns.addAll(
           context.storage.getRepairRunsForClusterPrioritiseRunning(clstr.getName(), limit))
       );
+      List<RepairRunStatus> runStatuses = Lists.newArrayList();
       RepairRunService.sortByRunState(repairRuns);
       runStatuses.addAll(
-          (List<RepairRunStatus>) getRunStatuses(
+          getRunStatuses(
               repairRuns.subList(0, min(repairRuns.size(), limit.orElse(1000))), desiredStates)
               .stream()
               .filter((run) -> !keyspace.isPresent()
@@ -700,7 +700,7 @@ public final class RepairRunResource {
     return runStatuses;
   }
 
-  static Set splitStateParam(Optional<String> state) {
+  static Set<String> splitStateParam(Optional<String> state) {
     if (state.isPresent()) {
       final Iterable<String> chunks = RepairRunService.COMMA_SEPARATED_LIST_SPLITTER.split(state.get());
       for (final String chunk : chunks) {

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -650,7 +650,7 @@ public final class RepairRunResource {
   @GET
   public Response listRepairRuns(
       @QueryParam("state") Optional<String> state,
-      @QueryParam("clusterName") Optional<String> cluster,
+      @QueryParam("cluster_name") Optional<String> cluster,
       @QueryParam("keyspace_name") Optional<String> keyspace,
       @QueryParam("limit") Optional<Integer> limit) {
 

--- a/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
+++ b/src/server/src/main/java/io/cassandrareaper/resources/RepairRunResource.java
@@ -604,9 +604,9 @@ public final class RepairRunResource {
    * @return all know repair runs for a cluster.
    */
   @GET
-  @Path("/cluster/{cluster_name}")
+  @Path("/cluster/{clusterName}")
   public Response getRepairRunsForCluster(
-      @PathParam("cluster_name") String clusterName,
+      @PathParam("clusterName") String clusterName,
       @QueryParam("limit") Optional<Integer> limit) {
 
     LOG.debug("get repair run for cluster called with: cluster_name = {}", clusterName);
@@ -650,7 +650,7 @@ public final class RepairRunResource {
   @GET
   public Response listRepairRuns(
       @QueryParam("state") Optional<String> state,
-      @QueryParam("cluster_name") Optional<String> cluster,
+      @QueryParam("clusterName") Optional<String> cluster,
       @QueryParam("keyspace_name") Optional<String> keyspace,
       @QueryParam("limit") Optional<Integer> limit) {
 
@@ -660,7 +660,7 @@ public final class RepairRunResource {
         return Response.status(Response.Status.BAD_REQUEST).build();
       }
 
-      Collection<Cluster> clusters = cluster.isPresent()
+      Collection<Cluster> clusters = cluster.isPresent() && !cluster.get().equals("all")
             ? Collections.singleton(context.storage.getCluster(cluster.get()))
             : context.storage.getClusters();
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/RepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/RepairRunDao.java
@@ -342,7 +342,7 @@ public class RepairRunDao {
           // UUIDs for one status.
           this.session
               .executeAsync(getRepairRunForClusterWhereStatusPrepStmt
-                  .bind(clusterName, state.toString(), limit.orElse(MAX_RETURNED_REPAIR_RUNS)
+                  .bind(clusterName, state, limit.orElse(MAX_RETURNED_REPAIR_RUNS)
                   )
               )
       );
@@ -365,12 +365,11 @@ public class RepairRunDao {
     // Merge the two lists and trim.
     repairUuidFuturesNoState.getUninterruptibly().forEach(row -> {
           UUID uuid = row.getUUID("id");
-          if (!flattenedUuids.contains(uuid)) {
+          if (!flattenedUuids.contains(uuid) && flattenedUuids.size() < limit.orElse(MAX_RETURNED_REPAIR_RUNS)) {
             flattenedUuids.add(uuid);
           }
         }
     );
-    flattenedUuids.subList(0, Math.min(flattenedUuids.size(), limit.orElse(MAX_RETURNED_REPAIR_RUNS)));
 
     // Run an async query on each UUID in the flattened list, against the main repair_run table with
     // all columns required as an input to `buildRepairRunFromRow`.

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/RepairSegmentDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/RepairSegmentDao.java
@@ -175,7 +175,7 @@ public class RepairSegmentDao {
 
   public int getSegmentAmountForRepairRun(UUID runId) {
     return (int) session
-        .execute(getRepairSegmentCountByRunIdAndStatePrepStmt.bind(runId))
+        .execute(getRepairSegmentCountByRunIdPrepStmt.bind(runId))
         .one()
         .getLong(0);
   }

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -2902,9 +2902,9 @@ public final class BasicSteps {
                                  String clusterName,
                                  String keyspace) throws Throwable {
     synchronized (BasicSteps.class) {
-      testContext.TEST_CLUSTER = (String) clusterName;
+      TestContext.TEST_CLUSTER = (String) clusterName;
       Set<String> tables = Sets.newHashSet();
-      testContext.addClusterInfo(clusterName, keyspace, tables);
+      TestContext.addClusterInfo(clusterName, keyspace, tables);
       HashMap<String, String> params = Maps.newHashMap();
       params.put("clusterName", clusterName);
       params.put("keyspace", keyspace);
@@ -2958,7 +2958,7 @@ public final class BasicSteps {
     }
   }
 
-  @Then("^when I list the last (\\d+) repairs, I can see (\\d+) repairs at (\\d+) state$")
+  @Then("^when I list the last (\\d+) repairs, I can see (\\d+) repairs at \"([^\"]*)\" state$")
   public void listRepairs(Integer limit, Integer expectedRepairsCount, String expectedState) {
     synchronized (BasicSteps.class) {
       RUNNERS.parallelStream().forEach(runner -> {
@@ -2978,61 +2978,70 @@ public final class BasicSteps {
         Assertions
             .assertThat(responseData).isNotBlank();
 
-        List<RepairRunStatus> runs = SimpleReaperClient.parseRepairRunStatusListJSON(responseData)
-            .stream()
-            .filter(r -> RepairRun.RunState.RUNNING == r.getState() || RepairRun.RunState.DONE == r.getState())
-            .filter(r -> r.getCause().contains(testContext.getCurrentScheduleId().toString()))
-            .collect(Collectors.toList());
+        List<RepairRunStatus> runs = SimpleReaperClient.parseRepairRunStatusListJSON(responseData);
+        LOG.info("Found {} repairs", runs);
+        LOG.info("Found {} repairs in state {}",
+            runs.stream()
+            .filter(run -> run.getState().toString().equals(expectedState))
+            .collect(Collectors.toList()).size(), expectedState);
+        LOG.info("Found states {}",
+            runs.stream()
+            .map(run -> run.getState().toString())
+            .collect(Collectors.toList()));
         Integer countInState = runs.stream()
-            .filter(run -> run.getState() == RepairRun.RunState.valueOf(expectedState))
+            .filter(run -> run.getState().toString().equals(expectedState))
             .collect(Collectors.toList())
             .size();
         Assertions
             .assertThat(countInState)
             .isEqualTo(expectedRepairsCount)
             .withFailMessage(
-                "actual number %i of repairs in state %s did not match expected number %i",
+                "actual number %d of repairs in state %s did not match expected number %d",
                 countInState,
                 expectedState,
                 expectedRepairsCount);
       });
       RUNNERS.parallelStream().forEach(runner -> {
-        HashMap<String, String> params = Maps.newHashMap();
-        params.put("limit", limit.toString());
-        // Run query against /repair_run
-        Response resp = runner.callReaper(
-            "GET",
-            "/repair_run",
-            Optional.of(params)
-        );
-        String responseData = resp.readEntity(String.class);
-        Assertions
-            .assertThat(resp.getStatus())
-            .isEqualTo(Response.Status.OK.getStatusCode())
-            .withFailMessage(responseData);
-        Assertions
-            .assertThat(responseData).isNotBlank();
+        // the getCluster() DAO call uses a 10 seconds cache, so we need to repeat the test until the cache is updated
+        await().with().pollInterval(POLL_INTERVAL).atMost(2, MINUTES).until(() -> {
+          try {
+            HashMap<String, String> params = Maps.newHashMap();
+            params.put("limit", limit.toString());
+            // Run query against /repair_run
+            Response resp = runner.callReaper(
+                "GET",
+                "/repair_run",
+                Optional.of(params)
+            );
+            String responseData = resp.readEntity(String.class);
+            Assertions
+                .assertThat(resp.getStatus())
+                .isEqualTo(Response.Status.OK.getStatusCode())
+                .withFailMessage(responseData);
+            Assertions
+                .assertThat(responseData).isNotBlank();
 
-        List<RepairRunStatus> runs = SimpleReaperClient.parseRepairRunStatusListJSON(responseData)
-            .stream()
-            .filter(r -> RepairRun.RunState.RUNNING == r.getState() || RepairRun.RunState.DONE == r.getState())
-            .filter(r -> r.getCause().contains(testContext.getCurrentScheduleId().toString()))
-            .collect(Collectors.toList());
-        Integer countInState = runs.stream()
-            .filter(run -> run.getState() == RepairRun.RunState.valueOf(expectedState))
-            .collect(Collectors.toList())
-            .size();
-        Assertions
-            .assertThat(countInState)
-            .isEqualTo(expectedRepairsCount)
-            .withFailMessage(
-                "actual number %i of repairs in state %s did not match expected number %i",
-                countInState,
-                expectedState,
-                expectedRepairsCount);
+            List<RepairRunStatus> runs = SimpleReaperClient.parseRepairRunStatusListJSON(responseData);
+            Integer countInState = runs.stream()
+                .filter(run -> run.getState().toString().equals(expectedState))
+                .collect(Collectors.toList())
+                .size();
+            Assertions
+                .assertThat(countInState)
+                .isEqualTo(expectedRepairsCount)
+                .withFailMessage(
+                    "actual number %d of repairs in state %s did not match expected number %d",
+                    countInState,
+                    expectedState,
+                    expectedRepairsCount);
+            return true;
+          } catch (AssertionError ex) {
+            LOG.warn("Assertion failed", ex);
+            return false;
+          }
+        });
       });
     }
   }
-
 }
 

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -60,6 +60,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -2958,49 +2959,9 @@ public final class BasicSteps {
     }
   }
 
-  @Then("^when I list the last (\\d+) repairs, I can see (\\d+) repairs at \"([^\"]*)\" state$")
+  @When("^I list the last (\\d+) repairs, I can see (\\d+) repairs at \"([^\"]*)\" state$")
   public void listRepairs(Integer limit, Integer expectedRepairsCount, String expectedState) {
     synchronized (BasicSteps.class) {
-      RUNNERS.parallelStream().forEach(runner -> {
-        HashMap<String, String> params = Maps.newHashMap();
-        params.put("limit", limit.toString());
-        // Run query against /repair_run/cluster/
-        Response resp = runner.callReaper(
-            "GET",
-            "/repair_run/cluster/" + TestContext.TEST_CLUSTER,
-            Optional.of(params)
-        );
-        String responseData = resp.readEntity(String.class);
-        Assertions
-            .assertThat(resp.getStatus())
-            .isEqualTo(Response.Status.OK.getStatusCode())
-            .withFailMessage(responseData);
-        Assertions
-            .assertThat(responseData).isNotBlank();
-
-        List<RepairRunStatus> runs = SimpleReaperClient.parseRepairRunStatusListJSON(responseData);
-        LOG.info("Found {} repairs", runs);
-        LOG.info("Found {} repairs in state {}",
-            runs.stream()
-            .filter(run -> run.getState().toString().equals(expectedState))
-            .collect(Collectors.toList()).size(), expectedState);
-        LOG.info("Found states {}",
-            runs.stream()
-            .map(run -> run.getState().toString())
-            .collect(Collectors.toList()));
-        Integer countInState = runs.stream()
-            .filter(run -> run.getState().toString().equals(expectedState))
-            .collect(Collectors.toList())
-            .size();
-        Assertions
-            .assertThat(countInState)
-            .isEqualTo(expectedRepairsCount)
-            .withFailMessage(
-                "actual number %d of repairs in state %s did not match expected number %d",
-                countInState,
-                expectedState,
-                expectedRepairsCount);
-      });
       RUNNERS.parallelStream().forEach(runner -> {
         // the getCluster() DAO call uses a 10 seconds cache, so we need to repeat the test until the cache is updated
         await().with().pollInterval(POLL_INTERVAL).atMost(2, MINUTES).until(() -> {
@@ -3041,6 +3002,96 @@ public final class BasicSteps {
           }
         });
       });
+    }
+  }
+
+  @When("^I list the last (\\d+) repairs for cluster \"([^\"]*)\", I can see (\\d+) repairs at \"([^\"]*)\" state$")
+  public void listRepairs(Integer limit, String clusterName, Integer expectedRepairsCount, String expectedState) {
+    synchronized (BasicSteps.class) {
+      // Test with GET /repair_run?cluster_name=... first
+      RUNNERS.parallelStream().forEach(runner -> {
+        HashMap<String, String> params = Maps.newHashMap();
+        params.put("limit", limit.toString());
+        params.put("clusterName", clusterName);
+        // Run query against /repair_run/cluster/
+        Response resp = runner.callReaper(
+            "GET",
+            "/repair_run",
+            Optional.of(params)
+        );
+        String responseData = resp.readEntity(String.class);
+        Assertions
+            .assertThat(resp.getStatus())
+            .isEqualTo(Response.Status.OK.getStatusCode())
+            .withFailMessage(responseData);
+        Assertions
+            .assertThat(responseData).isNotBlank();
+
+        List<RepairRunStatus> runs = SimpleReaperClient.parseRepairRunStatusListJSON(responseData);
+        Integer countInState = runs.stream()
+            .filter(run -> run.getState().toString().equals(expectedState))
+            .filter(run -> run.getClusterName().equals(clusterName))
+            .collect(Collectors.toList())
+            .size();
+        Assertions
+            .assertThat(countInState)
+            .isEqualTo(expectedRepairsCount)
+            .withFailMessage(
+                "actual number %d of repairs in state %s did not match expected number %d",
+                countInState,
+                expectedState,
+                expectedRepairsCount);
+      });
+      // Test with GET /repair_run/cluster/... next
+      RUNNERS.parallelStream().forEach(runner -> {
+        HashMap<String, String> params = Maps.newHashMap();
+        params.put("limit", limit.toString());
+        // Run query against /repair_run/cluster/
+        Response resp = runner.callReaper(
+            "GET",
+            "/repair_run/cluster/" + clusterName,
+            Optional.of(params)
+        );
+        String responseData = resp.readEntity(String.class);
+        Assertions
+            .assertThat(resp.getStatus())
+            .isEqualTo(Response.Status.OK.getStatusCode())
+            .withFailMessage(responseData);
+        Assertions
+            .assertThat(responseData).isNotBlank();
+
+        List<RepairRunStatus> runs = SimpleReaperClient.parseRepairRunStatusListJSON(responseData);
+        Integer countInState = runs.stream()
+            .filter(run -> run.getState().toString().equals(expectedState))
+            .filter(run -> run.getClusterName().equals(clusterName))
+            .collect(Collectors.toList())
+            .size();
+        Assertions
+            .assertThat(countInState)
+            .isEqualTo(expectedRepairsCount)
+            .withFailMessage(
+                "actual number %d of repairs in state %s did not match expected number %d",
+                countInState,
+                expectedState,
+                expectedRepairsCount);
+      });
+    }
+  }
+
+  @When("^we add a fake cluster named \"([^\"]*)\"$")
+  public void addFakeClusters(String clusterName) {
+    synchronized (BasicSteps.class) {
+      RUNNERS.parallelStream().forEach(
+          runner -> {
+            io.cassandrareaper.core.Cluster clusterToAdd = io.cassandrareaper.core.Cluster.builder()
+                .withName(clusterName)
+                .withSeedHosts(ImmutableSet.of("127.0.0.1"))
+                .withState(io.cassandrareaper.core.Cluster.State.ACTIVE)
+                .withPartitioner("Murmur3Partitioner")
+                .build();
+            runner.getContext().storage.addCluster(clusterToAdd);
+          }
+      );
     }
   }
 }

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -3012,7 +3012,7 @@ public final class BasicSteps {
       RUNNERS.parallelStream().forEach(runner -> {
         HashMap<String, String> params = Maps.newHashMap();
         params.put("limit", limit.toString());
-        params.put("clusterName", clusterName);
+        params.put("cluster_name", clusterName);
         // Run query against /repair_run/cluster/
         Response resp = runner.callReaper(
             "GET",

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -422,9 +422,19 @@ Feature: Using Reaper
     And reaper has no cluster in storage
     When an add-cluster request is made to reaper with authentication
     Then reaper has the last added cluster in storage
-    And I add 11 and abort the most recent 10 repairs for cluster "test" and keyspace "test_keyspace2"
-    Then when I list the last 10 repairs, I can see 1 repairs at "PAUSED" state
-    And when I list the last 10 repairs, I can see 9 repairs at "ABORTED" state
+    When we add a fake cluster named "fake1"
+    And we add a fake cluster named "fake2"
+    And I add 5 and abort the most recent 3 repairs for cluster "fake1" and keyspace "test_keyspace2"
+    And I add 25 and abort the most recent 24 repairs for cluster "fake2" and keyspace "test_keyspace2"
+    And I add 25 and abort the most recent 24 repairs for cluster "test" and keyspace "test_keyspace2"
+    When I list the last 10 repairs for cluster "test", I can see 1 repairs at "PAUSED" state
+    When I list the last 10 repairs for cluster "test", I can see 9 repairs at "ABORTED" state
+    When I list the last 10 repairs for cluster "fake1", I can see 2 repairs at "PAUSED" state
+    When I list the last 10 repairs for cluster "fake1", I can see 3 repairs at "ABORTED" state
+    When I list the last 10 repairs for cluster "fake2", I can see 1 repairs at "PAUSED" state
+    When I list the last 10 repairs for cluster "fake2", I can see 9 repairs at "ABORTED" state
+    When I list the last 10 repairs, I can see 4 repairs at "PAUSED" state
+    When I list the last 10 repairs, I can see 6 repairs at "ABORTED" state
     When the last added cluster is force deleted
     Then reaper has no longer the last added cluster in storage
   ${cucumber.upgrade-versions}

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -415,16 +415,16 @@ Feature: Using Reaper
     Then reaper has no longer the last added cluster in storage
   ${cucumber.upgrade-versions}
 
-@sidecar
+  @sidecar
+  @current_test
   Scenario Outline: Verify that ongoing repairs are prioritized over finished ones when listing the runs
     Given that reaper <version> is running
     And reaper has no cluster in storage
     When an add-cluster request is made to reaper with authentication
     Then reaper has the last added cluster in storage
-    And a new repair is added for "test" and keyspace "test_keyspace"
     And I add 11 and abort the most recent 10 repairs for cluster "test" and keyspace "test_keyspace2"
-    Then when I list the last 10 repairs, I can see 1 repairs at "NOT_STARTED" state
+    Then when I list the last 10 repairs, I can see 1 repairs at "PAUSED" state
     And when I list the last 10 repairs, I can see 9 repairs at "ABORTED" state
-    When the last added cluster is deleted
+    When the last added cluster is force deleted
     Then reaper has no longer the last added cluster in storage
   ${cucumber.upgrade-versions}

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality.feature
@@ -416,7 +416,6 @@ Feature: Using Reaper
   ${cucumber.upgrade-versions}
 
   @sidecar
-  @current_test
   Scenario Outline: Verify that ongoing repairs are prioritized over finished ones when listing the runs
     Given that reaper <version> is running
     And reaper has no cluster in storage

--- a/src/ui/app/jsx/repair-list.jsx
+++ b/src/ui/app/jsx/repair-list.jsx
@@ -335,7 +335,7 @@ const repairList = CreateReactClass({
 
   _handleTimer: function() {
       numberOfElementsToDisplay: 10,
-     this.props.repairRunSubject.onNext({ clusterName: this.state.currentCluster, limit: this.state.numberOfElementsToDisplay });
+     this.props.repairRunSubject.onNext({ cluster_name: this.state.currentCluster, limit: this.state.numberOfElementsToDisplay });
   },
 
   updateWindowDimensions: function() {


### PR DESCRIPTION
Fixes #1272

Several changes have been made to the `RepairRunResource.java` file, including updating the
`getRepairRunsForCluster` method to use `clusterName` instead of `cluster_name` as a path
parameter, updating the `listRepairRuns` method to use `clusterName` instead of `cluster_name`
as a query parameter. These changes fix bugs that have been existing for a while it seems, but were hidden by how repairs were listed by pure chronological order and client side filters applied in the UI.

In the RepairSegmentDao.java file, the `getSegmentAmountForRepairRun` method has
been updated to use `getRepairSegmentCountByRunIdPrepStmt` instead of
`getRepairSegmentCountByRunIdAndStatePrepStmt`, which was a bug.

A bug was fixed in the `RepairRunDao.getRepairRunsForClusterPrioritiseRunning()` method, which was not really applying a limit on the `flattenedUuids` list as  `subList()` returns a new list, it doesn't modify in place the list it's applied to. 

Additionally, this pull request includes updates to the acceptance tests to add fake
clusters and verify that ongoing repairs are prioritized over finished ones when listing them.
This checks that repair runs across multiple clusters are prioritized based on their state and that depending on the filters applied, we get the expected runs displayed.