### PR TITLE
Repair http methods

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,27 +78,11 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        cassandra-version: [ "binary:1.2.19", "binary:2.0.17", 'binary:2.1.22', 'binary:2.2.19', 'binary:3.0.25', 'binary:3.11.11', 'binary:4.0.1' ]
+        cassandra-version: [ 'binary:3.0.25', 'binary:3.11.11', 'binary:4.0.1' ]
         storage-type: [local]
         test-type: [ccm]
         include:
           # don't run against the following C* versions when using cassandra storage type
-          - cassandra-version: "binary:1.2.19"
-            cucumber-options: '--tags ~@cassandra_2_1_onwards --tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-            experimental: false
-            jdk-version: '8'
-          - cassandra-version: "binary:2.0.17"
-            cucumber-options: '--tags ~@cassandra_2_1_onwards --tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-            experimental: false
-            jdk-version: '8'
-          - cassandra-version: 'binary:2.1.22'
-            cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-            experimental: false
-            jdk-version: '8'
-          - cassandra-version: 'binary:2.2.19'
-            cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
-            experimental: false
-            jdk-version: '8'
           - cassandra-version: 'binary:3.0.25'
             cucumber-options: '--tags ~@cassandra_4_0_onwards --tags ~@cassandra_3_11_onwards'
             experimental: false

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -274,7 +274,7 @@
         <dependency>
             <groupId>io.k8ssandra</groupId>
             <artifactId>datastax-mgmtapi-client-openapi</artifactId>
-            <version>0.1.0-4778105</version>
+            <version>0.1.0-39f2fc4</version>
         </dependency>
         <!--test scope -->
 

--- a/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
@@ -118,8 +118,6 @@ public interface ICassandraManagementProxy {
    * @return Repair command number, or 0 if nothing to repair
    */
   int triggerRepair(
-      BigInteger beginToken,
-      BigInteger endToken,
       String keyspace,
       RepairParallelism repairParallelism,
       Collection<String> columnFamilies,

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -224,8 +224,6 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
 
   @Override
   public int triggerRepair(
-      BigInteger beginToken,
-      BigInteger endToken,
       String keyspace,
       RepairParallelism repairParallelism,
       Collection<String> columnFamilies,

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -56,6 +56,7 @@ import com.datastax.mgmtapi.client.invoker.ApiException;
 import com.datastax.mgmtapi.client.model.EndpointStates;
 import com.datastax.mgmtapi.client.model.Job;
 import com.datastax.mgmtapi.client.model.RepairRequest;
+import com.datastax.mgmtapi.client.model.RepairRequestResponse;
 import com.datastax.mgmtapi.client.model.SnapshotDetails;
 import com.datastax.mgmtapi.client.model.StatusChange;
 import com.datastax.mgmtapi.client.model.TakeSnapshotRequest;
@@ -237,7 +238,8 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
 
     String jobId;
     try {
-      jobId = apiClient.repair1(new RepairRequest());
+      RepairRequestResponse resp = apiClient.putRepairV2(new RepairRequest());
+      jobId = resp.getRepairId();
     } catch (ApiException e) {
       throw new ReaperException(e);
     }

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -250,13 +250,10 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
               .associatedTokens(
                   associatedTokens.stream().map(i ->
                       (new com.datastax.mgmtapi.client.model.RingRange())
-                          .start(i.getStart().intValue()) // TODO: figure out why we can't instantiate with the
-                          // BigInteger directly
-                          .end(i.getEnd().intValue())
-              ).collect(Collectors.toList()))
-
-
-
+                          .start(i.getStart().longValue())
+                          .end(i.getEnd().longValue())
+                ).collect(Collectors.toList())
+              )
       );
       jobId = resp.getRepairId();
     } catch (ApiException e) {

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -318,8 +318,6 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
             context.storage.getRepairSegmentDao().updateRepairSegment(segment);
 
             repairNo = coordinator.triggerRepair(
-                segment.getStartToken(),
-                segment.getEndToken(),
                 keyspace,
                 validationParallelism,
                 tablesToRepair,

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -24,6 +24,7 @@ import io.cassandrareaper.management.http.models.JobStatusTracker;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -33,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.datastax.mgmtapi.client.api.DefaultApi;
 import com.datastax.mgmtapi.client.model.Job;
+import com.datastax.mgmtapi.client.model.RepairRequest;
 import com.datastax.mgmtapi.client.model.RepairRequestResponse;
 import com.datastax.mgmtapi.client.model.SnapshotDetails;
 import com.datastax.mgmtapi.client.model.StatusChange;
@@ -51,6 +53,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -148,17 +152,13 @@ public class HttpCassandraManagementProxyTest {
 
   @Test
   public void testNotificationsTracker() throws Exception {
-    DefaultApi mockClient = Mockito.mock(DefaultApi.class);
-
-    HttpCassandraManagementProxy httpCassandraManagementProxy = mockProxy(mockClient);
-    HttpManagementConnectionFactory connectionFactory = Mockito.mock(HttpManagementConnectionFactory.class);
     DefaultApi mockClient = mock(DefaultApi.class);
     doReturn((new RepairRequestResponse()).repairId("repair-123456789")).when(mockClient).putRepairV2(any());
+    HttpCassandraManagementProxy httpCassandraManagementProxy = mockProxy(mockClient);
+    HttpManagementConnectionFactory connectionFactory = Mockito.mock(HttpManagementConnectionFactory.class);
+
     ScheduledExecutorService executorService = mock(ScheduledExecutorService.class);
     doReturn(ConcurrentUtils.constantFuture(null)).when(executorService).submit(any(Callable.class));
-    HttpCassandraManagementProxy httpCassandraManagementProxy = new HttpCassandraManagementProxy(
-        mock(MetricRegistry.class), "",
-        mock(InetSocketAddress.class), executorService, mockClient);
     when(connectionFactory.connectAny(any())).thenReturn(httpCassandraManagementProxy);
 
     // Since we don't have existing implementation of RepairStatusHandler interface, we'll create a small "mock
@@ -171,6 +171,18 @@ public class HttpCassandraManagementProxyTest {
         RepairParallelism.PARALLEL,
         Collections.singleton("table"), true, Collections.emptyList(), workAroundHandler,
         Collections.emptyList(), 1);
+
+    verify(mockClient).putRepairV2(eq(
+        (new RepairRequest())
+          .keyspace("ks")
+          .repairParallelism(RepairRequest.RepairParallelismEnum.PARALLEL)
+          .tables(Arrays.asList("table"))
+          .fullRepair(true)
+          .datacenters(null)
+          .repairThreadCount(1)
+          .associatedTokens(Collections.emptyList())
+        )
+    );
 
     // We want the execution to happen in the same thread for this test
     httpCassandraManagementProxy.repairStatusExecutors.put(repairNo, MoreExecutors.newDirectExecutorService());
@@ -253,4 +265,16 @@ public class HttpCassandraManagementProxyTest {
     return new HttpCassandraManagementProxy(
         null, "/", InetSocketAddress.createUnresolved("localhost", 8080), executorService, mockClient);
   }
+
+  @Test
+  public void testCancelAllRepairs() throws Exception {
+    DefaultApi mockClient = Mockito.mock(DefaultApi.class);
+    HttpCassandraManagementProxy httpCassandraManagementProxy = mockProxy(mockClient);
+
+    httpCassandraManagementProxy.cancelAllRepairs();
+    verify(mockClient).deleteRepairsV2();
+    verifyNoMoreInteractions(mockClient);
+  }
+
+
 }

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -22,7 +22,6 @@ import io.cassandrareaper.core.Table;
 import io.cassandrareaper.management.RepairStatusHandler;
 import io.cassandrareaper.management.http.models.JobStatusTracker;
 
-import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -124,7 +123,7 @@ public class HttpCassandraManagementProxyTest {
 
     RepairStatusHandler repairStatusHandler = Mockito.mock(RepairStatusHandler.class);
 
-    int repairNo = httpCassandraManagementProxy.triggerRepair(BigInteger.ZERO, BigInteger.ONE, "ks",
+    int repairNo = httpCassandraManagementProxy.triggerRepair("ks",
         RepairParallelism.PARALLEL,
         Collections.singleton("table"), true, Collections.emptyList(), repairStatusHandler, Collections.emptyList(), 1);
 
@@ -157,7 +156,7 @@ public class HttpCassandraManagementProxyTest {
     RepairStatusHandler workAroundHandler = (repairNumber, status, progress, message, cassandraManagementProxy)
         -> callTimes.incrementAndGet();
 
-    int repairNo = httpCassandraManagementProxy.triggerRepair(BigInteger.ZERO, BigInteger.ONE, "ks",
+    int repairNo = httpCassandraManagementProxy.triggerRepair("ks",
         RepairParallelism.PARALLEL,
         Collections.singleton("table"), true, Collections.emptyList(), workAroundHandler,
         Collections.emptyList(), 1);

--- a/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/resources/RepairRunResourceTest.java
@@ -156,8 +156,6 @@ public final class RepairRunResourceTest {
     when(proxy.getTokens()).thenReturn(TOKENS);
     when(proxy.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
     when(proxy.triggerRepair(
-        any(BigInteger.class),
-        any(BigInteger.class),
         anyString(),
         any(RepairParallelism.class),
         anyCollection(),

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -274,7 +274,7 @@ public final class RepairRunnerTest {
       throw new AssertionError(ex);
     }
     final AtomicInteger repairAttempts = new AtomicInteger(1);
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               assertEquals(RepairSegment.State.STARTED,
@@ -426,7 +426,7 @@ public final class RepairRunnerTest {
       throw new AssertionError(ex);
     }
     final AtomicInteger repairAttempts = new AtomicInteger(1);
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               assertEquals(
@@ -594,7 +594,7 @@ public final class RepairRunnerTest {
         context.storage.getRepairRunDao());
     AtomicInteger repairNumberCounter = new AtomicInteger(1);
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               final int repairNumber = repairNumberCounter.getAndIncrement();
@@ -721,7 +721,7 @@ public final class RepairRunnerTest {
         1,
         context.storage.getRepairRunDao());
     AtomicInteger repairNumberCounter = new AtomicInteger(1);
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               final int repairNumber = repairNumberCounter.getAndIncrement();
@@ -921,7 +921,7 @@ public final class RepairRunnerTest {
         1,
         context.storage.getRepairRunDao());
     AtomicInteger repairNumberCounter = new AtomicInteger(1);
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               final int repairNumber = repairNumberCounter.getAndIncrement();
@@ -1119,7 +1119,7 @@ public final class RepairRunnerTest {
         1,
         context.storage.getRepairRunDao());
     AtomicInteger repairNumberCounter = new AtomicInteger(1);
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               final int repairNumber = repairNumberCounter.getAndIncrement();

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -285,7 +285,7 @@ public final class RepairRunnerTest {
                   new Thread() {
                     @Override
                     public void run() {
-                      ((RepairStatusHandler) invocation.getArgument(7))
+                      ((RepairStatusHandler) invocation.getArgument(5))
                           .handle(repairNumber,
                               Optional.of(ActiveRepairService.Status.STARTED),
                               Optional.empty(), null, jmx);
@@ -299,7 +299,7 @@ public final class RepairRunnerTest {
                   new Thread() {
                     @Override
                     public void run() {
-                      ((RepairStatusHandler) invocation.getArgument(7))
+                      ((RepairStatusHandler) invocation.getArgument(5))
                           .handle(
                               repairNumber,
                               Optional.of(ActiveRepairService.Status.STARTED),
@@ -307,7 +307,7 @@ public final class RepairRunnerTest {
                       assertEquals(
                           RepairSegment.State.RUNNING,
                           storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
-                      ((RepairStatusHandler) invocation.getArgument(7))
+                      ((RepairStatusHandler) invocation.getArgument(5))
                           .handle(
                               repairNumber,
                               Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
@@ -315,7 +315,7 @@ public final class RepairRunnerTest {
                       assertEquals(
                           RepairSegment.State.DONE,
                           storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
-                      ((RepairStatusHandler) invocation.getArgument(7))
+                      ((RepairStatusHandler) invocation.getArgument(5))
                           .handle(repairNumber,
                               Optional.of(ActiveRepairService.Status.FINISHED),
                               Optional.empty(), null, jmx);
@@ -438,7 +438,7 @@ public final class RepairRunnerTest {
                   new Thread() {
                     @Override
                     public void run() {
-                      ((RepairStatusHandler) invocation.getArgument(7))
+                      ((RepairStatusHandler) invocation.getArgument(5))
                           .handle(
                               repairNumber, Optional.empty(),
                               Optional.of(ProgressEventType.START), null, jmx);
@@ -452,21 +452,21 @@ public final class RepairRunnerTest {
                   new Thread() {
                     @Override
                     public void run() {
-                      ((RepairStatusHandler) invocation.getArgument(7))
+                      ((RepairStatusHandler) invocation.getArgument(5))
                           .handle(
                               repairNumber, Optional.empty(),
                               Optional.of(ProgressEventType.START), null, jmx);
                       assertEquals(
                           RepairSegment.State.RUNNING,
                           storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
-                      ((RepairStatusHandler) invocation.getArgument(7))
+                      ((RepairStatusHandler) invocation.getArgument(5))
                           .handle(
                               repairNumber, Optional.empty(),
                               Optional.of(ProgressEventType.SUCCESS), null, jmx);
                       assertEquals(
                           RepairSegment.State.DONE,
                           storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
-                      ((RepairStatusHandler) invocation.getArgument(7))
+                      ((RepairStatusHandler) invocation.getArgument(5))
                           .handle(
                               repairNumber, Optional.empty(),
                               Optional.of(ProgressEventType.COMPLETE), null, jmx);
@@ -602,21 +602,21 @@ public final class RepairRunnerTest {
               new Thread() {
                 @Override
                 public void run() {
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.STARTED),
                           Optional.empty(),
                           null,
                           jmx);
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
                           Optional.empty(),
                           null,
                           jmx);
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.FINISHED),
@@ -729,21 +729,21 @@ public final class RepairRunnerTest {
               new Thread() {
                 @Override
                 public void run() {
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.STARTED),
                           Optional.empty(),
                           null,
                           jmx);
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
                           Optional.empty(),
                           null,
                           jmx);
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.FINISHED),
@@ -928,21 +928,21 @@ public final class RepairRunnerTest {
               new Thread() {
                 @Override
                 public void run() {
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.STARTED),
                           Optional.empty(),
                           null,
                           jmx);
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
                           Optional.empty(),
                           null,
                           jmx);
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.FINISHED),
@@ -1126,21 +1126,21 @@ public final class RepairRunnerTest {
               new Thread() {
                 @Override
                 public void run() {
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.STARTED),
                           Optional.empty(),
                           null,
                           jmx);
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
                           Optional.empty(),
                           null,
                           jmx);
-                  ((RepairStatusHandler) invocation.getArgument(7))
+                  ((RepairStatusHandler) invocation.getArgument(5))
                       .handle(
                           repairNumber,
                           Optional.of(ActiveRepairService.Status.FINISHED),

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -154,7 +154,7 @@ public final class SegmentRunnerTest {
     }
 
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               assertEquals(
@@ -276,7 +276,7 @@ public final class SegmentRunnerTest {
       throw new AssertionError(ex);
     }
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               assertEquals(
@@ -434,7 +434,7 @@ public final class SegmentRunnerTest {
     }
 
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             (invocation) -> {
               assertEquals(
@@ -581,7 +581,7 @@ public final class SegmentRunnerTest {
     }
 
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             invocation -> {
               assertEquals(
@@ -723,7 +723,7 @@ public final class SegmentRunnerTest {
     }
 
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             invocation -> {
               assertEquals(
@@ -867,7 +867,7 @@ public final class SegmentRunnerTest {
     }
 
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             invocation -> {
               assertEquals(
@@ -1012,7 +1012,7 @@ public final class SegmentRunnerTest {
     }
 
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .then(
             invocation -> {
               assertEquals(
@@ -1185,7 +1185,7 @@ public final class SegmentRunnerTest {
     }
 
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .thenThrow(new ReaperException("failure"));
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
@@ -1279,7 +1279,7 @@ public final class SegmentRunnerTest {
     }
 
 
-    when(jmx.triggerRepair(any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
+    when(jmx.triggerRepair(any(), any(), any(), anyBoolean(), any(), any(), any(), anyInt()))
         .thenReturn(0);
 
     context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -166,7 +166,7 @@ public final class SegmentRunnerTest {
                       new Thread() {
                         @Override
                         public void run() {
-                          ((RepairStatusHandler) invocation.getArgument(7))
+                          ((RepairStatusHandler) invocation.getArgument(5))
                               .handle(
                                   1,
                                   Optional.of(ActiveRepairService.Status.STARTED),
@@ -286,7 +286,7 @@ public final class SegmentRunnerTest {
               future.setValue(
                   executor.submit(
                       () -> {
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.STARTED),
@@ -300,7 +300,7 @@ public final class SegmentRunnerTest {
 
                         // test an unrelated repair. Should throw exception
                         try {
-                          ((RepairStatusHandler) invocation.getArgument(7))
+                          ((RepairStatusHandler) invocation.getArgument(5))
                               .handle(
                                   2,
                                   Optional.of(ActiveRepairService.Status.SESSION_FAILED),
@@ -311,7 +311,7 @@ public final class SegmentRunnerTest {
                         } catch (IllegalArgumentException ignore) {
                         }
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
@@ -323,7 +323,7 @@ public final class SegmentRunnerTest {
                             RepairSegment.State.DONE,
                             storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.FINISHED),
@@ -444,7 +444,7 @@ public final class SegmentRunnerTest {
               future.setValue(
                   executor.submit(
                       () -> {
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.STARTED),
@@ -456,7 +456,7 @@ public final class SegmentRunnerTest {
                             RepairSegment.State.RUNNING,
                             storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.SESSION_FAILED),
@@ -468,7 +468,7 @@ public final class SegmentRunnerTest {
                             RepairSegment.State.NOT_STARTED,
                             storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.FINISHED),
@@ -591,7 +591,7 @@ public final class SegmentRunnerTest {
               future.setValue(
                   executor.submit(
                       () -> {
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.STARTED),
@@ -599,7 +599,7 @@ public final class SegmentRunnerTest {
                                 "Repair command 1 has started",
                                 jmx);
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.FINISHED),
@@ -611,7 +611,7 @@ public final class SegmentRunnerTest {
                             RepairSegment.State.RUNNING,
                             storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
@@ -733,7 +733,7 @@ public final class SegmentRunnerTest {
               future.setValue(
                   executor.submit(
                       () -> {
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.empty(),
@@ -741,7 +741,7 @@ public final class SegmentRunnerTest {
                                 "Repair command 1 has started",
                                 jmx);
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.empty(),
@@ -753,7 +753,7 @@ public final class SegmentRunnerTest {
                             RepairSegment.State.RUNNING,
                             storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.empty(),
@@ -877,7 +877,7 @@ public final class SegmentRunnerTest {
               future.setValue(
                   executor.submit(
                       () -> {
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.STARTED),
@@ -885,7 +885,7 @@ public final class SegmentRunnerTest {
                                 "Repair command 1 has started",
                                 jmx);
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.FINISHED),
@@ -897,7 +897,7 @@ public final class SegmentRunnerTest {
                             RepairSegment.State.RUNNING,
                             storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.of(ActiveRepairService.Status.SESSION_FAILED),
@@ -1022,7 +1022,7 @@ public final class SegmentRunnerTest {
               future.setValue(
                   executor.submit(
                       () -> {
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.empty(),
@@ -1030,7 +1030,7 @@ public final class SegmentRunnerTest {
                                 "Repair command 1 has started",
                                 jmx);
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.empty(),
@@ -1042,7 +1042,7 @@ public final class SegmentRunnerTest {
                             RepairSegment.State.RUNNING,
                             storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState());
 
-                        ((RepairStatusHandler) invocation.getArgument(7))
+                        ((RepairStatusHandler) invocation.getArgument(5))
                             .handle(
                                 1,
                                 Optional.empty(),


### PR DESCRIPTION
Moves to the new HTTP client for triggering/cancelling repairs.

**Fixes issue**
#1343 