### PR TITLE
Upgrade snakeyaml

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -160,12 +160,16 @@
                     <groupId>com.boundary</groupId>
                     <artifactId>high-scale-lib</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.29</version>
+            <version>1.33</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -167,11 +167,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <version>4.1.70.Final</version>


### PR DESCRIPTION
Fixes #1494 

This upgrades snakeyaml from 1.29 to 1.31 based on what jackson-dataformat brings in (which is brought in by Dropwizard). To upgrade snakeyaml to 2.x, we will need to upgrade Dropwizard to 3.x or 4.x