### PR TITLE
Fix incorrect callback function

### DIFF
--- a/src/ui/app/jsx/cluster-list.jsx
+++ b/src/ui/app/jsx/cluster-list.jsx
@@ -64,8 +64,6 @@ const Cluster = CreateReactClass({
           },
           error: function(data) {
             console.error(this.component.props.name + " failed.");
-            this.component.setState({clusterStatuses: setTimeout(this.component._refreshClusterStatus, 30000)});
-
           }
       });
   },


### PR DESCRIPTION
Fixes #1442

According to JQuery doc (https://api.jquery.com/jQuery.ajax/), `complete` function will be called whether the ajax request succeeds or fails. As a result, `_refreshClusterStatus` will set two new scheduled calls if the ajax request gets an error response (the first one by `error` and the second one by `complete`).

If `_refreshClusterStatus` keeps getting error responses (e.g. token has expired, the ajax request always gets 304 response), it will generate a huge number of requests in 10min (doubles every 30s)
