### PR TITLE
Generate SHA256 digests when packaging RPM files.

### DIFF
--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -41,7 +41,7 @@ deb: prepare
 	fpm -s dir -t deb -a all -n reaper -v $(VERSION) --pre-install debian/preinstall.sh --post-install debian/postinstall.sh -C build .
 
 rpm: prepare
-	fpm -s dir -t rpm -a all -n reaper -v $(VERSION) --pre-install redhat/preinstall.sh --post-install redhat/postinstall.sh --config-files /etc/cassandra-reaper/cassandra-reaper.yaml -C build .
+	fpm -s dir -t rpm --rpm-digest sha256 -a all -n reaper -v $(VERSION) --pre-install redhat/preinstall.sh --post-install redhat/postinstall.sh --config-files /etc/cassandra-reaper/cassandra-reaper.yaml -C build .
 
 all: package deb rpm
 


### PR DESCRIPTION
For Enterprise Linux users with FIPS mode enabled, the reaper packages will not install without sidestepping digest checking or disabling FIPS mode.  This is primarily related to `MD5` hashing not being supported when FIPS is enabled.

Generated packages can be verified as having the SHA256 digests with `rpm --checksig -v reaper-3.5.0-1.noarch.rpm` and should appear as follows:
```
 rpm --checksig -v reaper-3.5.0-1.noarch.rpm
reaper-3.5.0-1.noarch.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
```

Prior to this change, packages would appear as follows:

```
rpm --checksig --verbose  reaper-3.5.0-1.noarch.rpm
reaper-3.5.0-1.noarch.rpm:
    Header RSA signature: NOTFOUND
    Header DSA signature: NOTFOUND
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    RSA signature: NOTFOUND
    DSA signature: NOTFOUND
```

```
cp resource/cassandra-reaper.yaml build/etc/cassandra-reaper/
cp resource/cassandra-reaper*.yaml build/etc/cassandra-reaper/configs
cp resource/cassandra-reaper-ssl.properties build/etc/cassandra-reaper/configs
cp ../server/target/cassandra-reaper-3.5.0.jar build/usr/share/cassandra-reaper/
cp bin/* build/usr/local/bin/
cp etc/bash_completion.d/spreaper build/etc/bash_completion.d/
cp debian/reaper.init build/etc/init.d/cassandra-reaper
cp debian/cassandra-reaper.service build/lib/systemd/system/cassandra-reaper.service
chmod 755 build/etc/init.d/cassandra-reaper
fpm -s dir -t deb -a all -n reaper -v 3.5.0 --pre-install debian/preinstall.sh --post-install debian/postinstall.sh -C build .
Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag {:level=>:warn}
Created package {:path=>"reaper_3.5.0_all.deb"}
fpm --rpm-digest sha256 -s dir -t rpm -a all -n reaper -v 3.5.0 --pre-install redhat/preinstall.sh --post-install redhat/postinstall.sh --config-files /etc/cassandra-reaper/cassandra-reaper.yaml -C build .
Created package {:path=>"reaper-3.5.0-1.noarch.rpm"}
+ mv reaper_3.5.0_all.deb reaper-3.5.0-1.noarch.rpm /usr/src/app/packages
+ cp ../server/target/cassandra-reaper-3.5.0-javadoc.jar ../server/target/cassandra-reaper-3.5.0-sources.jar ../server/target/cassandra-reaper-3.5.0.jar /usr/src/app/packages
+ rm -f /usr/src/app/packages/cassandra-reaper-3.5.0-sources.jar
```