### PR TITLE
Acceptance tests for HTTP management mechanism.

### DIFF
--- a/.github/scripts/configure-ccm.sh
+++ b/.github/scripts/configure-ccm.sh
@@ -67,7 +67,7 @@ case "${TEST_TYPE}" in
         echo "ERROR: Environment variable TEST_TYPE is unspecified."
         exit 1
         ;;
-    "ccm"|"upgrade"|"elassandra")
+    "ccm"|"upgrade"|"elassandra"|"http-api")
         mkdir -p ~/.local
         cp ./.github/files/jmxremote.password ~/.local/jmxremote.password
         chmod 400 ~/.local/jmxremote.password
@@ -116,5 +116,3 @@ case "${TEST_TYPE}" in
     *)
         echo "Skipping, no actions for TEST_TYPE=${TEST_TYPE}."
 esac
-
-

--- a/.github/scripts/configure-ccm.sh
+++ b/.github/scripts/configure-ccm.sh
@@ -71,7 +71,6 @@ case "${TEST_TYPE}" in
         mkdir -p ~/.local
         cp ./.github/files/jmxremote.password ~/.local/jmxremote.password
         chmod 400 ~/.local/jmxremote.password
-        ls -lrt /opt/hostedtoolcache/
         for jdk in /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/8*/; 
         do 
           sudo chmod 777 "${jdk/}"x64/jre/lib/management/jmxremote.access

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -29,6 +29,27 @@ function set_java_home() {
     done
 }
 
+add_management_api () {
+   if [[ ! -L /tmp/datastax-mgmtapi-agent.jar ]]; then
+     # Do some fancy pom.xml parsing to figure out which version of the Management API client we are using
+     MGMT_API_VERSION=`mvn dependency:tree -f src/server/pom.xml |grep datastax-mgmtapi-client-openapi|cut -d ":" -f 4`
+     # Download the Management API bundle
+     mvn dependency:copy -Dartifact=io.k8ssandra:datastax-mgmtapi-server:$MGMT_API_VERSION -f src/server/pom.xml -DoutputDirectory=/tmp -Dmdep.stripVersion=true -Dmdep.overWriteReleases=true
+     # Unzip the agent for the version of Cassandra
+     if [[ "$CASSANDRA_VERSION" == *"3.11"* ]]; then
+        mvn dependency:copy -Dartifact=io.k8ssandra:datastax-mgmtapi-agent-3.x:$MGMT_API_VERSION -f src/server/pom.xml -DoutputDirectory=/tmp -Dmdep.stripVersion=true -Dmdep.overWriteReleases=true
+        ln -s /tmp/datastax-mgmtapi-agent-3.x.jar /tmp/datastax-mgmtapi-agent.jar
+     elif [[ "$CASSANDRA_VERSION" == *"4.0"* ]]; then
+        mvn dependency:copy -Dartifact=io.k8ssandra:datastax-mgmtapi-agent-4.x:$MGMT_API_VERSION -f src/server/pom.xml -DoutputDirectory=/tmp -Dmdep.stripVersion=true -Dmdep.overWriteReleases=true
+        ln -s /tmp/datastax-mgmtapi-agent-4.x.jar /tmp/datastax-mgmtapi-agent.jar
+     elif [[ "$CASSANDRA_VERSION" == *"4.1"* ]]; then
+        mvn dependency:copy -Dartifact=io.k8ssandra:datastax-mgmtapi-agent-4.1.x:$MGMT_API_VERSION -f src/server/pom.xml -DoutputDirectory=/tmp -Dmdep.stripVersion=true -Dmdep.overWriteReleases=true
+        ln -s /tmp/datastax-mgmtapi-agent-4.1.x.jar /tmp/datastax-mgmtapi-agent.jar
+     fi
+   fi
+  echo "JVM_OPTS=\"\$JVM_OPTS -javaagent:/tmp/datastax-mgmtapi-agent.jar\"" >> ~/.ccm/test/node$1/conf/cassandra-env.sh
+}
+
 case "${TEST_TYPE}" in
     "")
         echo "ERROR: Environment variable TEST_TYPE is unspecified."
@@ -85,10 +106,34 @@ case "${TEST_TYPE}" in
             ps uax | grep cass
             # dependending on the version of cassandra, we may need to use a different jdk
             set_java_home ${JDK_VERSION}
+            # Add in  Management API agent jarfile
+            for i in `seq 1 2` ; do
+              add_management_api $i
+              mkdir -p /tmp/log/cassandra$i/ && touch /tmp/log/cassandra$i/stdout.log
+            done
             ccm start -v --no-wait --skip-wait-other-notice || true
             echo "${TEST_TYPE}" | grep -q ccm && sleep 30 || sleep 120
             ccm status
             ccm node1 nodetool -- -u cassandra -pw cassandrapassword status
+            # Stop CCM now so we can restart it with Management API
+            ccm stop
+            # Start Management API
+            MGMT_API_LOG_DIR=/tmp/log/cassandra1 bash -c 'nohup java -jar /tmp/datastax-mgmtapi-server.jar --db-socket=/tmp/db1.sock --host=unix:///tmp/mgmtapi1.sock --host=http://127.0.0.1:8080 --db-home=`dirname ~/.ccm/test/node1`/node1 &'
+            MGMT_API_LOG_DIR=/tmp/log/cassandra2 bash -c 'nohup java -jar /tmp/datastax-mgmtapi-server.jar --db-socket=/tmp/db2.sock --host=unix:///tmp/mgmtapi2.sock --host=http://127.0.0.2:8080 --db-home=`dirname ~/.ccm/test/node2`/node2 &'
+            # wait for Cassandra to be ready
+            for i in `seq 1 30` ; do
+                # keep curl from exiting with non-zero
+                HTTPCODE1=`curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8080/api/v0/probes/readiness` || true
+                HTTPCODE2=`curl -s -o /dev/null -w "%{http_code}" http://127.0.0.2:8080/api/v0/probes/readiness` || true
+                if [ "${HTTPCODE1}" != "200" -o "${HTTPCODE2}" != "200" ]
+                then
+                    echo "Cassandra not ready yet. Sleeping.... $i"
+                else
+                    echo "Cassandra started via Management API successfully"
+                    break
+                fi
+                sleep 5
+            done
             # Reaper requires JDK11 for compilation
             set_java_home 11
             case "${STORAGE_TYPE}" in

--- a/.github/workflows/check_pr_linked_issue.yaml
+++ b/.github/workflows/check_pr_linked_issue.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check linked issues
     steps:
-      - uses: nearform/github-action-check-linked-issues@v1
+      - uses: nearform-actions/github-action-check-linked-issues@v1
         continue-on-error: true
         id: check-linked-issues
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,6 +273,61 @@ jobs:
 
       - uses: codecov/codecov-action@v1
 
+  its-http-management:
+    needs: [ build ]
+    name: HTTP Management
+    runs-on: ubuntu-20.04
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        cassandra-version: [ 'binary:3.11.11', 'binary:4.0.1' ]
+        storage-type: [ local ]
+        test-type: [ "http-api" ]
+        grim-max: [ 1 ]
+        grim-min: [ 1 ]
+        # all versions but trunk have the same cucumber options, but we can't declare that more effectively (yet)
+        include:
+          - cassandra-version: 'binary:3.11.11'
+            cucumber-options: '--tags ~@cassandra_4_0_onwards --tags @http_management'
+            experimental: false
+            jdk-version: '8'
+          - cassandra-version: 'binary:4.0.1'
+            cucumber-options: '--tags @http_management'
+            experimental: false
+            jdk-version: '11'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Install CCM
+        run: |
+          pip install pyyaml
+          pip install ccm
+
+      - name: Setup CCM Cluster
+        run: ./.github/scripts/configure-ccm.sh
+        env:
+          TEST_TYPE: ${{ matrix.test-type }}
+          CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
+          STORAGE_TYPE: ${{ matrix.storage-type }}
+          JDK_VERSION: ${{ matrix.jdk-version }}
+
+      - name: Run Tests
+        run: ./.github/scripts/run-tests.sh || ./.github/scripts/run-tests.sh
+        env:
+          TEST_TYPE: ${{ matrix.test-type }}
+          CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
+          STORAGE_TYPE: ${{ matrix.storage-type }}
+          GRIM_MAX: ${{ matrix.grim-max }}
+          GRIM_MIN: ${{ matrix.grim-min }}
+          CUCUMBER_OPTIONS: ${{ matrix.cucumber-options }}
+          JDK_VERSION: ${{ matrix.jdk-version }}
+
+      - uses: codecov/codecov-action@v1
+
   its-each:
     needs: [docker-tests, its-ccm-local, its-ccm-cass]
     name: Each DC Availability
@@ -385,7 +440,6 @@ jobs:
           JDK_VERSION: ${{ matrix.jdk-version }}
 
       - uses: codecov/codecov-action@v1
-
 
   its-flapping:
     needs: [docker-tests, its-ccm-local, its-ccm-cass]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -316,7 +316,7 @@ jobs:
           JDK_VERSION: ${{ matrix.jdk-version }}
 
       - name: Run Tests
-        run: ./.github/scripts/run-tests.sh || ./.github/scripts/run-tests.sh
+        run: ./.github/scripts/run-tests.sh
         env:
           TEST_TYPE: ${{ matrix.test-type }}
           CASSANDRA_VERSION: ${{ matrix.cassandra-version }}

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -271,7 +271,12 @@
             <artifactId>jmxremote_optional-repackaged</artifactId>
             <version>5.0</version>
         </dependency>
-        <!--test scope -->
+        <dependency>
+            <groupId>io.k8ssandra</groupId>
+            <artifactId>datastax-mgmtapi-client-openapi</artifactId>
+            <version>0.1.0-507f418</version>
+        </dependency>
+<!--test scope -->
 
         <dependency>
             <groupId>junit</groupId>
@@ -773,6 +778,17 @@
             </releases>
             <snapshots>
             <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>thelastpickle-reaper-mvn</id>
+            <url>https://dl.cloudsmith.io/public/thelastpickle/reaper-mvn/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
     </repositories>

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -299,7 +299,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
   private void initializeManagement(AppContext context, Cryptograph cryptograph) {
     if (context.managementConnectionFactory == null) {
       LOG.info("no management connection factory given in context, creating default");
-      if (context.config.getHttpManagement() == null || !context.config.getHttpManagement().getEnabled()) {
+      if (context.config.getHttpManagement() == null || !context.config.getHttpManagement().isEnabled()) {
         LOG.info("HTTP management connection config not set, or set disabled. Creating JMX connection factory instead");
         context.managementConnectionFactory = new JmxManagementConnectionFactory(context, cryptograph);
       } else {

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -711,5 +711,6 @@ public final class ReaperApplicationConfiguration extends Configuration {
     public Boolean getEnabled() {
       return enabled;
     }
+    // TODO: Add ports and root paths here.
   }
 }

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -708,7 +708,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
     @JsonProperty
     private Boolean enabled = false;
 
-    public Boolean getEnabled() {
+    public Boolean isEnabled() {
       return enabled;
     }
     // TODO: Add ports and root paths here.

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/ReaperHttpIT.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/ReaperHttpIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.acceptance;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = {
+      "classpath:io.cassandrareaper.acceptance/integration_reaper_functionality_http.feature",
+    },
+    plugin = {"pretty"}
+    )
+public class ReaperHttpIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReaperHttpIT.class);
+  private static ReaperTestJettyRunner runner;
+  private static final String MEMORY_CONFIG_FILE = "cassandra-reaper-http-at.yaml";
+
+  protected ReaperHttpIT() {}
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    LOG.info(
+        "setting up testing Reaper runner with {} seed hosts defined, http management enabled and memory storage",
+        TestContext.TEST_CLUSTER_SEED_HOSTS.size());
+
+    runner = new ReaperTestJettyRunner(MEMORY_CONFIG_FILE);
+    BasicSteps.addReaperRunner(runner);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    LOG.info("Stopping reaper service...");
+    runner.runnerInstance.after();
+  }
+
+}

--- a/src/server/src/test/resources/cassandra-reaper-http-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-http-at.yaml
@@ -79,4 +79,4 @@ cryptograph:
   systemPropertySecret: REAPER_ENCRYPTION_KEY
 
 httpManagement:
-  isEnabled: true
+  enabled: true

--- a/src/server/src/test/resources/cassandra-reaper-http-at.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-http-at.yaml
@@ -1,0 +1,82 @@
+# Copyright 2014-2017 Spotify AB
+# Copyright 2016-2019 The Last Pickle Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Reaper for Apache Cassandra Configuration for Acceptance Tests.
+#
+segmentCountPerNode: 16
+repairParallelism: SEQUENTIAL
+repairIntensity: 0.95
+scheduleDaysBetween: 7
+repairRunThreadCount: 15
+hangingRepairTimeoutMins: 1
+storageType: memory
+incrementalRepair: false
+blacklistTwcsTables: true
+enableDynamicSeedList: false
+jmxConnectionTimeoutInSeconds: 10
+datacenterAvailability: LOCAL
+percentRepairedCheckIntervalMinutes: 1
+
+logging:
+  level: WARN
+  appenders:
+    - type: console
+
+server:
+  type: default
+  applicationConnectors:
+    - type: http
+      port: 8083
+      bindHost: 127.0.0.1
+  adminConnectors:
+    - type: http
+      port: 8084
+      bindHost: 127.0.0.1
+
+jmxPorts:
+  127.0.0.1: 7100
+  127.0.0.2: 7200
+  127.0.0.3: 7300
+  127.0.0.4: 7400
+  127.0.0.5: 7500
+  127.0.0.6: 7600
+  127.0.0.7: 7700
+  127.0.0.8: 7800
+
+jmxCredentials:
+  test:
+    username: cassandra
+    password: cassandrapassword
+
+# Config used to automatically add/remove sheduled repair for all keyspaces
+autoScheduling:
+  enabled: false
+  initialDelayPeriod: PT1M
+  periodBetweenPolls: PT10M
+  timeBeforeFirstSchedule: PT5M
+  scheduleSpreadPeriod: PT6H
+
+metrics:
+  frequency: 1 second
+  reporters:
+    - type: csv
+      file: target/dropwizard-metrics
+
+cryptograph:
+  type: symmetric
+  systemPropertySecret: REAPER_ENCRYPTION_KEY
+
+httpManagement:
+  isEnabled: true

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality_http.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality_http.feature
@@ -1,0 +1,432 @@
+# Copyright 2016-2017 Spotify AB
+# Copyright 2016-2019 The Last Pickle Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: Using Reaper
+
+  Background:
+    Given cluster seed host "127.0.0.1" points to cluster with name "test"
+    And cluster "test" has keyspace "booya" with tables "booya1, booya2"
+    And cluster "test" has keyspace "booya" with tables "booya_twcs"
+    And cluster "test" has keyspace "test_keyspace" with tables "test_table1, test_table2"
+    And cluster "test" has keyspace "test_keyspace2" with tables "test_table1, test_table2"
+    And cluster "test" has keyspace "test_keyspace3" with tables "test_table1, test_table2"
+
+@all_nodes_reachable
+  @cassandra_3_11_onwards
+  @snapshots
+  @http_management
+  Scenario Outline: Create a cluster, create a cluster wide snapshot and delete it
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    When a request is made to clear the existing snapshot cluster wide
+    And a cluster wide snapshot request is made to Reaper
+    Then there is 1 snapshot returned when listing snapshots
+    And a cluster wide snapshot request is made to Reaper for keyspace "booya"
+    And a cluster wide snapshot request fails for keyspace "nonexistent"
+    Then there is 2 snapshot returned when listing snapshots cluster wide
+    And I fail listing cluster wide snapshots for cluster "fake"
+    When a request is made to clear the existing snapshot cluster wide
+    Then there is 0 snapshot returned when listing snapshots
+    When the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @all_nodes_reachable
+  @cassandra_3_11_onwards
+  @snapshots
+  @http_management
+  Scenario Outline: Create a cluster, create a snapshot on a single host and delete it
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    When a request is made to clear the seed host existing snapshots
+    And a snapshot request for the seed host is made to Reaper
+    Then there is 1 snapshot returned when listing snapshots
+    And a snapshot request for the seed host and keyspace "booya" is made to Reaper
+    And a snapshot request for the seed host and keyspace "fake" fails
+    Then there is 2 snapshot returned when listing snapshots
+    And I fail listing snapshots for cluster "fake" and host "127.0.0.1"
+    And I fail listing snapshots for cluster "test" and host "fakenode"
+    When a request is made to clear the seed host existing snapshots
+    Then there is 0 snapshot returned when listing snapshots
+    When the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @http_management
+  @cassandra_3_11_onwards
+  Scenario Outline: Force deleting a cluster
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new daily "full" repair schedule is added for "test" and keyspace "test_keyspace"
+    Then reaper has a cluster called "test" in storage
+    And reaper has 1 scheduled repairs for cluster called "test"
+    Then reaper has a cluster called "test" in storage
+    And reaper has 1 scheduled repairs for cluster called "test"
+    When deleting cluster called "test" fails
+    Then reaper has a cluster called "test" in storage
+    And reaper has 1 scheduled repairs for cluster called "test"
+    When the last added cluster is force deleted
+    And reaper has 0 scheduled repairs for cluster called "test"
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Create a cluster and a scheduled repair run and delete them
+    Given that reaper <version> is running
+    And cluster seed host "127.0.0.2" points to cluster with name "test"
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And the seed node has vnodes
+    And reaper has 0 scheduled repairs for the last added cluster
+    And we can collect the tpstats from a seed node
+    And we can collect the dropped messages stats from a seed node
+    And we can collect the client request metrics from a seed node
+    When a new daily "full" repair schedule is added for the last added cluster and keyspace "booya"
+    Then reaper has 1 scheduled repairs for the last added cluster
+    Then reaper has 1 scheduled repairs for the last added cluster
+    And deleting cluster called "test" fails
+    When the last added schedule is deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @http_management
+  @cassandra_3_11_onwards
+  Scenario Outline: Registering multiple scheduled repairs
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new daily "full" repair schedule is added for "test" and keyspace "test_keyspace"
+    Then reaper has a cluster called "test" in storage
+    And reaper has 1 scheduled repairs for cluster called "test"
+    When a new daily "full" repair schedule is added for "test" and keyspace "test_keyspace2"
+    And a second daily repair schedule is added for "test" and keyspace "test_keyspace3"
+    Then reaper has a cluster called "test" in storage
+    And reaper has 3 scheduled repairs for cluster called "test"
+    And reaper has 3 scheduled repairs for cluster called "test"
+    When the last added schedule is deleted for cluster called "test"
+    Then reaper has 2 scheduled repairs for cluster called "test"
+    When a new daily "full" repair schedule is added that already exists for "test" and keyspace "test_keyspace2"
+    Then reaper has 2 scheduled repairs for cluster called "test"
+    And deleting cluster called "test" fails
+    When all added schedules are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @all_nodes_reachable
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Adding a scheduled full repair and a scheduled incremental repair for the same keyspace
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new daily "incremental" repair schedule is added for "test" and keyspace "test_keyspace3"
+    And a new daily "full" repair schedule is added that already exists for "test" and keyspace "test_keyspace3"
+    Then reaper has 1 scheduled repairs for cluster called "test"
+    Then reaper has 1 scheduled repairs for cluster called "test"
+    And deleting cluster called "test" fails
+    When all added schedules are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @all_nodes_reachable
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Adding a scheduled full repair and a scheduled incremental repair for the same keyspace with force option
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new daily "incremental" repair schedule is added for "test" and keyspace "test_keyspace3"
+    And a new daily "full" repair schedule fails to be added that already exists for "test" and keyspace "test_keyspace3"
+    And a new daily "full" repair schedule is added that already exists for "test" and keyspace "test_keyspace3" with force option
+    Then reaper has 2 scheduled repairs for cluster called "test"
+    Then reaper has 2 scheduled repairs for cluster called "test"
+    And deleting cluster called "test" fails
+    When all added schedules are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @all_nodes_reachable
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Add a scheduled incremental repair and collect percent repaired metrics
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new daily "incremental" repair schedule is added for "test" and keyspace "test_keyspace3"
+    Then reaper has 1 scheduled repairs for cluster called "test"
+    Then reaper has 1 scheduled repairs for cluster called "test"
+    And percent repaired metrics get collected for the existing schedule
+    And deleting cluster called "test" fails
+    When all added schedules are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Create a cluster and a scheduled repair run with repair run history and delete them
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for the last added cluster
+    When a new daily repair schedule is added for the last added cluster and keyspace "booya" with next repair immediately
+    Then reaper has 1 scheduled repairs for the last added cluster
+    And deleting cluster called "test" fails
+    When we wait for a scheduled repair run has started for cluster "test"
+    And we wait for at least 1 segments to be repaired
+    Then reaper has 1 started or done repairs for the last added cluster
+    When the last added repair is stopped
+    Then reseting one segment sets its state to not started
+    And all added repair runs are deleted for the last added cluster
+    And deleting cluster called "test" fails
+    When all added schedules are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Create a cluster and a repair run and delete them
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 repairs for the last added cluster
+    When a new repair is added for the last added cluster and keyspace "booya" with the table "booya2" blacklisted
+    And the last added repair has table "booya2" in the blacklist
+    And the last added repair has twcs table "booya_twcs" in the blacklist
+    And the last added repair has table "booya2" in the blacklist
+    And deleting cluster called "test" fails
+    And the last added repair is activated
+    And we wait for at least 1 segments to be repaired
+    Then reaper has 1 started or done repairs for the last added cluster
+    When the last added repair is stopped
+    And all added repair runs are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @cassandra_3_11_onwards
+  @http_management
+  # this has a problem in the upgrade integration tests, ref: 88d4d5c
+  Scenario Outline: Create a cluster and a repair run with auto twcs blacklist and delete them
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 repairs for the last added cluster
+    When a new repair is added for the last added cluster and keyspace "booya"
+    And the last added repair has twcs table "booya_twcs" in the blacklist
+    And the last added repair has twcs table "booya_twcs" in the blacklist
+    And deleting cluster called "test" fails
+    And the last added repair is activated
+    And we wait for at least 1 segments to be repaired
+    Then reaper has 1 started or done repairs for the last added cluster
+    When the last added repair is stopped
+    And all added repair runs are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+ ${cucumber.upgrade-versions}
+
+  @sidecar
+  @all_nodes_reachable
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Create a cluster and an incremental repair run and delete them
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 repairs for the last added cluster
+    When a new incremental repair is added for the last added cluster and keyspace "booya"
+    And deleting cluster called "test" fails
+    And the last added repair is activated
+    And we wait for at least 1 segments to be repaired
+    Then reaper has 1 started or done repairs for the last added cluster
+    Then reaper has 1 started or done repairs for the last added cluster
+    When the last added repair is stopped
+    When a new repair is added for the last added cluster and keyspace "booya" with force option
+    And the last added repair is activated
+    And we wait for at least 1 segments to be repaired
+    Then reaper has 2 repairs for cluster called "test"
+    When the last added repair is stopped
+    And all added repair runs are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @all_nodes_reachable
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Create a cluster and one incremental repair run and one full repair run
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    When a new incremental repair is added for "test" and keyspace "test_keyspace"
+    And the last added repair is activated
+    And a new repair is added for "test" and keyspace "test_keyspace2"
+    And the last added repair is activated
+    Then reaper has 2 repairs for cluster called "test"
+    Then reaper has 2 started or done repairs for the last added cluster
+    Then reaper has 2 started or done repairs for the last added cluster
+    And we wait for at least 1 segments to be repaired
+    And modifying the run state of the last added repair to "PAUSED" succeeds
+    And modifying the run state of the last added repair to "RUNNING" succeeds
+    And I can purge repair runs
+    When all added repair runs are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @all_nodes_reachable
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Test resources failure paths
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And reaper has 0 scheduled repairs for cluster called "test"
+    And a new repair fails to be added for keyspace "test_keyspace" and "tables" "nonexistent_table"
+    And a new repair fails to be added for keyspace "test_keyspace" and "blacklistedTables" "nonexistent_table"
+    And a new repair fails to be added for keyspace "test_keyspace" and "nodes" "nonexistent_node"
+    And a new repair fails to be added for keyspace "test_keyspace" and "segmentCountPerNode" "2000"
+    And a new repair fails to be added for keyspace "test_keyspace" and "repairParallelism" "whatever"
+    And a new repair fails to be added for keyspace "test_keyspace" including both node and datacenter lists
+    And a new repair fails to be added for keyspace "test_keyspace" including both tables and blacklisted tables lists
+    And a new repair fails to be added for keyspace "test_keyspace" without the "clusterName" param
+    And a new repair fails to be added for keyspace "test_keyspace" without the "owner" param
+    And a new repair fails to be added for keyspace "test_keyspace" without the "keyspace" param
+    And a new daily repair schedule fails being added with "2000-01-01T00:00:00" activation time
+    And a new daily repair schedule fails being added with "200-1-01T00-0-000" activation time
+    And a new daily repair schedule fails being added without "clusterName"
+    And a new daily repair schedule fails being added without "keyspace"
+    And a new daily repair schedule fails being added without "owner"
+    And a new daily repair schedule fails being added without "scheduleDaysBetween"
+    And a new daily repair schedule fails being added with "clusterName" "nonexistent_cluster"
+    And a new daily repair schedule fails being added with "tables" "nonexistent_table"
+    And a new daily repair schedule fails being added with "blacklistedTables" "nonexistent_table"
+    And a new daily repair schedule fails being added with "nodes" "nonexistent_node"
+    And a new daily repair schedule fails being added with "segmentCountPerNode" "2000"
+    And a new daily repair schedule fails being added with "repairParallelism" "whatever"
+    And a new daily repair schedule fails being added with "incrementalRepair" "True"
+    And a new daily repair schedule fails being added with "percentUnrepairedThreshold" "10"
+    And getting repair run "whatever" fails
+    And aborting a segment from a non existent repair fails
+    When a new incremental repair is added for the last added cluster and keyspace "booya"
+    Then aborting a segment on the last added repair fails
+    And the last added repair fails to be deleted
+    When the last added repair is activated
+    And the last added repair fails to be deleted
+    And modifying the run state of the last added repair to "WHATEVER" fails
+    And we wait for at least 1 segments to be repaired
+    And the last added repair is stopped
+    And the last added repair fails to be deleted with owner ""
+    And the last added repair fails to be deleted with owner "whatever"
+    And all added repair runs are deleted for the last added cluster
+    And the last added cluster is deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @all_nodes_reachable
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Exhaustive testing on schedules
+    Given that reaper <version> is running
+    And cluster seed host "127.0.0.2" points to cluster with name "test"
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper
+    Then reaper has the last added cluster in storage
+    And the seed node has vnodes
+    And reaper has 0 scheduled repairs for the last added cluster
+    When a new daily "full" repair schedule is added for the last added cluster and keyspace "booya"
+    Then reaper has 1 scheduled repairs for cluster "test" and keyspace "booya"
+    Then reaper has 1 scheduled repairs for cluster "" and keyspace "booya"
+    Then reaper has 1 scheduled repairs for cluster "test" and keyspace ""
+    Then reaper has 1 scheduled repairs for cluster "" and keyspace ""
+    And I can set the last added schedule state to "ACTIVE"
+    And the last added schedule fails being deleted for the last added cluster
+    And I can set the last added schedule state to "PAUSED"
+    And I can set the last added schedule state to "ACTIVE"
+    And I cannot set the last added schedule state to "UNKNOWN"
+    And I cannot set the last added schedule state to "DELETED"
+    And I cannot set an unknown schedule state to "ACTIVE"
+    And deleting cluster called "test" fails
+    And the last added schedule fails being deleted for the last added cluster with owner ""
+    And the last added schedule fails being deleted for the last added cluster with owner "fake"
+    And I can start the last added schedule
+    And I cannot start an unknown schedule
+    When the last added cluster is force deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
+
+  @sidecar
+  @cassandra_3_11_onwards
+  @http_management
+  Scenario Outline: Verify that ongoing repairs are prioritized over finished ones when listing the runs
+    Given that reaper <version> is running
+    And reaper has no cluster in storage
+    When an add-cluster request is made to reaper with authentication
+    Then reaper has the last added cluster in storage
+    When we add a fake cluster named "fake1"
+    And we add a fake cluster named "fake2"
+    And I add 5 and abort the most recent 3 repairs for cluster "fake1" and keyspace "test_keyspace2"
+    And I add 25 and abort the most recent 24 repairs for cluster "fake2" and keyspace "test_keyspace2"
+    And I add 25 and abort the most recent 24 repairs for cluster "test" and keyspace "test_keyspace2"
+    When I list the last 10 repairs for cluster "test", I can see 1 repairs at "PAUSED" state
+    When I list the last 10 repairs for cluster "test", I can see 9 repairs at "ABORTED" state
+    When I list the last 10 repairs for cluster "fake1", I can see 2 repairs at "PAUSED" state
+    When I list the last 10 repairs for cluster "fake1", I can see 3 repairs at "ABORTED" state
+    When I list the last 10 repairs for cluster "fake2", I can see 1 repairs at "PAUSED" state
+    When I list the last 10 repairs for cluster "fake2", I can see 9 repairs at "ABORTED" state
+    When I list the last 10 repairs, I can see 4 repairs at "PAUSED" state
+    When I list the last 10 repairs, I can see 6 repairs at "ABORTED" state
+    When the last added cluster is force deleted
+    Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality_http.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality_http.feature
@@ -23,7 +23,7 @@ Feature: Using Reaper
     And cluster "test" has keyspace "test_keyspace2" with tables "test_table1, test_table2"
     And cluster "test" has keyspace "test_keyspace3" with tables "test_table1, test_table2"
 
-@all_nodes_reachable
+  @all_nodes_reachable
   @cassandra_3_11_onwards
   @snapshots
   @http_management
@@ -43,7 +43,7 @@ Feature: Using Reaper
     Then there is 0 snapshot returned when listing snapshots
     When the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @all_nodes_reachable
   @cassandra_3_11_onwards
@@ -66,7 +66,7 @@ Feature: Using Reaper
     Then there is 0 snapshot returned when listing snapshots
     When the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @http_management
@@ -88,7 +88,7 @@ Feature: Using Reaper
     When the last added cluster is force deleted
     And reaper has 0 scheduled repairs for cluster called "test"
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @cassandra_3_11_onwards
@@ -111,7 +111,7 @@ Feature: Using Reaper
     When the last added schedule is deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @http_management
@@ -138,7 +138,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @all_nodes_reachable
@@ -158,7 +158,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @all_nodes_reachable
@@ -179,7 +179,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @all_nodes_reachable
@@ -199,7 +199,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @cassandra_3_11_onwards
@@ -223,7 +223,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @cassandra_3_11_onwards
@@ -246,11 +246,10 @@ Feature: Using Reaper
     And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
 
+  # this has a problem in the upgrade integration tests, ref: 88d4d5c
   @cassandra_3_11_onwards
   @http_management
-  # this has a problem in the upgrade integration tests, ref: 88d4d5c
   Scenario Outline: Create a cluster and a repair run with auto twcs blacklist and delete them
     Given that reaper <version> is running
     And reaper has no cluster in storage
@@ -268,7 +267,6 @@ Feature: Using Reaper
     And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
- ${cucumber.upgrade-versions}
 
   @sidecar
   @all_nodes_reachable
@@ -295,7 +293,7 @@ Feature: Using Reaper
     And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @all_nodes_reachable
@@ -321,7 +319,7 @@ Feature: Using Reaper
     When all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @all_nodes_reachable
   @cassandra_3_11_onwards
@@ -371,7 +369,7 @@ Feature: Using Reaper
     And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @all_nodes_reachable
@@ -404,7 +402,7 @@ Feature: Using Reaper
     And I cannot start an unknown schedule
     When the last added cluster is force deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}
+
 
   @sidecar
   @cassandra_3_11_onwards
@@ -429,4 +427,3 @@ Feature: Using Reaper
     When I list the last 10 repairs, I can see 6 repairs at "ABORTED" state
     When the last added cluster is force deleted
     Then reaper has no longer the last added cluster in storage
-  ${cucumber.upgrade-versions}

--- a/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality_http.feature
+++ b/src/server/src/test/resources/io.cassandrareaper.acceptance/integration_reaper_functionality_http.feature
@@ -43,7 +43,7 @@ Feature: Using Reaper
     Then there is 0 snapshot returned when listing snapshots
     When the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @all_nodes_reachable
   @cassandra_3_11_onwards
@@ -66,7 +66,7 @@ Feature: Using Reaper
     Then there is 0 snapshot returned when listing snapshots
     When the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @http_management
@@ -88,7 +88,7 @@ Feature: Using Reaper
     When the last added cluster is force deleted
     And reaper has 0 scheduled repairs for cluster called "test"
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @cassandra_3_11_onwards
@@ -111,7 +111,7 @@ Feature: Using Reaper
     When the last added schedule is deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @http_management
@@ -138,7 +138,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @all_nodes_reachable
@@ -158,7 +158,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @all_nodes_reachable
@@ -179,7 +179,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @all_nodes_reachable
@@ -199,7 +199,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @cassandra_3_11_onwards
@@ -223,7 +223,7 @@ Feature: Using Reaper
     When all added schedules are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @cassandra_3_11_onwards
@@ -246,6 +246,7 @@ Feature: Using Reaper
     And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
 
   # this has a problem in the upgrade integration tests, ref: 88d4d5c
   @cassandra_3_11_onwards
@@ -267,6 +268,7 @@ Feature: Using Reaper
     And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @all_nodes_reachable
@@ -293,7 +295,7 @@ Feature: Using Reaper
     And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @all_nodes_reachable
@@ -319,7 +321,7 @@ Feature: Using Reaper
     When all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @all_nodes_reachable
   @cassandra_3_11_onwards
@@ -369,7 +371,7 @@ Feature: Using Reaper
     And all added repair runs are deleted for the last added cluster
     And the last added cluster is deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @all_nodes_reachable
@@ -402,7 +404,7 @@ Feature: Using Reaper
     And I cannot start an unknown schedule
     When the last added cluster is force deleted
     Then reaper has no longer the last added cluster in storage
-
+  ${cucumber.upgrade-versions}
 
   @sidecar
   @cassandra_3_11_onwards
@@ -427,3 +429,4 @@ Feature: Using Reaper
     When I list the last 10 repairs, I can see 6 repairs at "ABORTED" state
     When the last added cluster is force deleted
     Then reaper has no longer the last added cluster in storage
+  ${cucumber.upgrade-versions}


### PR DESCRIPTION
The new HTTP management mechanism that relies on management API to replace JMX needs tests to ensure that all functionality still works. 

I have used the ReaperIT class as a base and replicated all tests there, these are expected to fail right now because CCM doesn't spin up Cassandra with the management API included. We will need to add this before merging.

**Solves issue**
https://github.com/thelastpickle/cassandra-reaper/issues/1347