### PR TITLE
Fix spelling

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
@@ -152,7 +152,7 @@ public class HttpManagementConnectionFactory implements IManagementConnectionFac
             (Gauge<Integer>) HTTP_CONNECTIONS::size);
       }
     } catch (IllegalArgumentException e) {
-      LOG.warn("Cannot create openHttoManagementConnections metric gauge", e);
+      LOG.warn("Cannot create openHttpManagementConnections metric gauge", e);
     }
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -177,7 +177,7 @@ public final class RepairManager implements AutoCloseable {
       Collection<RepairRun> pausedRepairRuns = repairRunDao.getRepairRunsWithState(RepairRun.RunState.PAUSED);
       abortAllRunningSegmentsWithNoLeader(runningRepairRuns);
       abortAllRunningSegmentsInKnownPausedRepairRuns(pausedRepairRuns);
-      resumeUnkownRunningRepairRuns(runningRepairRuns);
+      resumeUnknownRunningRepairRuns(runningRepairRuns);
       resumeUnknownPausedRepairRuns(pausedRepairRuns);
     } catch (RuntimeException e) {
       throw new ReaperException(e);
@@ -199,7 +199,7 @@ public final class RepairManager implements AutoCloseable {
         });
   }
 
-  private void resumeUnkownRunningRepairRuns(Collection<RepairRun> runningRepairRuns) throws ReaperException {
+  private void resumeUnknownRunningRepairRuns(Collection<RepairRun> runningRepairRuns) throws ReaperException {
     try {
       repairRunnersLock.lock();
       for (RepairRun repairRun : runningRepairRuns) {
@@ -247,7 +247,7 @@ public final class RepairManager implements AutoCloseable {
       pausedRepairRuns
           .stream()
           .filter((pausedRepairRun) -> (!repairRunners.containsKey(pausedRepairRun.getId())))
-          // add "paused" repair run to this reaper instance, so it can be visualised in UI
+          // add "paused" repair run to this reaper instance, so it can be visualized in UI
           .forEachOrdered((pausedRepairRun) -> startRunner(pausedRepairRun));
     } finally {
       repairRunnersLock.unlock();

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -648,7 +648,7 @@ public class HttpCassandraManagementProxyTest {
   }
 
   @Test
-  public void testgetEndpointToHostId() throws Exception {
+  public void testGetEndpointToHostId() throws Exception {
     DefaultApi mockClient = Mockito.mock(DefaultApi.class);
     EndpointStates states = new EndpointStates();
     states.addEntityItem(ImmutableMap.of(


### PR DESCRIPTION
Found _Cannot create openHtt**o**ManagementConnections metric gauge_ in logs.
Also fixed a few other typos I saw while opening the source. Might as well contribute them while on it! Go open source :tada: 

Fixes #1471