### PR TITLE
Allow mounting a volume to host the config and enable read only root FS

### DIFF
--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -106,15 +106,10 @@ ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
 ADD src/packaging/bin/spreaper /usr/local/bin/spreaper
 
 
-# get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper/cassandra-reaper.yml: Interrupted system call` unknown error
-RUN touch /etc/cassandra-reaper/cassandra-reaper.yml
-# get around `/usr/local/bin/configure-webui-authentication.sh: line 44: can't `create` /etc/cassandra-reaper/shiro.ini: Interrupted system call` unknown error
-RUN touch /etc/cassandra-reaper/shiro.ini
-
-
 RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
     mkdir -p /var/lib/cassandra-reaper && \
     mkdir -p /etc/cassandra-reaper/shiro && \
+    mkdir -p /etc/cassandra-reaper/config && \
     mkdir -p /var/log/cassandra-reaper && \
     mkdir -p ${REAPER_TMP_DIRECTORY} && \
     chown reaper:reaper \
@@ -131,6 +126,7 @@ RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
     chown -R reaper:reaper \
         /var/lib/cassandra-reaper \
         /etc/cassandra-reaper/shiro \
+        /etc/cassandra-reaper/config \
         /var/log/cassandra-reaper && \
     chmod +x \
         /usr/local/bin/entrypoint.sh \
@@ -142,6 +138,7 @@ RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
 
 VOLUME /var/lib/cassandra-reaper
 VOLUME /etc/cassandra-reaper/shiro
+VOLUME /etc/cassandra-reaper/config
 
 USER reaper
 

--- a/src/server/src/main/docker/configure-jmx-credentials.sh
+++ b/src/server/src/main/docker/configure-jmx-credentials.sh
@@ -17,7 +17,7 @@
 # we expect the jmx credentials to be a comma-separated list of 'user:password@cluster' entries
 if [ ! -z "${REAPER_JMX_CREDENTIALS}" ]; then
 
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 jmxCredentials:
 EOT
 
@@ -29,7 +29,7 @@ EOT
     PASSWORD=$(echo "${ENTRY}" | cut -d'@' -f1 | cut -d':' -f2 | sed 's/"/\\"/g')
 
     # finally, write out the YAML entries
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
   ${CLUSTER}:
     username: "${USERNAME}"
     password: "${PASSWORD}"
@@ -41,7 +41,7 @@ fi
 
 
 if [ ! -z "${REAPER_JMX_AUTH_USERNAME}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 jmxAuth:
   username: "$(echo "${REAPER_JMX_AUTH_USERNAME}" | sed 's/"/\\"/g')"
   password: "$(echo "${REAPER_JMX_AUTH_PASSWORD}" | sed 's/"/\\"/g')"
@@ -50,7 +50,7 @@ EOT
 fi
 
 if [ ! -z "${CRYPTO_SYSTEM_PROPERTY_SECRET}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 cryptograph:
   type: symmetric
   systemPropertySecret: ${CRYPTO_SYSTEM_PROPERTY_SECRET}

--- a/src/server/src/main/docker/configure-metrics.sh
+++ b/src/server/src/main/docker/configure-metrics.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 if [ "true" = "${REAPER_METRICS_ENABLED}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 metrics:
   frequency: ${REAPER_METRICS_FREQUENCY}
   reporters: ${REAPER_METRICS_REPORTERS}

--- a/src/server/src/main/docker/configure-persistence.sh
+++ b/src/server/src/main/docker/configure-persistence.sh
@@ -16,20 +16,20 @@
 
 # Add specific jmxAddressTranslator
 if [ ! -z "${JMX_ADDRESS_TRANSLATOR_TYPE}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 jmxAddressTranslator:
   type: ${JMX_ADDRESS_TRANSLATOR_TYPE}
 EOT
 fi
 
 if [ "multiIpPerNode" = "${JMX_ADDRESS_TRANSLATOR_TYPE}" ] && [ -n "$JMX_ADDRESS_TRANSLATOR_MAPPING" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
   ipTranslations:
 EOT
 IFS=',' read -ra mappings <<< "$JMX_ADDRESS_TRANSLATOR_MAPPING"
 for mapping in "${mappings[@]}"; do
 IFS=':' read -ra mapping <<< "$mapping"
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
     - from: "${mapping[0]}"
       to: "${mapping[1]}"
 EOT
@@ -40,7 +40,7 @@ case ${REAPER_STORAGE_TYPE} in
     "cassandra")
 
 # BEGIN cassandra persistence options
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 activateQueryLogger: ${REAPER_CASS_ACTIVATE_QUERY_LOGGER}
 
 cassandra:
@@ -59,7 +59,7 @@ cassandra:
 EOT
 
 if [ "true" = "${REAPER_CASS_AUTH_ENABLED}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
   authProvider:
     type: plainText
     username: "$(echo "${REAPER_CASS_AUTH_USERNAME}" | sed 's/"/\\"/g')"
@@ -68,27 +68,27 @@ EOT
 fi
 
 if [ "true" = "${REAPER_CASS_NATIVE_PROTOCOL_SSL_ENCRYPTION_ENABLED}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
   ssl:
     type: jdk
 EOT
 fi
 
 if [ "true" = "${REAPER_CASS_ADDRESS_TRANSLATOR_ENABLED}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
   addressTranslator:
     type: ${REAPER_CASS_ADDRESS_TRANSLATOR_TYPE}
 EOT
 fi
 
 if [ "multiIpPerNode" = "${REAPER_CASS_ADDRESS_TRANSLATOR_TYPE}" ] && [ -n "$REAPER_CASS_ADDRESS_TRANSLATOR_MAPPING" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
     ipTranslations:
 EOT
 IFS=',' read -ra mappings <<< "$REAPER_CASS_ADDRESS_TRANSLATOR_MAPPING"
 for mapping in "${mappings[@]}"; do
 IFS=':' read -ra mapping <<< "$mapping"
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
     - from: "${mapping[0]}"
       to: "${mapping[1]}"
 EOT
@@ -100,7 +100,7 @@ fi
     ;;
     "memory")
 # BEGIN cassandra persistence options
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 persistenceStoragePath: ${REAPER_MEMORY_STORAGE_DIRECTORY}
 
 EOT

--- a/src/server/src/main/docker/configure-webui-authentication.sh
+++ b/src/server/src/main/docker/configure-webui-authentication.sh
@@ -18,21 +18,21 @@ if [ "false" = "${REAPER_AUTH_ENABLED}" ]; then
 fi
 
 if [ ! -z "${REAPER_SHIRO_INI}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 accessControl:
   sessionTimeout: PT10M
   shiro:
     iniConfigs: ["file:${REAPER_SHIRO_INI}"]
 EOT
 elif [ ! -z "${REAPER_AUTH_USER}" ]; then
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 accessControl:
   sessionTimeout: PT10M
   shiro:
-    iniConfigs: ["file:/etc/cassandra-reaper/shiro.ini"]
+    iniConfigs: ["file:/etc/cassandra-reaper/config/shiro.ini"]
 EOT
 else
-cat <<EOT >> /etc/cassandra-reaper/cassandra-reaper.yml
+cat <<EOT >> /etc/cassandra-reaper/config/cassandra-reaper.yml
 accessControl:
   sessionTimeout: PT10M
   shiro:
@@ -41,7 +41,7 @@ EOT
 fi
 
 if [ ! -z "${REAPER_AUTH_USER}" ]; then
-cat <<EOT2 >> /etc/cassandra-reaper/shiro.ini
+cat <<EOT2 >> /etc/cassandra-reaper/config/shiro.ini
 ${REAPER_AUTH_USER} = ${REAPER_AUTH_PASSWORD}, operator
 EOT2
 fi

--- a/src/server/src/main/docker/entrypoint.sh
+++ b/src/server/src/main/docker/entrypoint.sh
@@ -36,8 +36,10 @@ if [ "$1" = 'cassandra-reaper' ]; then
     if [ -z "$REAPER_HEAP_SIZE" ]; then
         REAPER_HEAP_SIZE="1G"
     fi
+
     # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper/cassandra-reaper.yml: Interrupted system call` unknown error
-    touch /etc/cassandra-reaper/cassandra-reaper.yml
+    cp /etc/cassandra-reaper/cassandra-reaper.yml /etc/cassandra-reaper/config/cassandra-reaper.yml
+    cp /etc/cassandra-reaper/shiro.ini /etc/cassandra-reaper/config/shiro.ini
 
     /usr/local/bin/configure-persistence.sh
     /usr/local/bin/configure-webui-authentication.sh
@@ -49,13 +51,14 @@ if [ "$1" = 'cassandra-reaper' ]; then
             -Xmx${REAPER_HEAP_SIZE} \
             -Djava.io.tmpdir=${REAPER_TMP_DIRECTORY} \
             -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication server \
-            /etc/cassandra-reaper/cassandra-reaper.yml
+            /etc/cassandra-reaper/config/cassandra-reaper.yml
 fi
 
 if [ "$1" = 'schema-migration' ]; then
 
     # get around `/usr/local/bin/configure-persistence.sh: line 65: can't create /etc/cassandra-reaper/cassandra-reaper.yml: Interrupted system call` unknown error
-    touch /etc/cassandra-reaper/cassandra-reaper.yml
+    cp /etc/cassandra-reaper/cassandra-reaper.yml /etc/cassandra-reaper/config/cassandra-reaper.yml
+    cp /etc/cassandra-reaper/shiro.ini /etc/cassandra-reaper/config/shiro.ini
 
     /usr/local/bin/configure-persistence.sh
     /usr/local/bin/configure-webui-authentication.sh
@@ -65,7 +68,7 @@ if [ "$1" = 'schema-migration' ]; then
             ${JAVA_OPTS} \
             -Djava.io.tmpdir=${REAPER_TMP_DIRECTORY} \
             -cp "/usr/local/lib/*" io.cassandrareaper.ReaperApplication schema-migration \
-            /etc/cassandra-reaper/cassandra-reaper.yml
+            /etc/cassandra-reaper/config/cassandra-reaper.yml
 fi
 
 if [ "$1" = 'register-clusters' ]; then


### PR DESCRIPTION
Fixes #1506 

Instead of modifying files in `/etc/cassandra-reaper` (which is located on the root FS), this PR uses a volume mount under `/etc/cassandra-reaper/config` which can be an emptyDir in Kubernetes. It will be writeable whatever the uid is and while keeping the root FS read only.

The entrypoint scripts will copy the base cassandra.yaml and shiro.ini files from `/etc/cassandra-reaper` to `/etc/cassandra-reaper/config` and update them there to add all the necessary settings.

This solution is backwards compatible with pods running with no specific security context.