### PR TITLE
Refactor getSnapshotDetails 

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/SnapshotProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/SnapshotProxy.java
@@ -21,26 +21,13 @@ import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Snapshot;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.management.openmbean.TabularData;
 
-import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public final class SnapshotProxy {
-
-  private static final long KB_FACTOR = 1000;
-  private static final long KIB_FACTOR = 1024;
-  private static final long MB_FACTOR = 1000 * KB_FACTOR;
-  private static final long GB_FACTOR = 1000 * MB_FACTOR;
-  private static final long MIB_FACTOR = 1024 * KIB_FACTOR;
-  private static final long GIB_FACTOR = 1024 * MIB_FACTOR;
-
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotProxy.class);
 
   private final ICassandraManagementProxy proxy;
@@ -52,31 +39,6 @@ public final class SnapshotProxy {
   public static SnapshotProxy create(ICassandraManagementProxy proxy) {
 
     return new SnapshotProxy((ICassandraManagementProxy) proxy);
-  }
-
-  public static double parseHumanReadableSize(String readableSize) {
-    int spaceNdx = readableSize.indexOf(" ");
-
-    double ret = readableSize.contains(".")
-        ? Double.parseDouble(readableSize.substring(0, spaceNdx))
-        : Double.parseDouble(readableSize.substring(0, spaceNdx).replace(",", "."));
-
-    switch (readableSize.substring(spaceNdx + 1)) {
-      case "GB":
-        return ret * GB_FACTOR;
-      case "GiB":
-        return ret * GIB_FACTOR;
-      case "MB":
-        return ret * MB_FACTOR;
-      case "MiB":
-        return ret * MIB_FACTOR;
-      case "KB":
-        return ret * KB_FACTOR;
-      case "KiB":
-        return ret * KIB_FACTOR;
-      default:
-        return 0;
-    }
   }
 
   public void clearSnapshot(String repairId, String keyspaceName) {
@@ -104,62 +66,7 @@ public final class SnapshotProxy {
   }
 
   public List<Snapshot> listSnapshots() throws UnsupportedOperationException {
-    List<Snapshot> snapshots = Lists.newArrayList();
-
-    String cassandraVersion = proxy.getCassandraVersion();
-    if (ICassandraManagementProxy.versionCompare(cassandraVersion, "2.1.0") < 0) {
-      // 2.0 and prior do not allow to list snapshots
-      throw new UnsupportedOperationException(
-          "Snapshot listing is not supported in Cassandra 2.0 and prior.");
-    }
-
-    Map<String, TabularData> snapshotDetails = Collections.emptyMap();
-    try {
-      snapshotDetails = proxy.getSnapshotDetails();
-    } catch (RuntimeException ex) {
-      LOG.warn("failed getting snapshots details from " + proxy.getClusterName(), ex);
-    }
-
-    if (snapshotDetails.isEmpty()) {
-      LOG.debug("There are no snapshots on host {}", proxy.getHost());
-      return snapshots;
-    }
-    // display column names only once
-    final List<String> indexNames
-        = snapshotDetails.entrySet().iterator().next().getValue().getTabularType().getIndexNames();
-
-    for (final Map.Entry<String, TabularData> snapshotDetail : snapshotDetails.entrySet()) {
-      Set<?> values = snapshotDetail.getValue().keySet();
-      for (Object eachValue : values) {
-        int index = 0;
-        Snapshot.Builder snapshotBuilder = Snapshot.builder().withHost(proxy.getHost());
-        final List<?> valueList = (List<?>) eachValue;
-        for (Object value : valueList) {
-          switch (indexNames.get(index)) {
-            case "Snapshot name":
-              snapshotBuilder.withName((String) value);
-              break;
-            case "Keyspace name":
-              snapshotBuilder.withKeyspace((String) value);
-              break;
-            case "Column family name":
-              snapshotBuilder.withTable((String) value);
-              break;
-            case "True size":
-              snapshotBuilder.withTrueSize(parseHumanReadableSize((String) value));
-              break;
-            case "Size on disk":
-              snapshotBuilder.withSizeOnDisk(parseHumanReadableSize((String) value));
-              break;
-            default:
-              break;
-          }
-          index++;
-        }
-        snapshots.add(snapshotBuilder.withClusterName(proxy.getClusterName()).build());
-      }
-    }
-    return snapshots;
+    return proxy.listSnapshots();
   }
 
   public String takeSnapshot(String snapshotName, String... keyspaceNames) throws ReaperException {

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -18,6 +18,7 @@
 package io.cassandrareaper.management.http;
 
 import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.Snapshot;
 import io.cassandrareaper.core.Table;
 import io.cassandrareaper.management.ICassandraManagementProxy;
 import io.cassandrareaper.management.RepairStatusHandler;
@@ -37,7 +38,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.management.JMException;
 import javax.management.openmbean.CompositeData;
-import javax.management.openmbean.TabularData;
 import javax.validation.constraints.NotNull;
 
 import com.codahale.metrics.MetricRegistry;
@@ -187,9 +187,8 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
     // TODO: implement me.
   }
 
-  public Map<String, TabularData> getSnapshotDetails() {
-    // TODO: implement me.
-    return new HashMap<>();
+  public List<Snapshot> listSnapshots() throws UnsupportedOperationException {
+    return new ArrayList<Snapshot>();
   }
 
   public void takeSnapshot(String var1, String... var2) throws IOException {

--- a/src/server/src/test/java/io/cassandrareaper/service/SnapshotServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SnapshotServiceTest.java
@@ -105,7 +105,7 @@ public final class SnapshotServiceTest {
     ICassandraManagementProxy proxy = (ICassandraManagementProxy) mock(
         Class.forName("io.cassandrareaper.management.jmx.JmxCassandraManagementProxy"));
     when(proxy.getCassandraVersion()).thenReturn("2.1.0");
-    when(proxy.getSnapshotDetails()).thenReturn(Collections.emptyMap());
+    when(proxy.listSnapshots()).thenReturn(Collections.emptyList());
 
     AppContext cxt = new AppContext();
     cxt.config = TestRepairConfiguration.defaultConfig();
@@ -119,7 +119,7 @@ public final class SnapshotServiceTest {
         .listSnapshots(Node.builder().withHostname("127.0.0.1").build());
 
     Assertions.assertThat(result).isEmpty();
-    verify(proxy, times(1)).getSnapshotDetails();
+    verify(proxy, times(1)).listSnapshots();
   }
 
   @Test


### PR DESCRIPTION
Refactor getSnapshotDetails into JMX management impl as it is JMX specific. Put listSnapshots into ICassandraManagementProxy and implement in both HTTP and JMX impls.

**Fixes issue:**
#1357 