### PR TITLE
Set segment count per node to consistent value across defaults and docs

### DIFF
--- a/docs/docs/configuration/reaper_specific/index.html
+++ b/docs/docs/configuration/reaper_specific/index.html
@@ -523,7 +523,7 @@ blocking in cause some thread is waiting for I/O, like calling a Cassandra clust
 <!-- raw HTML omitted -->
 <h3 id="segmentcountpernode"><code>segmentCountPerNode</code></h3>
 <p>Type: <em>Integer</em></p>
-<p>Default: <em>16</em></p>
+<p>Default: <em>64</em></p>
 <p>Defines the default amount of repair segments to create for newly registered Cassandra repair runs, for each node in the cluster. When running a repair run by Reaper, each segment is repaired separately by the Reaper process, until all the segments in a token ring are repaired. The count might be slightly off the defined value, as clusters residing in multiple data centers require additional small token ranges in addition to the expected. This value can be overwritten when executing a repair run via Reaper.</p>
 <p>In a 10 nodes cluster, setting a value of 20 segments per node will generate a repair run that splits the work into 200 token subranges. This number can vary due to vnodes (before 1.2.0, Reaper cannot create a segment with multiple token ranges, so the number of segments will be at least the total number of vnodes in the cluster). As Reaper tries to size segments evenly, the presence of very small token ranges can lead to have more segments than expected.</p>
 <!-- raw HTML omitted -->

--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -352,7 +352,7 @@ Defines the amount of days to wait between scheduling new repairs. The value con
 
 Type: *Integer*
 
-Default: *16*
+Default: *64*
 
 Defines the default amount of repair segments to create for newly registered Cassandra repair runs, for each node in the cluster. When running a repair run by Reaper, each segment is repaired separately by the Reaper process, until all the segments in a token ring are repaired. The count might be slightly off the defined value, as clusters residing in multiple data centers require additional small token ranges in addition to the expected. This value can be overwritten when executing a repair run via Reaper.
 

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunService.java
@@ -62,7 +62,7 @@ public final class RepairRunService {
 
   public static final Splitter COMMA_SEPARATED_LIST_SPLITTER
       = Splitter.on(',').trimResults(CharMatcher.anyOf(" ()[]\"'")).omitEmptyStrings();
-  public static final int DEFAULT_SEGMENT_COUNT_PER_NODE = 16;
+  public static final int DEFAULT_SEGMENT_COUNT_PER_NODE = 64;
 
   private static final Logger LOG = LoggerFactory.getLogger(RepairRunService.class);
 

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -196,7 +196,7 @@ public final class RepairRunServiceTest {
   public void computeGlobalSegmentCount256TokenPerNodeTest() {
 
     Map<List<String>, List<String>> rangeToEndpoint = Maps.newHashMap();
-    for (int i = 0; i < 768; i++) {
+    for (int i = 0; i < 3072; i++) {
       rangeToEndpoint.put(
           Arrays.asList(i + "", (i + 1) + ""), Arrays.asList("node1", "node2", "node3"));
     }

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -189,7 +189,7 @@ public final class RepairRunServiceTest {
     endpointToRange.put("node2", Lists.newArrayList());
     endpointToRange.put("node3", Lists.newArrayList());
 
-    assertEquals(48, RepairRunService.computeGlobalSegmentCount(0, endpointToRange));
+    assertEquals(192, RepairRunService.computeGlobalSegmentCount(0, endpointToRange));
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunServiceTest.java
@@ -196,7 +196,7 @@ public final class RepairRunServiceTest {
   public void computeGlobalSegmentCount256TokenPerNodeTest() {
 
     Map<List<String>, List<String>> rangeToEndpoint = Maps.newHashMap();
-    for (int i = 0; i < 3072; i++) {
+    for (int i = 0; i < 768; i++) {
       rangeToEndpoint.put(
           Arrays.asList(i + "", (i + 1) + ""), Arrays.asList("node1", "node2", "node3"));
     }
@@ -206,7 +206,7 @@ public final class RepairRunServiceTest {
     endpointToRange.put("node2", Lists.newArrayList());
     endpointToRange.put("node3", Lists.newArrayList());
 
-    assertEquals(48, RepairRunService.computeGlobalSegmentCount(0, endpointToRange));
+    assertEquals(192, RepairRunService.computeGlobalSegmentCount(0, endpointToRange));
   }
 
   @Test


### PR DESCRIPTION
Per https://github.com/thelastpickle/cassandra-reaper/issues/1192 the default should be 64.  So, set that everywhere, including docs