### PR TITLE
Fix webui login not working in some cases

### DIFF
--- a/src/server/src/main/resources/shiro.ini
+++ b/src/server/src/main/resources/shiro.ini
@@ -13,17 +13,6 @@
 # limitations under the License.
 
 [main]
-sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
-sessionManager.sessionIdCookieEnabled = true
-sessionManager.sessionIdCookie.secure = true
-sessionManager.sessionIdCookie.sameSite = NONE
-securityManager.sessionManager = $sessionManager
-
-rememberMeManager = org.apache.shiro.web.mgt.CookieRememberMeManager
-rememberMeManager.cookie.secure = true
-rememberMeManager.cookie.sameSite = NONE
-securityManager.rememberMeManager = $rememberMeManager 
-
 authc = org.apache.shiro.web.filter.authc.PassThruAuthenticationFilter
 authc.loginUrl = /webui/login.html
 


### PR DESCRIPTION
Fixes #1450 

The recent-ish addition to the shiro.ini to specify settings for the Session and RememberMe managers created some bugs (under circumstances that we couldn't figure out) where any login attempt would fail without any error message despite passing the correct credentials.

Tests in an environment that was exhibiting the bug (on an EC2 instance running both Reaper and Cassandra) allowed to verify that removing those additions to the shiro.ini file would fix the issue.