### PR TITLE
Ignore repair_run_by_cluster_v2 rows with no corresponding repair

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/CassandraRepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/CassandraRepairRunDao.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -399,14 +400,10 @@ public class CassandraRepairRunDao implements IRepairRunDao {
     // Defuture the repair_run rows and build the strongly typed RepairRun objects from the contents.
     return repairRunFutures
         .stream()
-        .map(
-            row -> {
-              Row extractedRow = row.getUninterruptibly().one();
-              return (extractedRow == null)
-                      ? (null)
-                      : (buildRepairRunFromRow(extractedRow, extractedRow.getUUID("id")));
-            }
-        ).filter(x -> x != null).collect(Collectors.toList());
+        .map(row -> row.getUninterruptibly().one())
+        .filter(Objects::nonNull)
+        .map(extractedRow -> buildRepairRunFromRow(extractedRow, extractedRow.getUUID("id")))
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/storage/repairrun/CassandraRepairRunDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/repairrun/CassandraRepairRunDao.java
@@ -395,15 +395,18 @@ public class CassandraRepairRunDao implements IRepairRunDao {
                 )
         )
     );
+
     // Defuture the repair_run rows and build the strongly typed RepairRun objects from the contents.
     return repairRunFutures
         .stream()
         .map(
             row -> {
               Row extractedRow = row.getUninterruptibly().one();
-              return buildRepairRunFromRow(extractedRow, extractedRow.getUUID("id"));
+              return (extractedRow == null)
+                      ? (null)
+                      : (buildRepairRunFromRow(extractedRow, extractedRow.getUUID("id")));
             }
-        ).collect(Collectors.toList());
+        ).filter(x -> x != null).collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
When bad things (like Reaper filling the drive with logs) happen, it's possible to end up with repair_run_by_cluster_v2 rows with no corresponding repair row, which breaks Reaper.  So, just skip them.