### PR TITLE
Implement `HttpCassandraManagementProxy.getUntranslatedHost()`.

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/EndpointSnitchInfoProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/EndpointSnitchInfoProxy.java
@@ -17,6 +17,8 @@
 
 package io.cassandrareaper.management;
 
+import io.cassandrareaper.ReaperException;
+
 import java.util.concurrent.ExecutionException;
 
 import com.google.common.cache.Cache;
@@ -40,7 +42,7 @@ public final class EndpointSnitchInfoProxy {
   }
 
 
-  public String getDataCenter() {
+  public String getDataCenter() throws ReaperException {
     return getDataCenter(proxy.getUntranslatedHost());
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
@@ -179,7 +179,7 @@ public interface ICassandraManagementProxy {
     return version1.compareTo(version2);
   }
 
-  String getUntranslatedHost();
+  String getUntranslatedHost() throws ReaperException;
 
   static double parseHumanReadableSize(String readableSize) {
     int spaceNdx = readableSize.indexOf(" ");

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -480,9 +480,9 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   }
 
   @Override
-  public String getUntranslatedHost() {
-    //TODO: implement me
-    return "";
+  public String getUntranslatedHost() throws ReaperException {
+    // TODO: we eventually need to implement address translation.
+    return getLocalEndpoint();
   }
 
   private Job getJobStatus(String id) {

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
@@ -828,7 +828,7 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
     return lastEventIdProxy;
   }
 
-  public String getUntranslatedHost() {
+  public String getUntranslatedHost() throws ReaperException {
     return hostBeforeTranslation;
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -570,7 +570,7 @@ final class RepairRunner implements Runnable {
       ICassandraManagementProxy coordinator,
       RepairSegment segment,
       Map<String, String> dcByNode,
-      UUID segmentId) {
+      UUID segmentId) throws ReaperException {
 
     Collection<String> nodes = getNodesInvolvedInSegment(dcByNode);
     LOG.debug("Nodes involved in segment {}: {}", segmentId, nodes);

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -473,7 +473,13 @@ public class HttpCassandraManagementProxyTest {
         null, "/", InetSocketAddress.createUnresolved("localhost", 8080), executorService, mockClient);
     assertThat(mockProxyDns.getLocalEndpoint()).isEqualTo("127.0.0.1");
 
+  }
 
+  @Test
+  public void testGetUntranslatedHost() throws ReaperException {
+    DefaultApi mockClient = Mockito.mock(DefaultApi.class);
+    ICassandraManagementProxy proxy = mockProxy(mockClient);
+    assertThat(proxy.getUntranslatedHost()).isEqualTo("127.0.0.1");
   }
 
 }

--- a/src/server/src/test/java/io/cassandrareaper/management/jmx/CassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/jmx/CassandraManagementProxyTest.java
@@ -31,7 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 public final class CassandraManagementProxyTest {
 
-  public static JmxCassandraManagementProxy mockJmxProxyImpl() throws UnknownHostException {
+  public static JmxCassandraManagementProxy mockJmxProxyImpl() throws UnknownHostException, ReaperException {
     JmxCassandraManagementProxy impl = Mockito.mock(JmxCassandraManagementProxy.class);
     Mockito.when(impl.getUntranslatedHost()).thenReturn("test-host-" + new Random().nextInt());
     Mockito.when(impl.getDatacenter(any())).thenReturn("dc1");


### PR DESCRIPTION
As described above. Note that we aren't doing address translation right now, so this just calls getLocalEndpoint(). 

Fixes #1392 