### PR TITLE
Implement schema methods in the HttpManagementProxy (fixes #1344)

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -274,7 +274,7 @@
         <dependency>
             <groupId>io.k8ssandra</groupId>
             <artifactId>datastax-mgmtapi-client-openapi</artifactId>
-            <version>0.1.0-4d2a772</version>
+            <version>0.1.0-5506d26</version>
         </dependency>
         <!--test scope -->
 

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -32,6 +32,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.management.JMException;
 import javax.management.openmbean.CompositeData;
 import javax.validation.constraints.NotNull;
@@ -159,12 +161,27 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
 
   @Override
   public List<String> getKeyspaces() {
-    return null; // TODO: implement me.
+    try {
+      return apiClient.listKeyspaces("");
+    } catch (ApiException ae) {
+      LOG.error("Failed to list keyspaces", ae);
+      return Collections.emptyList();
+    }
   }
 
   @Override
   public Set<Table> getTablesForKeyspace(String keyspace) throws ReaperException {
-    return null; // TODO: implement me.
+    try {
+      return apiClient.listTablesV1(keyspace).stream()
+          .map(t ->
+              Table.builder()
+                  .withName(t.getName())
+                  .withCompactionStrategy(t.getCompaction().get("class"))
+                  .build())
+          .collect(Collectors.toSet());
+    } catch (ApiException e) {
+      throw new ReaperException("Error querying table data", e);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes #1344 

Prerequisites:
- [x] merge k8ssandra/management-api-for-apache-cassandra#352
- [x] update the `datastax-mgmtapi-client-openapi` version in `src/server/pom.xml`.