### PR TITLE
Use "http" for Management API connection instead of "https"

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -274,7 +274,7 @@
         <dependency>
             <groupId>io.k8ssandra</groupId>
             <artifactId>datastax-mgmtapi-client-openapi</artifactId>
-            <version>0.1.0-5506d26</version>
+            <version>0.1.0-4778105</version>
         </dependency>
         <!--test scope -->
 

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
@@ -126,7 +126,7 @@ public class HttpManagementConnectionFactory implements IManagementConnectionFac
       throw new ReaperException("Could not get PID for node " + node.getHostname());
     }
     DefaultApi apiClient = new DefaultApi(
-        new ApiClient().setBasePath("https://" + node.getHostname() + ":" + managementPort + rootPath));
+        new ApiClient().setBasePath("http://" + node.getHostname() + ":" + managementPort + rootPath));
 
     InstrumentedScheduledExecutorService statusTracker = new InstrumentedScheduledExecutorService(
         jobStatusPollerExecutor, metricRegistry);


### PR DESCRIPTION
This should fix the SSLExceptions on all the HTTP tests and get at least the first couple of tests passing again.