### PR TITLE
update doc for persistenceStoragePath

### DIFF
--- a/src/docs/content/docs/backends/memory.md
+++ b/src/docs/content/docs/backends/memory.md
@@ -11,6 +11,9 @@ To use in memory storage as the storage type for Reaper, the `storageType` setti
 
 ```yaml
 storageType: memory
+persistenceStoragePath: /var/lib/cassandra-reaper/storage
 ```
 
 In-memory storage is volatile and as such all registered cluster, column families and repair information will be lost upon service restart. This storage setting is intended for testing purposes only.
+
+Starting from 3.6.0, persistenceStoragePath is required for memory storage type. This enable lightweight deployments of Reaper, without requiring the use of a Cassandra database. It will store the data locally and reload them consistently upon startup.


### PR DESCRIPTION
persistenceStoragePath has been added in v3.6.0. Same has to be updated in https://cassandra-reaper.io/docs/backends/memory/