### PR TITLE
Update Dockerfile to specify restricted Java temp directory

### DIFF
--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -82,7 +82,9 @@ ENV REAPER_SEGMENT_COUNT_PER_NODE=64 \
     REAPER_MGMT_API_METRICS_PORT=9000 \
     REAPER_HTTP_MANAGEMENT_ENABLE="false" \
     REAPER_HTTP_MANAGEMENT_KEYSTORE_PATH="" \
-    REAPER_HTTP_MANAGEMENT_TRUSTSTORE_PATH=""
+    REAPER_HTTP_MANAGEMENT_TRUSTSTORE_PATH="" \
+    REAPER_TMP_DIRECTORY="/var/tmp/cassandra-reaper" \
+    REAPER_MEMORY_STORAGE_DIRECTORY="/var/lib/cassandra-reaper/storage"
 
 # used to run spreaper cli
 RUN apk add --update \
@@ -114,6 +116,7 @@ RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
     mkdir -p /var/lib/cassandra-reaper && \
     mkdir -p /etc/cassandra-reaper/shiro && \
     mkdir -p /var/log/cassandra-reaper && \
+    mkdir -p ${REAPER_TMP_DIRECTORY} && \
     chown reaper:reaper \
         /etc/cassandra-reaper/cassandra-reaper.yml \
         /usr/local/lib/cassandra-reaper.jar \
@@ -123,7 +126,8 @@ RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
         /usr/local/bin/configure-metrics.sh \
         /usr/local/bin/configure-jmx-credentials.sh \
         /usr/local/bin/spreaper \
-        /etc/cassandra-reaper/shiro.ini && \
+        /etc/cassandra-reaper/shiro.ini \
+        ${REAPER_TMP_DIRECTORY} && \
     chown -R reaper:reaper \
         /var/lib/cassandra-reaper \
         /etc/cassandra-reaper/shiro \

--- a/src/server/src/main/docker/configure-persistence.sh
+++ b/src/server/src/main/docker/configure-persistence.sh
@@ -98,4 +98,11 @@ fi
 # END cassandra persistence options
 
     ;;
+    "memory")
+# BEGIN cassandra persistence options
+cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+persistenceStoragePath: ${REAPER_MEMORY_STORAGE_DIRECTORY}
+
+EOT
+    ;;
 esac

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -47,6 +47,7 @@ if [ "$1" = 'cassandra-reaper' ]; then
             ${JAVA_OPTS} \
             -Xms${REAPER_HEAP_SIZE} \
             -Xmx${REAPER_HEAP_SIZE} \
+            -Djava.io.tmpdir=${REAPER_TMP_DIRECTORY} \
             -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication server \
             /etc/cassandra-reaper/cassandra-reaper.yml
 fi
@@ -62,6 +63,7 @@ if [ "$1" = 'schema-migration' ]; then
     /usr/local/bin/configure-jmx-credentials.sh
     exec java \
             ${JAVA_OPTS} \
+            -Djava.io.tmpdir=${REAPER_TMP_DIRECTORY} \
             -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication schema-migration \
             /etc/cassandra-reaper/cassandra-reaper.yml
 fi


### PR DESCRIPTION
Fixes #1495

This does not update the Guava dependency to address [CVE-2023-2976](https://github.com/advisories/GHSA-7g45-4rm6-3mm3), but rather implements a workaround to ensure that the Java temp directory is set to a path that is restricted to the Reaper user.

It also adds the Memeory Storage backend directory location that is needed in the image as of https://github.com/thelastpickle/cassandra-reaper/issues/1487

NOTE: This Fixes #1489 as well