### PR TITLE
Remove close from proxy interface

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/ICassandraManagementProxy.java
@@ -128,8 +128,6 @@ public interface ICassandraManagementProxy {
       int repairThreadCount)
       throws ReaperException;
 
-  void close();
-
   void removeRepairStatusHandler(int repairNo);
 
   // From StorageServiceMBean

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -328,11 +328,6 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   }
 
   @Override
-  public void close() {
-    // TODO: implement me.
-  }
-
-  @Override
   public List<String> getLiveNodes() throws ReaperException {
     try {
       List<String> liveNodes = new ArrayList<>();

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
@@ -749,7 +749,6 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
   /**
    * Cleanly shut down by un-registering the listener and closing the JMX connection.
    */
-  @Override
   public void close() {
     try {
       mbeanServer.removeNotificationListener(ObjectNames.STORAGE_SERVICE, this);


### PR DESCRIPTION
Fixes #1385 

`close()` is really only called by the JMX implementation to get rid of stale JMX connections. We son't have that situation with the Management API client, nor is there any real way to _close_ the client. So this essentially refactors the parent interface to remove `close()` and only implement it within the JMX proxy and factory classes.