### PR TITLE
Implement isRepairRunning

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -17,6 +17,7 @@
 
 package io.cassandrareaper.management;
 
+import io.cassandrareaper.ReaperException;
 import io.cassandrareaper.core.Compaction;
 
 import java.io.IOException;
@@ -26,7 +27,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.management.JMException;
 import javax.management.MalformedObjectNameException;
 import javax.management.ReflectionException;
 
@@ -95,7 +95,7 @@ public final class CompactionProxy {
   public Integer getPendingCompactions() {
     try {
       return proxy.getPendingCompactions();
-    } catch (JMException e) {
+    } catch (ReaperException e) {
       LOG.warn("Could not fetch pending compactions from {}", proxy.getHost(), e);
       return -1;
     }

--- a/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import javax.management.JMException;
 import javax.management.openmbean.CompositeData;
 import javax.validation.constraints.NotNull;
 
@@ -87,7 +86,7 @@ public interface ICassandraManagementProxy {
   /**
    * @return number of pending compactions on the node this proxy is connected to
    */
-  int getPendingCompactions() throws JMException;
+  int getPendingCompactions() throws ReaperException;
 
   Map<List<String>, List<String>> getRangeToEndpointMap(String keyspace) throws ReaperException;
 
@@ -101,7 +100,7 @@ public interface ICassandraManagementProxy {
   /**
    * @return true if any repairs are running on the node.
    */
-  boolean isRepairRunning() throws JMException;
+  boolean isRepairRunning() throws ReaperException;
 
   /**
    * Checks if table exists in the cluster by instantiating a MBean for that table.

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -46,7 +46,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import javax.management.JMException;
 import javax.management.openmbean.CompositeData;
 import javax.validation.constraints.NotNull;
 
@@ -229,13 +228,13 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   }
 
   @Override
-  public int getPendingCompactions() throws JMException {
+  public int getPendingCompactions() throws ReaperException {
     return 1; // TODO: implement me.
   }
 
   @Override
-  public boolean isRepairRunning() throws JMException {
-    return true; // TODO: implement me.
+  public boolean isRepairRunning() throws ReaperException {
+    return !jobTracker.isEmpty();
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
@@ -420,7 +420,7 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
   }
 
   @Override
-  public int getPendingCompactions() throws JMException {
+  public int getPendingCompactions() throws ReaperException {
     try {
       int pendingCount = (int) mbeanServer.getAttribute(ObjectNames.COMPACTIONS_PENDING, VALUE_ATTRIBUTE);
       return pendingCount;
@@ -433,14 +433,20 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
       return 0;
     } catch (RuntimeException e) {
       LOG.error(ERROR_GETTING_ATTR_JMX, e);
+    } catch (JMException e) {
+      throw new ReaperException(e);
     }
     // If uncertain, assume it's running
     return 0;
   }
 
   @Override
-  public boolean isRepairRunning() throws JMException {
-    return isRepairRunningPost22() || isValidationCompactionRunning();
+  public boolean isRepairRunning() throws ReaperException {
+    try {
+      return isRepairRunningPost22() || isValidationCompactionRunning();
+    } catch (JMException e) {
+      throw new ReaperException(e);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #1383 
There was a small refactor here to get `JMException` out of the parent interface.