### PR TITLE
Remove JMX specific interfaces from ICassandraManagementProxy

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -233,7 +233,7 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
 
     HttpClient httpClient = createHttpClient(config, environment);
 
-    if (context.managementConnectionFactory instanceof JmxManagementConnectionFactory) {
+    if (config.getHttpManagement() == null || !config.getHttpManagement().getEnabled()) {
       ScheduledExecutorService ses = environment.lifecycle().scheduledExecutorService("Diagnostics").threads(6).build();
       final DiagEventSubscriptionResource eventsResource = new DiagEventSubscriptionResource(context, httpClient, ses,
           context.storage.getEventsDao());

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplication.java
@@ -232,13 +232,16 @@ public final class ReaperApplication extends Application<ReaperApplicationConfig
     environment.jersey().register(addCryptoResource);
 
     HttpClient httpClient = createHttpClient(config, environment);
-    ScheduledExecutorService ses = environment.lifecycle().scheduledExecutorService("Diagnostics").threads(6).build();
-    final DiagEventSubscriptionResource eventsResource = new DiagEventSubscriptionResource(context, httpClient, ses,
-        context.storage.getEventsDao());
-    environment.jersey().register(eventsResource);
-    final DiagEventSseResource diagEvents = new DiagEventSseResource(context, httpClient, ses,
-        context.storage.getEventsDao());
-    environment.jersey().register(diagEvents);
+
+    if (context.managementConnectionFactory instanceof JmxManagementConnectionFactory) {
+      ScheduledExecutorService ses = environment.lifecycle().scheduledExecutorService("Diagnostics").threads(6).build();
+      final DiagEventSubscriptionResource eventsResource = new DiagEventSubscriptionResource(context, httpClient, ses,
+          context.storage.getEventsDao());
+      environment.jersey().register(eventsResource);
+      final DiagEventSseResource diagEvents = new DiagEventSseResource(context, httpClient, ses,
+          context.storage.getEventsDao());
+      environment.jersey().register(diagEvents);
+    }
 
     if (config.isAccessControlEnabled()) {
       SessionHandler sessionHandler = new SessionHandler();

--- a/src/server/src/main/java/io/cassandrareaper/management/DiagnosticProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/DiagnosticProxy.java
@@ -17,6 +17,7 @@
 
 package io.cassandrareaper.management;
 
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.service.DiagEventSubscriptionService;
 
 import java.io.IOException;
@@ -35,13 +36,13 @@ public final class DiagnosticProxy {
 
   private static final Logger LOG = LoggerFactory.getLogger(DiagEventSubscriptionService.class);
 
-  private final ICassandraManagementProxy proxy;
+  private final JmxCassandraManagementProxy proxy;
 
-  private DiagnosticProxy(ICassandraManagementProxy proxy) {
+  private DiagnosticProxy(JmxCassandraManagementProxy proxy) {
     this.proxy = proxy;
   }
 
-  public static DiagnosticProxy create(ICassandraManagementProxy proxy) {
+  public static DiagnosticProxy create(JmxCassandraManagementProxy proxy) {
 
     return new DiagnosticProxy(proxy);
   }

--- a/src/server/src/main/java/io/cassandrareaper/management/DiagnosticProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/DiagnosticProxy.java
@@ -43,7 +43,6 @@ public final class DiagnosticProxy {
   }
 
   public static DiagnosticProxy create(JmxCassandraManagementProxy proxy) {
-
     return new DiagnosticProxy(proxy);
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
@@ -32,17 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ExecutionException;
-import javax.management.AttributeList;
-import javax.management.InstanceNotFoundException;
-import javax.management.IntrospectionException;
 import javax.management.JMException;
-import javax.management.ListenerNotFoundException;
-import javax.management.MBeanInfo;
-import javax.management.NotificationFilter;
-import javax.management.NotificationListener;
-import javax.management.ObjectName;
-import javax.management.QueryExp;
-import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 import javax.validation.constraints.NotNull;
@@ -51,7 +41,7 @@ import com.datastax.driver.core.VersionNumber;
 import org.apache.cassandra.repair.RepairParallelism;
 
 
-public interface ICassandraManagementProxy extends NotificationListener {
+public interface ICassandraManagementProxy {
 
   Duration DEFAULT_JMX_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
 
@@ -102,8 +92,6 @@ public interface ICassandraManagementProxy extends NotificationListener {
    * @return list of tokens in the cluster
    */
   List<BigInteger> getTokens();
-
-  boolean isConnectionAlive();
 
   /**
    * @return true if any repairs are running on the node.
@@ -157,19 +145,6 @@ public interface ICassandraManagementProxy extends NotificationListener {
   void forceKeyspaceCompaction(boolean var1, String var2, String... var3) throws IOException, ExecutionException,
       InterruptedException;
 
-
-  // From MBeanServerConnection
-  Set<ObjectName> queryNames(ObjectName name, QueryExp query)
-      throws IOException;
-
-  MBeanInfo getMBeanInfo(ObjectName name)
-      throws InstanceNotFoundException, IntrospectionException,
-      ReflectionException, IOException;
-
-  AttributeList getAttributes(ObjectName name, String[] attributes)
-      throws InstanceNotFoundException, ReflectionException,
-      IOException;
-
   // From CompactionManagerMBean
 
   List<Map<String, String>> getCompactions();
@@ -194,16 +169,6 @@ public interface ICassandraManagementProxy extends NotificationListener {
 
   // From StreamManagerMBean
   Set<CompositeData> getCurrentStreams();
-
-
-  void addConnectionNotificationListener(NotificationListener listener);
-
-  void removeConnectionNotificationListener(NotificationListener listener) throws ListenerNotFoundException;
-
-  void addNotificationListener(NotificationListener listener, NotificationFilter filter)
-      throws IOException, JMException;
-
-  void removeNotificationListener(NotificationListener listener) throws IOException, JMException;
 
   /**
    * Compares two Cassandra versions using classes provided by the Datastax Java Driver.

--- a/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
@@ -22,7 +22,6 @@ import io.cassandrareaper.core.Table;
 import io.cassandrareaper.service.RingRange;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.time.Duration;
@@ -30,7 +29,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.concurrent.ExecutionException;
 import javax.management.JMException;
 import javax.management.openmbean.CompositeData;
@@ -156,16 +154,6 @@ public interface ICassandraManagementProxy {
 
   // From EndpointSnitchInfoMBean
   String getDatacenter(String var1) throws UnknownHostException;
-
-  // from DiagnosticEventPersistenceMBean
-  SortedMap<Long, Map<String, Serializable>> readEvents(String eventClass, Long lastKey, int limit);
-
-  void enableEventPersistence(String eventClass);
-
-  void disableEventPersistence(String eventClass);
-
-  // From LastEventIdBroadcasterMBean
-  Map<String, Comparable> getLastEventIdsIfModified(long lastUpdate);
 
   // From StreamManagerMBean
   Set<CompositeData> getCurrentStreams();

--- a/src/server/src/main/java/io/cassandrareaper/management/IManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/IManagementConnectionFactory.java
@@ -17,15 +17,9 @@
 
 package io.cassandrareaper.management;
 
-import io.cassandrareaper.ReaperException;
-import io.cassandrareaper.core.Node;
-
-import java.util.Collection;
 import java.util.Set;
 
 public interface IManagementConnectionFactory {
-  ICassandraManagementProxy connectAny(Collection<Node> nodes) throws ReaperException;
-
   //  void setAddressTranslator(AddressTranslator addressTranslator); // TODO: May not be needed for GA
   Set<String> getAccessibleDatacenters();
 

--- a/src/server/src/main/java/io/cassandrareaper/management/IManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/IManagementConnectionFactory.java
@@ -17,10 +17,15 @@
 
 package io.cassandrareaper.management;
 
+import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.Node;
+
+import java.util.Collection;
 import java.util.Set;
 
 public interface IManagementConnectionFactory {
-  //  void setAddressTranslator(AddressTranslator addressTranslator); // TODO: May not be needed for GA
+  ICassandraManagementProxy connectAny(Collection<Node> nodes) throws ReaperException;
+
   Set<String> getAccessibleDatacenters();
 
   HostConnectionCounters getHostConnectionCounters();

--- a/src/server/src/main/java/io/cassandrareaper/management/JmxMetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/JmxMetricsProxy.java
@@ -17,7 +17,6 @@
 
 package io.cassandrareaper.management;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.cassandrareaper.core.DroppedMessages;
 import io.cassandrareaper.core.GenericMetric;
 import io.cassandrareaper.core.JmxStat;
@@ -38,6 +37,7 @@ import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.ObjectName;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.joda.time.DateTime;

--- a/src/server/src/main/java/io/cassandrareaper/management/JmxMetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/JmxMetricsProxy.java
@@ -17,6 +17,7 @@
 
 package io.cassandrareaper.management;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.cassandrareaper.core.DroppedMessages;
 import io.cassandrareaper.core.GenericMetric;
 import io.cassandrareaper.core.JmxStat;
@@ -144,7 +145,8 @@ public final class JmxMetricsProxy {
     }
   }
 
-  private List<GenericMetric> convertToGenericMetrics(Map<String, List<JmxStat>> jmxStats, Node node) {
+  @VisibleForTesting
+  public static List<GenericMetric> convertToGenericMetrics(Map<String, List<JmxStat>> jmxStats, Node node) {
     List<GenericMetric> metrics = Lists.newArrayList();
     DateTime now = DateTime.now();
     for (Entry<String, List<JmxStat>> jmxStatEntry : jmxStats.entrySet()) {

--- a/src/server/src/main/java/io/cassandrareaper/management/MetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/MetricsProxy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020-2020 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.management;
+
+import io.cassandrareaper.core.GenericMetric;
+import io.cassandrareaper.core.Node;
+import io.cassandrareaper.management.http.HttpCassandraManagementProxy;
+import io.cassandrareaper.management.http.HttpMetricsProxy;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxMetricsProxy;
+
+import java.io.IOException;
+import java.util.List;
+import javax.management.JMException;
+
+public interface MetricsProxy {
+
+  static MetricsProxy create(ICassandraManagementProxy proxy) {
+    if (proxy == null) {
+      throw new RuntimeException("ICassandraManagementProxy is null");
+    }
+    if (proxy instanceof JmxCassandraManagementProxy) {
+      return JmxMetricsProxy.create((JmxCassandraManagementProxy) proxy);
+    } else if (proxy instanceof HttpCassandraManagementProxy) {
+      return HttpMetricsProxy.create((HttpCassandraManagementProxy) proxy);
+    }
+    throw new UnsupportedOperationException("Unknown ICassandraManagementProxy implementation");
+  }
+
+  List<GenericMetric> collectTpStats(Node node) throws JMException, IOException;
+
+  List<GenericMetric> collectDroppedMessages(Node node) throws JMException, IOException;
+
+  List<GenericMetric> collectLatencyMetrics(Node node) throws JMException, IOException;
+
+  List<GenericMetric> collectGenericMetrics(Node node) throws JMException, IOException;
+
+  List<GenericMetric> collectPercentRepairedMetrics(Node node, String keyspaceName)
+      throws JMException, IOException;
+}

--- a/src/server/src/main/java/io/cassandrareaper/management/MetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/MetricsProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 The Last Pickle Ltd
+ * Copyright 2023-2023 DataStax, Inc.
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -24,7 +24,6 @@ import io.cassandrareaper.management.RepairStatusHandler;
 import io.cassandrareaper.service.RingRange;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -35,8 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import javax.management.JMException;
 import javax.management.openmbean.CompositeData;
@@ -219,25 +216,6 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   public String getDatacenter(String var1) throws UnknownHostException {
     // TODO: implement me.
     return "";
-  }
-
-  // from DiagnosticEventPersistenceMBean
-  public SortedMap<Long, Map<String, Serializable>> readEvents(String eventClass, Long lastKey, int limit) {
-    //TODO: implement me
-    return new TreeMap<>();
-  }
-
-  public void enableEventPersistence(String eventClass) {
-    //TODO: implement me
-  }
-
-  public void disableEventPersistence(String eventClass) {
-    //TODO: implement me
-  }
-
-  // From LastEventIdBroadcasterMBean
-  public Map<String, Comparable> getLastEventIdsIfModified(long lastUpdate) {
-    return new HashMap<String, Comparable>();
   }
 
   // From StreamManagerMBean

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -38,18 +38,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
-import javax.management.AttributeList;
-import javax.management.InstanceNotFoundException;
-import javax.management.IntrospectionException;
 import javax.management.JMException;
-import javax.management.ListenerNotFoundException;
-import javax.management.MBeanInfo;
-import javax.management.Notification;
-import javax.management.NotificationFilter;
-import javax.management.NotificationListener;
-import javax.management.ObjectName;
-import javax.management.QueryExp;
-import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 import javax.validation.constraints.NotNull;
@@ -168,16 +157,6 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   }
 
   @Override
-  public void handleNotification(final Notification notification, Object handback) {
-    // TODO: implement me.
-  }
-
-  @Override
-  public boolean isConnectionAlive() {
-    return true; // TODO: implement me.
-  }
-
-  @Override
   public void removeRepairStatusHandler(int repairNo) {
     // TODO: implement me.
   }
@@ -219,29 +198,6 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       ExecutionException, InterruptedException {
     // TODO: implement me.
   }
-
-
-  // From MBeanServerConnection
-  public Set<ObjectName> queryNames(ObjectName name, QueryExp query)
-      throws IOException {
-    // TODO: implement me.
-    return new HashSet<ObjectName>();
-  }
-
-  public MBeanInfo getMBeanInfo(ObjectName name)
-      throws InstanceNotFoundException, IntrospectionException,
-      ReflectionException, IOException {
-    // TODO: implement me.
-    return new MBeanInfo("", "", null, null, null, null);
-  }
-
-  public AttributeList getAttributes(ObjectName name, String[] attributes)
-      throws InstanceNotFoundException, ReflectionException,
-      IOException {
-    // TODO: implement me.
-    return new AttributeList();
-  }
-
 
   // From CompactionManagerMBean
   public List<Map<String, String>> getCompactions() {
@@ -287,22 +243,6 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   // From StreamManagerMBean
   public Set<CompositeData> getCurrentStreams() {
     return new HashSet<CompositeData>();
-  }
-
-  public void addConnectionNotificationListener(NotificationListener listener) {
-    // TODO - implement me.
-  }
-
-  public void removeConnectionNotificationListener(NotificationListener listener) throws ListenerNotFoundException {
-    // TODO - implement me.
-  }
-
-  public void addNotificationListener(NotificationListener listener, NotificationFilter filter) {
-    // TODO - implement me.
-  }
-
-  public void removeNotificationListener(NotificationListener listener) throws IOException, JMException {
-    // TODO - implement me.
   }
 
   public String getUntranslatedHost() {

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpMetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpMetricsProxy.java
@@ -1,0 +1,46 @@
+package io.cassandrareaper.management.http;
+
+import io.cassandrareaper.core.GenericMetric;
+import io.cassandrareaper.core.Node;
+import io.cassandrareaper.management.MetricsProxy;
+
+import javax.management.JMException;
+import java.io.IOException;
+import java.util.List;
+
+public class HttpMetricsProxy implements MetricsProxy {
+
+    private HttpCassandraManagementProxy proxy;
+
+    private HttpMetricsProxy(HttpCassandraManagementProxy proxy) {
+        this.proxy = proxy;
+    }
+    public static HttpMetricsProxy create(HttpCassandraManagementProxy proxy) {
+        return new HttpMetricsProxy(proxy);
+    }
+
+    @Override
+    public List<GenericMetric> collectTpStats(Node node) throws JMException, IOException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public List<GenericMetric> collectDroppedMessages(Node node) throws JMException, IOException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public List<GenericMetric> collectLatencyMetrics(Node node) throws JMException, IOException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public List<GenericMetric> collectGenericMetrics(Node node) throws JMException, IOException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public List<GenericMetric> collectPercentRepairedMetrics(Node node, String keyspaceName) throws JMException, IOException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpMetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpMetricsProxy.java
@@ -1,46 +1,65 @@
+/*
+ * Copyright 2020-2020 The Last Pickle Ltd
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.cassandrareaper.management.http;
 
 import io.cassandrareaper.core.GenericMetric;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.management.MetricsProxy;
 
-import javax.management.JMException;
 import java.io.IOException;
 import java.util.List;
+import javax.management.JMException;
 
-public class HttpMetricsProxy implements MetricsProxy {
+public final class HttpMetricsProxy implements MetricsProxy {
 
-    private HttpCassandraManagementProxy proxy;
+  private HttpCassandraManagementProxy proxy;
 
-    private HttpMetricsProxy(HttpCassandraManagementProxy proxy) {
-        this.proxy = proxy;
-    }
-    public static HttpMetricsProxy create(HttpCassandraManagementProxy proxy) {
-        return new HttpMetricsProxy(proxy);
-    }
+  private HttpMetricsProxy(HttpCassandraManagementProxy proxy) {
+    this.proxy = proxy;
+  }
 
-    @Override
-    public List<GenericMetric> collectTpStats(Node node) throws JMException, IOException {
-        throw new UnsupportedOperationException("Not implemented");
-    }
+  public static HttpMetricsProxy create(HttpCassandraManagementProxy proxy) {
+    return new HttpMetricsProxy(proxy);
+  }
 
-    @Override
-    public List<GenericMetric> collectDroppedMessages(Node node) throws JMException, IOException {
-        throw new UnsupportedOperationException("Not implemented");
-    }
+  @Override
+  public List<GenericMetric> collectTpStats(Node node) throws JMException, IOException {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
-    @Override
-    public List<GenericMetric> collectLatencyMetrics(Node node) throws JMException, IOException {
-        throw new UnsupportedOperationException("Not implemented");
-    }
+  @Override
+  public List<GenericMetric> collectDroppedMessages(Node node) throws JMException, IOException {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
-    @Override
-    public List<GenericMetric> collectGenericMetrics(Node node) throws JMException, IOException {
-        throw new UnsupportedOperationException("Not implemented");
-    }
+  @Override
+  public List<GenericMetric> collectLatencyMetrics(Node node) throws JMException, IOException {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
-    @Override
-    public List<GenericMetric> collectPercentRepairedMetrics(Node node, String keyspaceName) throws JMException, IOException {
-        throw new UnsupportedOperationException("Not implemented");
-    }
+  @Override
+  public List<GenericMetric> collectGenericMetrics(Node node) throws JMException, IOException {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public List<GenericMetric> collectPercentRepairedMetrics(Node node, String keyspaceName)
+      throws JMException, IOException {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 }

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
@@ -107,7 +107,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-final class JmxCassandraManagementProxy implements ICassandraManagementProxy {
+final class JmxCassandraManagementProxy implements ICassandraManagementProxy, NotificationListener  {
 
   private static final Logger LOG = LoggerFactory.getLogger(ICassandraManagementProxy.class);
 
@@ -167,7 +167,7 @@ final class JmxCassandraManagementProxy implements ICassandraManagementProxy {
     registerConnectionsGauge();
   }
 
-  static ICassandraManagementProxy connect(
+  static JmxCassandraManagementProxy connect(
       String host,
       Optional<JmxCredentials> jmxCredentials,
       final AddressTranslator addressTranslator,
@@ -203,7 +203,7 @@ final class JmxCassandraManagementProxy implements ICassandraManagementProxy {
    * @param addressTranslator if EC2MultiRegionAddressTranslator isn't null it will be used to
    *                          translate addresses
    */
-  private static ICassandraManagementProxy connect(
+  private static JmxCassandraManagementProxy connect(
       String originalHost,
       int port,
       Optional<JmxCredentials> jmxCredentials,
@@ -264,7 +264,7 @@ final class JmxCassandraManagementProxy implements ICassandraManagementProxy {
         smProxy = Optional.of(JMX.newMBeanProxy(mbeanServerConn, ObjectNames.STREAM_MANAGER, StreamManagerMBean.class));
       }
 
-      ICassandraManagementProxy proxy
+      JmxCassandraManagementProxy proxy
           = new JmxCassandraManagementProxy(
           host,
           originalHost,
@@ -853,7 +853,6 @@ final class JmxCassandraManagementProxy implements ICassandraManagementProxy {
     return jmxConnector.getConnectionId();
   }
 
-  @Override
   public boolean isConnectionAlive() {
     try {
       String connectionId = getConnectionId();

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
@@ -107,7 +107,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-final class JmxCassandraManagementProxy implements ICassandraManagementProxy, NotificationListener  {
+public final class JmxCassandraManagementProxy implements ICassandraManagementProxy, NotificationListener  {
 
   private static final Logger LOG = LoggerFactory.getLogger(ICassandraManagementProxy.class);
 

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxManagementConnectionFactory.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
 public class JmxManagementConnectionFactory implements IManagementConnectionFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(JmxManagementConnectionFactory.class);
-  private static final ConcurrentMap<String, ICassandraManagementProxy> JMX_CONNECTIONS = Maps.newConcurrentMap();
+  private static final ConcurrentMap<String, JmxCassandraManagementProxy> JMX_CONNECTIONS = Maps.newConcurrentMap();
   private final MetricRegistry metricRegistry;
   private final HostConnectionCounters hostConnectionCounters;
   private final AppContext context;
@@ -153,7 +153,7 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
     return host;
   }
 
-  protected ICassandraManagementProxy connectImpl(Node node) throws ReaperException, InterruptedException {
+  protected JmxCassandraManagementProxy connectImpl(Node node) throws ReaperException, InterruptedException {
     // use configured jmx port for host if provided
     String host = determineHost(node);
 
@@ -164,7 +164,7 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
           host, jmxCredentials, context.config.getJmxConnectionTimeoutInSeconds(),
           this.metricRegistry, cryptograph, this.jmxmp);
       JMX_CONNECTIONS.computeIfAbsent(host, provider::apply);
-      ICassandraManagementProxy proxy = JMX_CONNECTIONS.get(host);
+      JmxCassandraManagementProxy proxy = JMX_CONNECTIONS.get(host);
       if (!proxy.isConnectionAlive()) {
         LOG.info("Adding new JMX Proxy for host {}", host);
         JMX_CONNECTIONS.put(host, provider.apply(host)).close();
@@ -295,10 +295,10 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
     }
 
     @Override
-    public ICassandraManagementProxy apply(String host) {
+    public JmxCassandraManagementProxy apply(String host) {
       Preconditions.checkArgument(host.equals(this.host));
       try {
-        ICassandraManagementProxy proxy = JmxCassandraManagementProxy.connect(
+        JmxCassandraManagementProxy proxy = JmxCassandraManagementProxy.connect(
             host, jmxCredentials, addressTranslator, connectionTimeout, metricRegistry, cryptograph, jmxmp);
         return proxy;
       } catch (ReaperException | InterruptedException ex) {

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxManagementConnectionFactory.java
@@ -185,7 +185,7 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
   }
 
   @VisibleForTesting
-  public final ICassandraManagementProxy connectAny(Collection<Node> nodes) throws ReaperException {
+  public final JmxCassandraManagementProxy connectAny(Collection<Node> nodes) throws ReaperException {
 
     Preconditions.checkArgument(
         null != nodes && !nodes.isEmpty(), "no hosts provided to connectAny");
@@ -200,7 +200,7 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
           try {
             LOG.debug("Trying to connect to node {} with {} successful connections with i = {}",
                 node.getHostname(), getHostConnectionCounters().getSuccessfulConnections(node.getHostname()), i);
-            ICassandraManagementProxy cassandraManagementProxy = connectImpl(node);
+            JmxCassandraManagementProxy cassandraManagementProxy = connectImpl(node);
             getHostConnectionCounters().incrementSuccessfulConnections(node.getHostname());
             if (getHostConnectionCounters().getSuccessfulConnections(node.getHostname()) > 0) {
               accessibleDatacenters.add(EndpointSnitchInfoProxy.create(cassandraManagementProxy).getDataCenter());

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxMetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxMetricsProxy.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package io.cassandrareaper.management;
+package io.cassandrareaper.management.jmx;
 
 import io.cassandrareaper.core.DroppedMessages;
 import io.cassandrareaper.core.GenericMetric;
@@ -23,7 +23,7 @@ import io.cassandrareaper.core.JmxStat;
 import io.cassandrareaper.core.MetricsHistogram;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.core.ThreadPoolStat;
-import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
+import io.cassandrareaper.management.MetricsProxy;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public final class JmxMetricsProxy {
+public final class JmxMetricsProxy implements MetricsProxy {
 
   private static final Logger LOG = LoggerFactory.getLogger(JmxMetricsProxy.class);
 
@@ -169,16 +169,19 @@ public final class JmxMetricsProxy {
     return metrics;
   }
 
+  @Override
   public List<GenericMetric> collectTpStats(Node node) throws JMException, IOException {
     return convertToGenericMetrics(collectMetrics(
         "org.apache.cassandra.metrics:type=ThreadPools,path=request,*",
         "org.apache.cassandra.metrics:type=ThreadPools,path=internal,*"), node);
   }
 
+  @Override
   public List<GenericMetric> collectDroppedMessages(Node node) throws JMException, IOException {
     return convertToGenericMetrics(collectMetrics("org.apache.cassandra.metrics:type=DroppedMessage,*"), node);
   }
 
+  @Override
   public List<GenericMetric> collectLatencyMetrics(Node node) throws JMException, IOException {
     return convertToGenericMetrics(collectMetrics("org.apache.cassandra.metrics:type=ClientRequest,*"), node);
   }
@@ -210,10 +213,12 @@ public final class JmxMetricsProxy {
     return groupedStatList;
   }
 
+  @Override
   public List<GenericMetric> collectGenericMetrics(Node node) throws JMException, IOException {
     return convertToGenericMetrics(collectMetrics(GENERIC_METRICS), node);
   }
 
+  @Override
   public List<GenericMetric> collectPercentRepairedMetrics(Node node, String keyspaceName)
           throws JMException, IOException {
     return convertToGenericMetrics(collectMetrics(String.format(PERCENT_REPAIRED_METRICS, keyspaceName)), node);

--- a/src/server/src/main/java/io/cassandrareaper/service/DiagEventPoller.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/DiagEventPoller.java
@@ -19,7 +19,7 @@ package io.cassandrareaper.service;
 
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.management.DiagnosticProxy;
-import io.cassandrareaper.management.ICassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.resources.view.DiagnosticEvent;
 
 import java.io.Serializable;
@@ -60,7 +60,7 @@ final class DiagEventPoller {
 
   DiagEventPoller(
       Node node,
-      ICassandraManagementProxy cassandraManagementProxy,
+      JmxCassandraManagementProxy cassandraManagementProxy,
       Consumer<DiagnosticEvent> eventConsumer,
       ScheduledExecutorService scheduledExecutor) {
 

--- a/src/server/src/main/java/io/cassandrareaper/service/DiagEventSubscriptionService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/DiagEventSubscriptionService.java
@@ -104,6 +104,8 @@ public final class DiagEventSubscriptionService {
 
   public static DiagEventSubscriptionService create(AppContext cxt, HttpClient client, ScheduledExecutorService exec,
                                                     IEventsDao eventsDao) {
+    Preconditions.checkState(cxt.managementConnectionFactory instanceof JmxManagementConnectionFactory,
+        "JMX diagnostic events are only available when JMX connections are used.");
     return new DiagEventSubscriptionService(cxt, client, exec, eventsDao);
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/DiagEventSubscriptionService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/DiagEventSubscriptionService.java
@@ -23,7 +23,8 @@ import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.DiagEventSubscription;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.management.DiagnosticProxy;
-import io.cassandrareaper.management.ICassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 import io.cassandrareaper.resources.view.DiagnosticEvent;
 import io.cassandrareaper.storage.events.IEventsDao;
 
@@ -211,7 +212,8 @@ public final class DiagEventSubscriptionService {
           try {
             Thread.currentThread().setName(node.getHostname());
             LOG.debug("Starting to update event subscriptions for {}", node);
-            ICassandraManagementProxy jmx = context.managementConnectionFactory.connectAny(Collections.singleton(node));
+            JmxCassandraManagementProxy jmx = ((JmxManagementConnectionFactory) context.managementConnectionFactory)
+                    .connectAny(Collections.singleton(node));
 
             // create set of active and inactive events based on all subscriptions for this node
             // active events are all events included in an active subscription
@@ -287,7 +289,7 @@ public final class DiagEventSubscriptionService {
   }
 
   private void enableEvents(Node node, Set<String> events, boolean enabled,
-                            ICassandraManagementProxy cassandraManagementProxy) {
+                            JmxCassandraManagementProxy cassandraManagementProxy) {
     for (String event : events) {
       LOG.debug("{} {} for {}", enabled ? "Enabling" : "Disabling", event, node);
       try {
@@ -310,7 +312,7 @@ public final class DiagEventSubscriptionService {
   }
 
   private DiagEventPoller createPoller(Node node,
-                                       ICassandraManagementProxy cassandraManagementProxy,
+                                       JmxCassandraManagementProxy cassandraManagementProxy,
                                        Set<String> events,
                                        boolean enabled) {
     DiagEventPoller poller = POLLERS_BY_NODE
@@ -325,7 +327,7 @@ public final class DiagEventSubscriptionService {
     return poller;
   }
 
-  private void subscribeNotifications(Node node, ICassandraManagementProxy cassandraManagementProxy,
+  private void subscribeNotifications(Node node, JmxCassandraManagementProxy cassandraManagementProxy,
                                       DiagEventPoller poller) {
     if (!listenerByNode.containsKey(node)) {
       LOG.debug("Subscribing to notifications on {} ({})", cassandraManagementProxy.getHost(),
@@ -345,7 +347,7 @@ public final class DiagEventSubscriptionService {
     }
   }
 
-  private void unsubscribeNotifications(Node node, ICassandraManagementProxy cassandraManagementProxy) {
+  private void unsubscribeNotifications(Node node, JmxCassandraManagementProxy cassandraManagementProxy) {
     LOG.debug("Unsubscribing from notifications on {} ({})", cassandraManagementProxy.getHost(),
         cassandraManagementProxy.getClusterName());
     NotificationListener listener = listenerByNode.remove(node);

--- a/src/server/src/main/java/io/cassandrareaper/service/Heart.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/Heart.java
@@ -242,7 +242,6 @@ public final class Heart implements AutoCloseable {
    * Such metrics will only be retrieved if an incremental repair schedule exists.
    *
    * @param node                       An optional node to grab the metrics from (the local node if not provided)
-   * @param incrementalRepairSchedules a collection of incremental repair schedules
    */
   private void updatePercentRepairedForNode(
       Optional<Node> node,

--- a/src/server/src/test/java/io/cassandrareaper/management/ClusterFacadeTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/ClusterFacadeTest.java
@@ -26,8 +26,6 @@ import io.cassandrareaper.core.Compaction;
 import io.cassandrareaper.core.CompactionStats;
 import io.cassandrareaper.core.JmxCredentials;
 import io.cassandrareaper.core.StreamSession;
-import io.cassandrareaper.management.ClusterFacade;
-import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 

--- a/src/server/src/test/java/io/cassandrareaper/management/ClusterFacadeTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/ClusterFacadeTest.java
@@ -28,6 +28,7 @@ import io.cassandrareaper.core.JmxCredentials;
 import io.cassandrareaper.core.StreamSession;
 import io.cassandrareaper.management.ClusterFacade;
 import io.cassandrareaper.management.ICassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 
 import java.io.IOException;
@@ -210,7 +211,7 @@ public class ClusterFacadeTest {
 
     contextSpy.config.setDatacenterAvailability(DatacenterAvailability.SIDECAR);
     JmxManagementConnectionFactory jmxManagementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy mockProxy = mock(ICassandraManagementProxy.class);
+    JmxCassandraManagementProxy mockProxy = mock(JmxCassandraManagementProxy.class);
     when(jmxManagementConnectionFactory.connectAny(any(Collection.class))).thenReturn(mockProxy);
     contextSpy.managementConnectionFactory = jmxManagementConnectionFactory;
     final ClusterFacade cf = ClusterFacade.create(contextSpy);

--- a/src/server/src/test/java/io/cassandrareaper/management/ClusterFacadeTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/ClusterFacadeTest.java
@@ -72,8 +72,8 @@ public class ClusterFacadeTest {
         new HashSet<String>(Arrays.asList("dc1")));
     contextSpy.managementConnectionFactory = jmxManagementConnectionFactory;
     ClusterFacade clusterFacade = ClusterFacade.create(contextSpy);
-    assertTrue(clusterFacade.nodeIsAccessibleThroughJmx("dc1", contextSpy.getLocalNodeAddress()));
-    assertFalse(clusterFacade.nodeIsAccessibleThroughJmx("dc1", "127.0.0.2"));
+    assertTrue(clusterFacade.nodeIsDirectlyAccessible("dc1", contextSpy.getLocalNodeAddress()));
+    assertFalse(clusterFacade.nodeIsDirectlyAccessible("dc1", "127.0.0.2"));
   }
 
   @Test
@@ -86,8 +86,8 @@ public class ClusterFacadeTest {
         .thenReturn(new HashSet<>(Arrays.asList("dc1")));
 
     context.config.setDatacenterAvailability(DatacenterAvailability.ALL);
-    assertTrue(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc1", "127.0.0.1"));
-    assertTrue(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc2", "127.0.0.2"));
+    assertTrue(ClusterFacade.create(context).nodeIsDirectlyAccessible("dc1", "127.0.0.1"));
+    assertTrue(ClusterFacade.create(context).nodeIsDirectlyAccessible("dc2", "127.0.0.2"));
   }
 
   @Test
@@ -101,9 +101,9 @@ public class ClusterFacadeTest {
 
     context.config.setDatacenterAvailability(DatacenterAvailability.LOCAL);
     // it's in another DC so LOCAL disallows attempting it
-    assertFalse(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc2", "127.0.0.2"));
+    assertFalse(ClusterFacade.create(context).nodeIsDirectlyAccessible("dc2", "127.0.0.2"));
     // Should be accessible, same DC
-    assertTrue(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc1", "127.0.0.2"));
+    assertTrue(ClusterFacade.create(context).nodeIsDirectlyAccessible("dc1", "127.0.0.2"));
   }
 
   @Test
@@ -117,9 +117,9 @@ public class ClusterFacadeTest {
 
     context.config.setDatacenterAvailability(DatacenterAvailability.EACH);
     // Should not be accessible as it's in another DC
-    assertFalse(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc2", "127.0.0.2"));
+    assertFalse(ClusterFacade.create(context).nodeIsDirectlyAccessible("dc2", "127.0.0.2"));
     // Should be accessible, same DC
-    assertTrue(ClusterFacade.create(context).nodeIsAccessibleThroughJmx("dc1", "127.0.0.2"));
+    assertTrue(ClusterFacade.create(context).nodeIsDirectlyAccessible("dc1", "127.0.0.2"));
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/management/jmx/CassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/jmx/CassandraManagementProxyTest.java
@@ -31,10 +31,11 @@ import static org.mockito.ArgumentMatchers.any;
 
 public final class CassandraManagementProxyTest {
 
-  public static ICassandraManagementProxy mockJmxProxyImpl() throws UnknownHostException {
+  public static JmxCassandraManagementProxy mockJmxProxyImpl() throws UnknownHostException {
     JmxCassandraManagementProxy impl = Mockito.mock(JmxCassandraManagementProxy.class);
     Mockito.when(impl.getUntranslatedHost()).thenReturn("test-host-" + new Random().nextInt());
     Mockito.when(impl.getDatacenter(any())).thenReturn("dc1");
+    Mockito.when(impl.isConnectionAlive()).thenReturn(true);
     return impl;
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/management/jmx/JmxConnectionsInitializerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/jmx/JmxConnectionsInitializerTest.java
@@ -24,7 +24,6 @@ import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.crypto.Cryptograph;
-import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.storage.IStorageDao;
 import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 import io.cassandrareaper.storage.cluster.IClusterDao;
@@ -53,7 +52,7 @@ public class JmxConnectionsInitializerTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     final Cryptograph cryptographMock = mock(Cryptograph.class);
-    final ICassandraManagementProxy cassandraManagementProxyMock = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy cassandraManagementProxyMock = CassandraManagementProxyTest.mockJmxProxyImpl();
     final AtomicInteger connectionAttempts = new AtomicInteger(0);
 
     context.config.setDatacenterAvailability(DatacenterAvailability.EACH);
@@ -62,8 +61,8 @@ public class JmxConnectionsInitializerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, cryptographMock) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node node) throws ReaperException {
-        final ICassandraManagementProxy jmx = cassandraManagementProxyMock;
+      protected JmxCassandraManagementProxy connectImpl(Node node) throws ReaperException {
+        final JmxCassandraManagementProxy jmx = cassandraManagementProxyMock;
         connectionAttempts.incrementAndGet();
         return jmx;
       }
@@ -96,13 +95,13 @@ public class JmxConnectionsInitializerTest {
     context.storage = mock(CassandraStorageFacade.class);
     when(context.storage.getClusterDao()).thenReturn(mock(IClusterDao.class));
     final Cryptograph cryptographMock = mock(Cryptograph.class);
-    final ICassandraManagementProxy cassandraManagementProxyMock = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy cassandraManagementProxyMock = CassandraManagementProxyTest.mockJmxProxyImpl();
     final AtomicInteger connectionAttempts = new AtomicInteger(0);
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, cryptographMock) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node node) throws ReaperException {
-        final ICassandraManagementProxy jmx = cassandraManagementProxyMock;
+      protected JmxCassandraManagementProxy connectImpl(Node node) throws ReaperException {
+        final JmxCassandraManagementProxy jmx = cassandraManagementProxyMock;
         connectionAttempts.incrementAndGet();
         return jmx;
       }
@@ -134,13 +133,13 @@ public class JmxConnectionsInitializerTest {
     context.storage = mock(IStorageDao.class);
     when(context.storage.getClusterDao()).thenReturn(mock(IClusterDao.class));
     final Cryptograph cryptographMock = mock(Cryptograph.class);
-    final ICassandraManagementProxy cassandraManagementProxyMock = mock(ICassandraManagementProxy.class);
+    final JmxCassandraManagementProxy cassandraManagementProxyMock = mock(JmxCassandraManagementProxy.class);
     final AtomicInteger connectionAttempts = new AtomicInteger(0);
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, cryptographMock) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node node) throws ReaperException {
-        final ICassandraManagementProxy jmx = cassandraManagementProxyMock;
+      protected JmxCassandraManagementProxy connectImpl(Node node) throws ReaperException {
+        final JmxCassandraManagementProxy jmx = cassandraManagementProxyMock;
         connectionAttempts.incrementAndGet();
         return jmx;
       }

--- a/src/server/src/test/java/io/cassandrareaper/management/jmx/JmxCustomPortTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/jmx/JmxCustomPortTest.java
@@ -24,7 +24,6 @@ import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.crypto.Cryptograph;
 import io.cassandrareaper.management.HostConnectionCounters;
-import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.storage.IStorageDao;
 import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 import io.cassandrareaper.storage.cluster.IClusterDao;

--- a/src/server/src/test/java/io/cassandrareaper/management/jmx/JmxCustomPortTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/jmx/JmxCustomPortTest.java
@@ -54,7 +54,7 @@ public final class JmxCustomPortTest {
     AppContext context = new AppContext();
     context.config = new ReaperApplicationConfiguration();
     final Cryptograph cryptographMock = mock(Cryptograph.class);
-    final ICassandraManagementProxy cassandraManagementProxyMock = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy cassandraManagementProxyMock = CassandraManagementProxyTest.mockJmxProxyImpl();
     final AtomicInteger port = new AtomicInteger(0);
     HostConnectionCounters hostConnectionCounters = mock(HostConnectionCounters.class);
     when(hostConnectionCounters.getSuccessfulConnections(any())).thenReturn(1);
@@ -63,8 +63,8 @@ public final class JmxCustomPortTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, cryptographMock) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node node) throws ReaperException {
-        final ICassandraManagementProxy jmx = cassandraManagementProxyMock;
+      protected JmxCassandraManagementProxy connectImpl(Node node) throws ReaperException {
+        final JmxCassandraManagementProxy jmx = cassandraManagementProxyMock;
         port.set(node.getJmxPort());
         return jmx;
       }
@@ -85,7 +85,7 @@ public final class JmxCustomPortTest {
         .withJmxPort(7188)
         .build();
 
-    context.managementConnectionFactory
+    ((JmxManagementConnectionFactory) context.managementConnectionFactory)
         .connectAny(Collections.singleton(Node.builder().withCluster(cluster).withHostname("127.0.0.1").build()));
 
     assertEquals(7188, port.get());
@@ -97,7 +97,7 @@ public final class JmxCustomPortTest {
         .withJmxPort(7198)
         .build();
 
-    context.managementConnectionFactory
+    ((JmxManagementConnectionFactory) context.managementConnectionFactory)
         .connectAny(Collections.singleton(Node.builder().withCluster(cluster2).withHostname("127.0.0.3").build()));
 
     assertEquals(7198, port.get());

--- a/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
@@ -25,6 +25,7 @@ import io.cassandrareaper.crypto.Cryptograph;
 import io.cassandrareaper.crypto.NoopCrypotograph;
 import io.cassandrareaper.management.ClusterFacade;
 import io.cassandrareaper.management.ICassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 import io.cassandrareaper.service.TestRepairConfiguration;
 import io.cassandrareaper.storage.MemoryStorageFacade;
@@ -654,13 +655,13 @@ public final class ClusterResourceTest {
     UriInfo uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(SAMPLE_URI));
 
-    ICassandraManagementProxy cassandraManagementProxy = mock(ICassandraManagementProxy.class);
+    JmxCassandraManagementProxy cassandraManagementProxy = mock(JmxCassandraManagementProxy.class);
     when(cassandraManagementProxy.getClusterName()).thenReturn(CLUSTER_NAME);
     when(cassandraManagementProxy.getPartitioner()).thenReturn(PARTITIONER);
 
     context.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
 
-    when(context.managementConnectionFactory.connectAny(Mockito.anyCollection())).thenReturn(cassandraManagementProxy);
+    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection())).thenReturn(cassandraManagementProxy);
 
     Cryptograph cryptograph = mock(Cryptograph.class);
     when(cryptograph.encrypt(any(String.class))).thenReturn(RandomStringUtils.randomNumeric(10));

--- a/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/ClusterResourceTest.java
@@ -661,7 +661,8 @@ public final class ClusterResourceTest {
 
     context.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
 
-    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection())).thenReturn(cassandraManagementProxy);
+    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection()))
+            .thenReturn(cassandraManagementProxy);
 
     Cryptograph cryptograph = mock(Cryptograph.class);
     when(cryptograph.encrypt(any(String.class))).thenReturn(RandomStringUtils.randomNumeric(10));

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -27,6 +27,7 @@ import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Table;
 import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.management.jmx.CassandraManagementProxyTest;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 import io.cassandrareaper.resources.view.RepairRunStatus;
 import io.cassandrareaper.service.RepairManager;
@@ -153,7 +154,6 @@ public final class RepairRunResourceTest {
             .collect(Collectors.toSet()));
     when(proxy.getEndpointToHostId()).thenReturn(NODES_MAP);
     when(proxy.getTokens()).thenReturn(TOKENS);
-    when(proxy.isConnectionAlive()).thenReturn(Boolean.TRUE);
     when(proxy.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
     when(proxy.triggerRepair(
         any(BigInteger.class),
@@ -177,10 +177,10 @@ public final class RepairRunResourceTest {
     }
 
     context.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    when(context.managementConnectionFactory.connectAny(Mockito.anyCollection())).thenReturn(proxy);
+    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection())).thenReturn((JmxCassandraManagementProxy) proxy);
 
-    when(context.managementConnectionFactory.connectAny(Mockito.anyCollection()))
-        .thenReturn(proxy);
+    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection()))
+        .thenReturn((JmxCassandraManagementProxy) proxy);
 
     RepairUnit.Builder repairUnitBuilder = RepairUnit.builder()
         .clusterName(clustername)

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -177,7 +177,8 @@ public final class RepairRunResourceTest {
     }
 
     context.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection())).thenReturn((JmxCassandraManagementProxy) proxy);
+    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection()))
+            .thenReturn((JmxCassandraManagementProxy) proxy);
 
     when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection()))
         .thenReturn((JmxCassandraManagementProxy) proxy);

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -82,7 +82,8 @@ public final class ClusterRepairSchedulerTest {
     clusterRepairAuto = new ClusterRepairScheduler(context, context.storage.getRepairRunDao());
     cassandraManagementProxy = mock(ICassandraManagementProxy.class);
 
-    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection())).thenReturn((JmxCassandraManagementProxy) cassandraManagementProxy);
+    when(((JmxManagementConnectionFactory) context.managementConnectionFactory)
+            .connectAny(Mockito.anyCollection())).thenReturn((JmxCassandraManagementProxy) cassandraManagementProxy);
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -80,10 +80,10 @@ public final class ClusterRepairSchedulerTest {
 
     context.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
     clusterRepairAuto = new ClusterRepairScheduler(context, context.storage.getRepairRunDao());
-    cassandraManagementProxy = mock(ICassandraManagementProxy.class);
+    cassandraManagementProxy = mock(JmxCassandraManagementProxy.class);
 
-    when(((JmxManagementConnectionFactory) context.managementConnectionFactory)
-            .connectAny(Mockito.anyCollection())).thenReturn((JmxCassandraManagementProxy) cassandraManagementProxy);
+    when(context.managementConnectionFactory
+            .connectAny(Mockito.anyCollection())).thenReturn(cassandraManagementProxy);
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/ClusterRepairSchedulerTest.java
@@ -25,6 +25,7 @@ import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Table;
 import io.cassandrareaper.management.ICassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 import io.cassandrareaper.storage.MemoryStorageFacade;
 
@@ -81,7 +82,7 @@ public final class ClusterRepairSchedulerTest {
     clusterRepairAuto = new ClusterRepairScheduler(context, context.storage.getRepairRunDao());
     cassandraManagementProxy = mock(ICassandraManagementProxy.class);
 
-    when(context.managementConnectionFactory.connectAny(Mockito.anyCollection())).thenReturn(cassandraManagementProxy);
+    when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(Mockito.anyCollection())).thenReturn((JmxCassandraManagementProxy) cassandraManagementProxy);
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
@@ -266,10 +266,10 @@ public final class HeartTest {
     context.storage = Mockito.mock(CassandraStorageFacade.class);
     context.managementConnectionFactory = Mockito.mock(JmxManagementConnectionFactory.class);
 
-    ICassandraManagementProxy nodeProxy = Mockito.mock(ICassandraManagementProxy.class);
+    JmxCassandraManagementProxy nodeProxy = Mockito.mock(JmxCassandraManagementProxy.class);
 
-    Mockito.when(((JmxManagementConnectionFactory) context.managementConnectionFactory)
-            .connectAny(any(Collection.class))).thenReturn((JmxCassandraManagementProxy) nodeProxy);
+    Mockito.when(context.managementConnectionFactory
+            .connectAny(any(Collection.class))).thenReturn(nodeProxy);
 
     try (Heart heart = Heart.create(context)) {
       context.isDistributed.set(true);
@@ -316,10 +316,10 @@ public final class HeartTest {
                 .withJmxPort(7199)
                 .build());
 
-    ICassandraManagementProxy nodeProxy = Mockito.mock(ICassandraManagementProxy.class);
+    ICassandraManagementProxy nodeProxy = Mockito.mock(JmxCassandraManagementProxy.class);
 
-    Mockito.when(((JmxManagementConnectionFactory) context.managementConnectionFactory)
-            .connectAny(any(Collection.class))).thenReturn((JmxCassandraManagementProxy) nodeProxy);
+    Mockito.when(context.managementConnectionFactory
+            .connectAny(any(Collection.class))).thenReturn(nodeProxy);
 
     try (Heart heart = Heart.create(context)) {
       context.isDistributed.set(true);

--- a/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
@@ -24,6 +24,7 @@ import io.cassandrareaper.core.Cluster;
 import io.cassandrareaper.core.Cluster.State;
 import io.cassandrareaper.crypto.NoopCrypotograph;
 import io.cassandrareaper.management.ICassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 import io.cassandrareaper.storage.IStorageDao;
 import io.cassandrareaper.storage.MemoryStorageFacade;
@@ -238,7 +239,7 @@ public final class HeartTest {
     }
 
     Mockito.verify((CassandraStorageFacade) context.storage, Mockito.times(1)).saveHeartbeat();
-    Mockito.verify(context.managementConnectionFactory, Mockito.times(0)).connectAny(any(Collection.class));
+    Mockito.verify(((JmxManagementConnectionFactory) context.managementConnectionFactory), Mockito.times(0)).connectAny(any(Collection.class));
   }
 
   @Test
@@ -266,7 +267,7 @@ public final class HeartTest {
 
     ICassandraManagementProxy nodeProxy = Mockito.mock(ICassandraManagementProxy.class);
 
-    Mockito.when(context.managementConnectionFactory.connectAny(any(Collection.class))).thenReturn(nodeProxy);
+    Mockito.when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn((JmxCassandraManagementProxy) nodeProxy);
 
     try (Heart heart = Heart.create(context)) {
       context.isDistributed.set(true);
@@ -275,7 +276,7 @@ public final class HeartTest {
     }
 
     Mockito.verify((CassandraStorageFacade) context.storage, Mockito.times(1)).saveHeartbeat();
-    Mockito.verify(context.managementConnectionFactory, Mockito.times(0)).connectAny(any(Collection.class));
+    Mockito.verify(((JmxManagementConnectionFactory) context.managementConnectionFactory), Mockito.times(0)).connectAny(any(Collection.class));
   }
 
   @Test
@@ -314,7 +315,7 @@ public final class HeartTest {
 
     ICassandraManagementProxy nodeProxy = Mockito.mock(ICassandraManagementProxy.class);
 
-    Mockito.when(context.managementConnectionFactory.connectAny(any(Collection.class))).thenReturn(nodeProxy);
+    Mockito.when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn((JmxCassandraManagementProxy) nodeProxy);
 
     try (Heart heart = Heart.create(context)) {
       context.isDistributed.set(true);

--- a/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/HeartTest.java
@@ -239,7 +239,8 @@ public final class HeartTest {
     }
 
     Mockito.verify((CassandraStorageFacade) context.storage, Mockito.times(1)).saveHeartbeat();
-    Mockito.verify(((JmxManagementConnectionFactory) context.managementConnectionFactory), Mockito.times(0)).connectAny(any(Collection.class));
+    Mockito.verify(((JmxManagementConnectionFactory) context.managementConnectionFactory),
+            Mockito.times(0)).connectAny(any(Collection.class));
   }
 
   @Test
@@ -267,7 +268,8 @@ public final class HeartTest {
 
     ICassandraManagementProxy nodeProxy = Mockito.mock(ICassandraManagementProxy.class);
 
-    Mockito.when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn((JmxCassandraManagementProxy) nodeProxy);
+    Mockito.when(((JmxManagementConnectionFactory) context.managementConnectionFactory)
+            .connectAny(any(Collection.class))).thenReturn((JmxCassandraManagementProxy) nodeProxy);
 
     try (Heart heart = Heart.create(context)) {
       context.isDistributed.set(true);
@@ -276,7 +278,8 @@ public final class HeartTest {
     }
 
     Mockito.verify((CassandraStorageFacade) context.storage, Mockito.times(1)).saveHeartbeat();
-    Mockito.verify(((JmxManagementConnectionFactory) context.managementConnectionFactory), Mockito.times(0)).connectAny(any(Collection.class));
+    Mockito.verify(((JmxManagementConnectionFactory) context.managementConnectionFactory),
+            Mockito.times(0)).connectAny(any(Collection.class));
   }
 
   @Test
@@ -315,7 +318,8 @@ public final class HeartTest {
 
     ICassandraManagementProxy nodeProxy = Mockito.mock(ICassandraManagementProxy.class);
 
-    Mockito.when(((JmxManagementConnectionFactory) context.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn((JmxCassandraManagementProxy) nodeProxy);
+    Mockito.when(((JmxManagementConnectionFactory) context.managementConnectionFactory)
+            .connectAny(any(Collection.class))).thenReturn((JmxCassandraManagementProxy) nodeProxy);
 
     try (Heart heart = Heart.create(context)) {
       context.isDistributed.set(true);

--- a/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
@@ -25,9 +25,9 @@ import io.cassandrareaper.core.JmxStat;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.core.ThreadPoolStat;
 import io.cassandrareaper.management.ClusterFacade;
-import io.cassandrareaper.management.jmx.JmxMetricsProxy;
 import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
+import io.cassandrareaper.management.jmx.JmxMetricsProxy;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
@@ -20,13 +20,10 @@ package io.cassandrareaper.service;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperApplicationConfiguration;
 import io.cassandrareaper.ReaperException;
-import io.cassandrareaper.core.DroppedMessages;
-import io.cassandrareaper.core.JmxStat;
-import io.cassandrareaper.core.Node;
-import io.cassandrareaper.core.ThreadPoolStat;
+import io.cassandrareaper.core.*;
 import io.cassandrareaper.management.ClusterFacade;
-import io.cassandrareaper.management.ICassandraManagementProxy;
-import io.cassandrareaper.management.MetricsProxy;
+import io.cassandrareaper.management.JmxMetricsProxy;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 
 import java.io.IOException;
@@ -59,9 +56,9 @@ public class MetricsServiceTest {
     cxt.config = new ReaperApplicationConfiguration();
     cxt.config.setJmxConnectionTimeoutInSeconds(10);
     cxt.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy jmx = (ICassandraManagementProxy) mock(
+    JmxCassandraManagementProxy jmx = (JmxCassandraManagementProxy) mock(
         Class.forName("io.cassandrareaper.management.jmx.JmxCassandraManagementProxy"));
-    when(cxt.managementConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
+    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn(jmx);
 
     // @todo capture objectName and return valid set of objectNames,
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToThreadPoolStats(..)
@@ -124,7 +121,7 @@ public class MetricsServiceTest {
     AppContext context = new AppContext();
     List<ThreadPoolStat> threadPoolStats
         = ClusterFacade.create(context).convertToThreadPoolStats(
-        MetricsProxy.convertToGenericMetrics(jmxStats, node));
+        JmxMetricsProxy.convertToGenericMetrics(jmxStats, node));
     ThreadPoolStat tpstat = threadPoolStats.get(0);
 
     assertEquals(1, tpstat.getPendingTasks().intValue());
@@ -145,9 +142,9 @@ public class MetricsServiceTest {
     cxt.config = new ReaperApplicationConfiguration();
     cxt.config.setJmxConnectionTimeoutInSeconds(10);
     cxt.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy jmx = (ICassandraManagementProxy) mock(
+    JmxCassandraManagementProxy jmx = (JmxCassandraManagementProxy) mock(
         Class.forName("io.cassandrareaper.management.jmx.JmxCassandraManagementProxy"));
-    when(cxt.managementConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
+    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn(jmx);
 
     // @todo capture objectName and return valid set of objectNames,
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToDroppedMessages(..)
@@ -208,7 +205,7 @@ public class MetricsServiceTest {
     Node node = Node.builder().withHostname("127.0.0.1").build();
     List<DroppedMessages> droppedMessages
         = clusterFacade.convertToDroppedMessages(
-        MetricsProxy.convertToGenericMetrics(jmxStats, node));
+        JmxMetricsProxy.convertToGenericMetrics(jmxStats, node));
     DroppedMessages dropped = droppedMessages.get(0);
 
     assertEquals(1, dropped.getMeanRate().intValue());
@@ -228,9 +225,9 @@ public class MetricsServiceTest {
     cxt.config = new ReaperApplicationConfiguration();
     cxt.config.setJmxConnectionTimeoutInSeconds(10);
     cxt.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy jmx = (ICassandraManagementProxy) mock(
+    JmxCassandraManagementProxy jmx = (JmxCassandraManagementProxy) mock(
         Class.forName("io.cassandrareaper.management.jmx.JmxCassandraManagementProxy"));
-    when(cxt.managementConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
+    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn(jmx);
 
     // @todo capture objectName and return valid set of objectNames,
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToMetricsHistogram(..)

--- a/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
@@ -25,7 +25,7 @@ import io.cassandrareaper.core.JmxStat;
 import io.cassandrareaper.core.Node;
 import io.cassandrareaper.core.ThreadPoolStat;
 import io.cassandrareaper.management.ClusterFacade;
-import io.cassandrareaper.management.JmxMetricsProxy;
+import io.cassandrareaper.management.jmx.JmxMetricsProxy;
 import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 

--- a/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/MetricsServiceTest.java
@@ -20,7 +20,10 @@ package io.cassandrareaper.service;
 import io.cassandrareaper.AppContext;
 import io.cassandrareaper.ReaperApplicationConfiguration;
 import io.cassandrareaper.ReaperException;
-import io.cassandrareaper.core.*;
+import io.cassandrareaper.core.DroppedMessages;
+import io.cassandrareaper.core.JmxStat;
+import io.cassandrareaper.core.Node;
+import io.cassandrareaper.core.ThreadPoolStat;
 import io.cassandrareaper.management.ClusterFacade;
 import io.cassandrareaper.management.JmxMetricsProxy;
 import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
@@ -58,7 +61,8 @@ public class MetricsServiceTest {
     cxt.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
     JmxCassandraManagementProxy jmx = (JmxCassandraManagementProxy) mock(
         Class.forName("io.cassandrareaper.management.jmx.JmxCassandraManagementProxy"));
-    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn(jmx);
+    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class)))
+            .thenReturn(jmx);
 
     // @todo capture objectName and return valid set of objectNames,
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToThreadPoolStats(..)
@@ -144,7 +148,8 @@ public class MetricsServiceTest {
     cxt.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
     JmxCassandraManagementProxy jmx = (JmxCassandraManagementProxy) mock(
         Class.forName("io.cassandrareaper.management.jmx.JmxCassandraManagementProxy"));
-    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn(jmx);
+    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class)))
+            .thenReturn(jmx);
 
     // @todo capture objectName and return valid set of objectNames,
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToDroppedMessages(..)
@@ -227,7 +232,8 @@ public class MetricsServiceTest {
     cxt.managementConnectionFactory = mock(JmxManagementConnectionFactory.class);
     JmxCassandraManagementProxy jmx = (JmxCassandraManagementProxy) mock(
         Class.forName("io.cassandrareaper.management.jmx.JmxCassandraManagementProxy"));
-    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class))).thenReturn(jmx);
+    when(((JmxManagementConnectionFactory) cxt.managementConnectionFactory).connectAny(any(Collection.class)))
+            .thenReturn(jmx);
 
     // @todo capture objectName and return valid set of objectNames,
     // to properly test MetricsProxy.collectMetrics(..) and MetricsService.convertToMetricsHistogram(..)

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -30,6 +30,7 @@ import io.cassandrareaper.crypto.NoopCrypotograph;
 import io.cassandrareaper.management.ClusterFacade;
 import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.management.jmx.CassandraManagementProxyTest;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 import io.cassandrareaper.storage.IStorageDao;
 import io.cassandrareaper.storage.MemoryStorageFacade;
@@ -268,9 +269,8 @@ public final class RepairRunServiceTest {
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -292,7 +292,7 @@ public final class RepairRunServiceTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -356,9 +356,8 @@ public final class RepairRunServiceTest {
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
     final Semaphore mutex = new Semaphore(0);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -380,7 +379,7 @@ public final class RepairRunServiceTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -431,7 +430,6 @@ public final class RepairRunServiceTest {
         .withPartitioner("Murmur3Partitioner")
         .build();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
 
 
@@ -491,7 +489,6 @@ public final class RepairRunServiceTest {
         .withPartitioner("Murmur3Partitioner")
         .build();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
 
 
@@ -547,10 +544,10 @@ public final class RepairRunServiceTest {
     context.storage = storage;
     Mockito.when(context.storage.getClusterDao()).thenReturn(Mockito.mock(IClusterDao.class));
     context.config = new ReaperApplicationConfiguration();
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      public ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      public JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -569,7 +566,6 @@ public final class RepairRunServiceTest {
         .withPartitioner("Murmur3Partitioner")
         .build();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
 
     RepairRunService repairRunService = RepairRunService.create(context, context.storage.getRepairRunDao());
@@ -609,10 +605,10 @@ public final class RepairRunServiceTest {
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
     Mockito.when(context.storage.getClusterDao()).thenReturn(Mockito.mock(IClusterDao.class));
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      public ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      public JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -631,7 +627,6 @@ public final class RepairRunServiceTest {
         .withPartitioner("Murmur3Partitioner")
         .build();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class))).thenReturn(jmx);
@@ -857,9 +852,8 @@ public final class RepairRunServiceTest {
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
     final Semaphore mutex = new Semaphore(0);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -881,7 +875,7 @@ public final class RepairRunServiceTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -282,7 +282,7 @@ public final class RepairRunServiceTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class))).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any())).thenReturn(Lists.newArrayList(NODES));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
         .thenThrow(new ReaperException("fail"));
@@ -369,7 +369,7 @@ public final class RepairRunServiceTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class))).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any())).thenReturn(Lists.newArrayList(NODES));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
         .thenReturn((Map) ImmutableMap.of(Lists.newArrayList("0", "100"), Lists.newArrayList(NODES)));
@@ -435,7 +435,7 @@ public final class RepairRunServiceTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class))).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any())).thenReturn(Lists.newArrayList(NODES));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
         .thenReturn((Map) ImmutableMap.of(Lists.newArrayList("0", "100"), Lists.newArrayList(NODES)));
@@ -494,7 +494,7 @@ public final class RepairRunServiceTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class))).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any())).thenReturn(Lists.newArrayList(NODES));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
         .thenReturn((Map) ImmutableMap.of(Lists.newArrayList("0", "100"), Lists.newArrayList(NODES)));
@@ -865,7 +865,7 @@ public final class RepairRunServiceTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class))).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any())).thenReturn(Lists.newArrayList(NODES));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
         .thenReturn((Map) ImmutableMap.of(Lists.newArrayList("0", "100"), Collections.EMPTY_LIST));

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -333,7 +333,7 @@ public final class RepairRunnerTest {
             });
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any())).thenReturn(Lists.newArrayList(nodeSet));
     when(clusterFacade.getEndpointToHostId(any())).thenReturn(endpointToHostIDMap);
     when(clusterFacade.listActiveCompactions(any())).thenReturn(CompactionStats.builder().withActiveCompactions(
@@ -482,7 +482,7 @@ public final class RepairRunnerTest {
             });
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(nodeSet));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
@@ -573,7 +573,7 @@ public final class RepairRunnerTest {
     }
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(nodeSet));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
@@ -702,7 +702,7 @@ public final class RepairRunnerTest {
     }
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(nodeSet));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
@@ -899,7 +899,7 @@ public final class RepairRunnerTest {
     }
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(nodeSet));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
@@ -1097,7 +1097,7 @@ public final class RepairRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(nodeSet));
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
@@ -1326,7 +1326,7 @@ public final class RepairRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(proxy);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.listActiveCompactions(any())).thenReturn(CompactionStats.builder().withActiveCompactions(
         Collections.emptyList()).withPendingCompactions(Optional.of(3)).build());
     when(clusterFacade.getRangeToEndpointMap(any(), anyString()))

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -31,7 +31,6 @@ import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Segment;
 import io.cassandrareaper.crypto.NoopCrypotograph;
 import io.cassandrareaper.management.ClusterFacade;
-import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.management.RepairStatusHandler;
 import io.cassandrareaper.management.jmx.CassandraManagementProxyTest;
 import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -34,6 +34,7 @@ import io.cassandrareaper.management.ClusterFacade;
 import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.management.RepairStatusHandler;
 import io.cassandrareaper.management.jmx.CassandraManagementProxyTest;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 import io.cassandrareaper.storage.IDistributedStorage;
 import io.cassandrareaper.storage.IStorageDao;
@@ -261,11 +262,10 @@ public final class RepairRunnerTest {
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
     final Semaphore mutex = new Semaphore(0);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     Map<String, String> endpointToHostIDMap = endpointToHostIDMap();
     when(jmx.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -351,7 +351,7 @@ public final class RepairRunnerTest {
         context.storage.getRepairRunDao());
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -416,9 +416,8 @@ public final class RepairRunnerTest {
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
     final Semaphore mutex = new Semaphore(0);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.sixNodeCluster());
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -502,7 +501,7 @@ public final class RepairRunnerTest {
         context.storage.getRepairRunDao());
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -561,9 +560,8 @@ public final class RepairRunnerTest {
     final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState(),
         RepairSegment.State.NOT_STARTED);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
     when(jmx.getEndpointToHostId()).thenReturn(nodeMap);
     when(jmx.getTokens()).thenReturn(tokens);
@@ -632,7 +630,7 @@ public final class RepairRunnerTest {
             });
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -691,9 +689,8 @@ public final class RepairRunnerTest {
     final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState(),
         RepairSegment.State.NOT_STARTED);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
     when(jmx.getEndpointToHostId()).thenReturn(nodeMap);
     when(jmx.getTokens()).thenReturn(tokens);
@@ -760,7 +757,7 @@ public final class RepairRunnerTest {
             });
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -888,9 +885,8 @@ public final class RepairRunnerTest {
     final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState(),
         RepairSegment.State.NOT_STARTED);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
 
     when(jmx.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
@@ -960,7 +956,7 @@ public final class RepairRunnerTest {
             });
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -1087,9 +1083,8 @@ public final class RepairRunnerTest {
     final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState(),
         RepairSegment.State.NOT_STARTED);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn(cluster.getName());
-    when(jmx.isConnectionAlive()).thenReturn(true);
     when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
     when(jmx.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
     when(jmx.getTokens()).thenReturn(tokens);
@@ -1159,7 +1154,7 @@ public final class RepairRunnerTest {
             });
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -1237,7 +1232,7 @@ public final class RepairRunnerTest {
     Mockito.when(context.storage.getClusterDao()).thenReturn(mockedClusterDao);
     Mockito.when(mockedClusterDao.getCluster(any())).thenReturn(cluster);
     JmxManagementConnectionFactory jmxManagementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy jmx = mock(ICassandraManagementProxy.class);
+    JmxCassandraManagementProxy jmx = mock(JmxCassandraManagementProxy.class);
     when(jmxManagementConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     when(jmx.getClusterName()).thenReturn(cluster.getName());
     when(jmx.isConnectionAlive()).thenReturn(true);
@@ -1312,9 +1307,8 @@ public final class RepairRunnerTest {
     final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
     assertEquals(storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState(),
         RepairSegment.State.NOT_STARTED);
-    final ICassandraManagementProxy proxy = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy proxy = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(proxy.getClusterName()).thenReturn(cluster.getName());
-    when(proxy.isConnectionAlive()).thenReturn(true);
     when(proxy.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
     when(proxy.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
     when(proxy.getTokens()).thenReturn(tokens);
@@ -1422,7 +1416,7 @@ public final class RepairRunnerTest {
     Mockito.when(context.storage.getClusterDao()).thenReturn(mockedClusterDao);
     Mockito.when(mockedClusterDao.getCluster(any())).thenReturn(cluster);
     JmxManagementConnectionFactory jmxManagementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy jmx = mock(ICassandraManagementProxy.class);
+    JmxCassandraManagementProxy jmx = mock(JmxCassandraManagementProxy.class);
     when(jmxManagementConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     when(jmx.getClusterName()).thenReturn(cluster.getName());
     when(jmx.isConnectionAlive()).thenReturn(true);
@@ -1519,7 +1513,7 @@ public final class RepairRunnerTest {
     Mockito.when(context.storage.getClusterDao()).thenReturn(mockedClusterDao);
     Mockito.when(mockedClusterDao.getCluster(any())).thenReturn(cluster);
     JmxManagementConnectionFactory jmxManagementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy jmx = mock(ICassandraManagementProxy.class);
+    JmxCassandraManagementProxy jmx = mock(JmxCassandraManagementProxy.class);
     when(jmxManagementConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     when(jmx.getClusterName()).thenReturn(cluster.getName());
     when(jmx.isConnectionAlive()).thenReturn(true);
@@ -1621,7 +1615,7 @@ public final class RepairRunnerTest {
 
     Mockito.when(mockedClusterDao.getCluster(any())).thenReturn(cluster);
     JmxManagementConnectionFactory jmxManagementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy jmx = mock(ICassandraManagementProxy.class);
+    JmxCassandraManagementProxy jmx = mock(JmxCassandraManagementProxy.class);
     when(jmxManagementConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     when(jmx.getClusterName()).thenReturn(cluster.getName());
     when(jmx.isConnectionAlive()).thenReturn(true);
@@ -1704,7 +1698,7 @@ public final class RepairRunnerTest {
     Mockito.when(context.storage.getClusterDao()).thenReturn(mockedClusterDao);
     Mockito.when(mockedClusterDao.getCluster(any())).thenReturn(cluster);
     JmxManagementConnectionFactory jmxManagementConnectionFactory = mock(JmxManagementConnectionFactory.class);
-    ICassandraManagementProxy jmx = mock(ICassandraManagementProxy.class);
+    JmxCassandraManagementProxy jmx = mock(JmxCassandraManagementProxy.class);
     when(jmxManagementConnectionFactory.connectAny(any(Collection.class))).thenReturn(jmx);
     when(jmx.getClusterName()).thenReturn(cluster.getName());
     when(jmx.isConnectionAlive()).thenReturn(true);

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -196,12 +196,12 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
 
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
     when(clusterFacade.listActiveCompactions(any())).thenReturn(CompactionStats.builder().withActiveCompactions(
         Collections.emptyList()).withPendingCompactions(Optional.of(0)).build());
 
@@ -350,7 +350,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
@@ -497,7 +497,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
@@ -639,7 +639,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
@@ -781,7 +781,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
@@ -925,7 +925,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
@@ -1070,7 +1070,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
@@ -1201,7 +1201,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
@@ -1295,7 +1295,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));
@@ -1404,7 +1404,7 @@ public final class SegmentRunnerTest {
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
-    when(clusterFacade.nodeIsAccessibleThroughJmx(any(), any())).thenReturn(true);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
 
     when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
         .thenReturn(Lists.newArrayList(cf.getNodes()));

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -33,6 +33,7 @@ import io.cassandrareaper.management.ClusterFacade;
 import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.management.RepairStatusHandler;
 import io.cassandrareaper.management.jmx.CassandraManagementProxyTest;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
 import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
 import io.cassandrareaper.storage.IStorageDao;
 import io.cassandrareaper.storage.MemoryStorageFacade;
@@ -141,9 +142,8 @@ public final class SegmentRunnerTest {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     final MutableObject<Future<?>> future = new MutableObject<>();
 
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -185,7 +185,7 @@ public final class SegmentRunnerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      public ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      public JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -266,9 +266,8 @@ public final class SegmentRunnerTest {
     context.config = Mockito.mock(ReaperApplicationConfiguration.class);
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
     try {
@@ -340,7 +339,7 @@ public final class SegmentRunnerTest {
             });
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -423,9 +422,8 @@ public final class SegmentRunnerTest {
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
 
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -488,7 +486,7 @@ public final class SegmentRunnerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -571,9 +569,8 @@ public final class SegmentRunnerTest {
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
 
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -631,7 +628,7 @@ public final class SegmentRunnerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -714,9 +711,8 @@ public final class SegmentRunnerTest {
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
 
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -774,7 +770,7 @@ public final class SegmentRunnerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -859,9 +855,8 @@ public final class SegmentRunnerTest {
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
 
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -919,7 +914,7 @@ public final class SegmentRunnerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -1005,9 +1000,8 @@ public final class SegmentRunnerTest {
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
 
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -1065,7 +1059,7 @@ public final class SegmentRunnerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -1179,9 +1173,8 @@ public final class SegmentRunnerTest {
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
 
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -1197,7 +1190,7 @@ public final class SegmentRunnerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -1274,9 +1267,8 @@ public final class SegmentRunnerTest {
     when(context.config.getJmxConnectionTimeoutInSeconds()).thenReturn(30);
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
 
-    final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
 
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
@@ -1292,7 +1284,7 @@ public final class SegmentRunnerTest {
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
       @Override
-      protected ICassandraManagementProxy connectImpl(Node host) throws ReaperException {
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
         return jmx;
       }
     };
@@ -1395,7 +1387,6 @@ public final class SegmentRunnerTest {
     when(context.config.getDatacenterAvailability()).thenReturn(DatacenterAvailability.ALL);
     final ICassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
     when(jmx.getClusterName()).thenReturn("reaper");
-    when(jmx.isConnectionAlive()).thenReturn(true);
     EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
     when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
     try {


### PR DESCRIPTION
This refactors the current state of ICassandraManagementProxy a little by removing JMX specific methods from the interface as they're not going to be implemented by the HTTP server.