### PR TITLE
Use Cassandra Storage in E2E tests for HTTP Management Proxy

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -274,7 +274,7 @@
         <dependency>
             <groupId>io.k8ssandra</groupId>
             <artifactId>datastax-mgmtapi-client-openapi</artifactId>
-            <version>0.1.0-f0f2d06</version>
+            <version>0.1.0-70692f3</version>
         </dependency>
         <!--test scope -->
 

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -274,7 +274,7 @@
         <dependency>
             <groupId>io.k8ssandra</groupId>
             <artifactId>datastax-mgmtapi-client-openapi</artifactId>
-            <version>0.1.0-70692f3</version>
+            <version>0.1.0-7062a75</version>
         </dependency>
         <!--test scope -->
 


### PR DESCRIPTION
We currently observe issues when trying to run the e2e tests against the HTTP management proxy. 

Despite the fact that these appear to work when run against memory storage and using JMX, we see the following error in `nodesReadyForNewRepair()` when we try to use the HTTP management interface:

```
got to the nodesReadyForNewRepair method's for loop, processing nodeMetricsTasks(127.0.0.1,java.util.concurrent.FutureTask@2ea756a8[Completed exceptionally: java.lang.ClassCastException: class io.cassandrareaper.storage.MemoryStorageFacade cannot be cast to class io.cassandrareaper.storage.IDistributedStorage (io.cassandrareaper.storage.MemoryStorageFacade and io.cassandrareaper.storage.IDistributedStorage are in unnamed module of loader 'app')])
```

This indicates that using memory storage will not work because it does not implement IDistributedStorage.

This branch attempts to move to using Cassandra storage instead. It currently encounters errors however, as ClusterResource appears to try to find JMX credentials and still fails.

