### PR TITLE
Fix http factory DC tracking and add notification to triggerRepair

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -274,7 +274,7 @@
         <dependency>
             <groupId>io.k8ssandra</groupId>
             <artifactId>datastax-mgmtapi-client-openapi</artifactId>
-            <version>0.1.0-3727fab</version>
+            <version>0.1.0-f0f2d06</version>
         </dependency>
         <!--test scope -->
 

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -319,6 +319,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
           (new RepairRequest())
               .fullRepair(fullRepair)
               .keyspace(keyspace)
+              .notifications(true)
               .tables(new ArrayList<>(columnFamilies))
               .repairParallelism(RepairRequest.RepairParallelismEnum.fromValue(repairParallelism.getName()))
               .repairThreadCount(repairThreadCount)

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -190,6 +190,7 @@ public class HttpCassandraManagementProxyTest {
                 .repairParallelism(RepairRequest.RepairParallelismEnum.PARALLEL)
                 .tables(Arrays.asList("table"))
                 .fullRepair(true)
+                .notifications(true)
                 .datacenters(null)
                 .repairThreadCount(1)
                 .associatedTokens(Collections.emptyList())


### PR DESCRIPTION
- Fixes the triggerRepair call to add `notifications(true)`.
- Fixes the Http Proxy Factory class so that it actually adds Datacenters to the available list