### PR TITLE
Fix testSSLHotReload so it can be run locally

### DIFF
--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -811,8 +811,8 @@ public class HttpCassandraManagementProxyTest {
     context.config = config;
 
     Path tempDirectory = Files.createTempDirectory("reload-test");
-    Path ks = Paths.get("/home/runner/work/cassandra-reaper/cassandra-reaper/.github/files/keystore.jks");
-    Path ts = Paths.get("/home/runner/work/cassandra-reaper/cassandra-reaper/.github/files/truststore.jks");
+    Path ks = Paths.get("../../.github/files/keystore.jks");
+    Path ts = Paths.get("../../.github/files/truststore.jks");
 
     Path tsCopy =
         Files.copy(ts, tempDirectory.resolve(ts.getFileName()));


### PR DESCRIPTION
Use relative path to specify path to trust- and keystore files

Fixes #1480 