### PR TITLE
Add version compatibility info to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ be used only for testing purposes.
 This project is built on top of Dropwizard:
 http://dropwizard.io/
 
+Version compatibility 
+------------
+Reaper can be built using Java 8 or 11.  It is tested against Cassandra 3.11 and 4.0.  It is no longer tested against Cassandra 2.x.
+
+We have confirmed the Reaper UI will build with npm 5.6.0, node 10.0.0. 
+
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Version compatibility
 ------------
 Reaper can be built using Java 8 or 11.  It is tested against Cassandra 3.11 and 4.0.  It is no longer tested against Cassandra 2.x.
 
-We have confirmed the Reaper UI will build with npm 5.6.0, node 10.0.0. 
+We have confirmed the Reaper UI will build with npm 5.6.0, node 10.0.0. We believe that more generally versions of npm up to 6.14 and both node 12.x and 14.x will work. Builds are confirmed to fail with node 16+.
+
+We recommend the use of nvm to manage node versions.
 
 
 Dependencies


### PR DESCRIPTION
We don't have any version compatibility info right now. We need to add some because our version of node is ancient.

Fixes: https://github.com/thelastpickle/cassandra-reaper/issues/1411