### PR TITLE
Add new Management API client dependency and initialisation code.

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -271,6 +271,11 @@
             <artifactId>jmxremote_optional-repackaged</artifactId>
             <version>5.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.k8ssandra</groupId>
+            <artifactId>datastax-mgmtapi-client-openapi</artifactId>
+            <version>0.1.0-507f418</version>
+        </dependency>
         <!--test scope -->
 
         <dependency>
@@ -773,6 +778,17 @@
             </releases>
             <snapshots>
             <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>thelastpickle-reaper-mvn</id>
+            <url>https://dl.cloudsmith.io/public/thelastpickle/reaper-mvn/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
     </repositories>

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -41,13 +41,19 @@ import javax.management.openmbean.TabularData;
 import javax.validation.constraints.NotNull;
 
 import com.codahale.metrics.MetricRegistry;
+import com.datastax.mgmtapi.client.api.DefaultApi;
+import com.datastax.mgmtapi.client.invoker.ApiClient;
 import org.apache.cassandra.repair.RepairParallelism;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
+  private static final Logger LOG = LoggerFactory.getLogger(HttpCassandraManagementProxy.class);
   String host;
   MetricRegistry metricRegistry;
   String rootPath;
   InetSocketAddress endpoint;
+  DefaultApi apiClient;
 
   public HttpCassandraManagementProxy(MetricRegistry metricRegistry,
                                       String rootPath,
@@ -56,6 +62,8 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
     this.metricRegistry = metricRegistry;
     this.rootPath = rootPath;
     this.endpoint = endpoint;
+    this.apiClient = new DefaultApi(
+        new ApiClient().setBasePath("https://" + endpoint.getHostName() + ":" + endpoint.getPort() + rootPath));
   }
 
   @Override


### PR DESCRIPTION
This PR adds the management API client to Reaper and initialises it. It is taken mainly from [this](https://github.com/Miles-Garnsey/cassandra-reaper/pull/2/files) PR, with thanks to @emerkle826 .

**Fixes**
#1353 