### PR TITLE
Improve idempotency of db creation scripts

### DIFF
--- a/src/server/src/main/resources/db/astra/003_concurrent_repairs_part2.cql
+++ b/src/server/src/main/resources/db/astra/003_concurrent_repairs_part2.cql
@@ -15,7 +15,7 @@
 --
 -- Add a table to control the number of concurrent repairs
 
-CREATE TABLE running_repairs(
+CREATE TABLE IF NOT EXISTS running_repairs(
      repair_id uuid,
      node text,
      reaper_instance_host text,

--- a/src/server/src/main/resources/db/astra/004_percent_repaired_schedule.cql
+++ b/src/server/src/main/resources/db/astra/004_percent_repaired_schedule.cql
@@ -15,7 +15,7 @@
 --
 -- Add a table to store the percent repaired metrics for incremental repair schedules
 
-CREATE TABLE percent_repaired_by_schedule(
+CREATE TABLE IF NOT EXISTS percent_repaired_by_schedule(
      cluster_name text,
      repair_schedule_id uuid,
      time_bucket text,

--- a/src/server/src/main/resources/db/cassandra/027_concurrent_repairs_part2.cql
+++ b/src/server/src/main/resources/db/cassandra/027_concurrent_repairs_part2.cql
@@ -15,7 +15,7 @@
 --
 -- Add a table to control the number of concurrent repairs
 
-CREATE TABLE running_repairs(
+CREATE TABLE IF NOT EXISTS running_repairs(
      repair_id uuid,
      node text,
      reaper_instance_host text,

--- a/src/server/src/main/resources/db/cassandra/028_percent_repaired_schedule.cql
+++ b/src/server/src/main/resources/db/cassandra/028_percent_repaired_schedule.cql
@@ -15,7 +15,7 @@
 --
 -- Add a table to store the percent repaired metrics for incremental repair schedules
 
-CREATE TABLE percent_repaired_by_schedule(
+CREATE TABLE IF NOT EXISTS percent_repaired_by_schedule(
      cluster_name text,
      repair_schedule_id uuid,
      time_bucket text,


### PR DESCRIPTION
Ensure that all db creation scripts (cassandra and atlas) use `IF NOT EXISTS` for `CREATE` operations to make those statements rerunnable.

Fixes #1476 