### PR TITLE
Fail repair after additive change in cluster topology

### DIFF
--- a/src/packaging/resource/cassandra-reaper.yaml
+++ b/src/packaging/resource/cassandra-reaper.yaml
@@ -32,6 +32,8 @@ activateQueryLogger: false
 jmxConnectionTimeoutInSeconds: 5
 useAddressTranslator: false
 maxParallelRepairs: 2
+scheduleRetryOnError: false
+scheduleRetryDelay: PT1H
 # purgeRecordsAfterInDays: 30
 # numberOfRunsToKeepPerUnit: 10
 

--- a/src/server/src/checkstyle/suppressions.xml
+++ b/src/server/src/checkstyle/suppressions.xml
@@ -20,5 +20,6 @@
   <!-- suppressions for tests -->
   <suppress checks="MethodName" files="[/\\]src[/\\]test[/\\]java[/\\]" />
   <suppress checks="AbbreviationAsWordInName" files="[/\\]src[/\\]test[/\\]java[/\\]" />
+  <suppress checks="MethodLength" files="[/\\]src[/\\]test[/\\]java[/\\]" />
 
 </suppressions>

--- a/src/server/src/main/docker/cassandra-reaper.yml
+++ b/src/server/src/main/docker/cassandra-reaper.yml
@@ -30,6 +30,8 @@ repairManagerSchedulingIntervalSeconds: ${REAPER_REPAIR_MANAGER_SCHEDULING_INTER
 jmxConnectionTimeoutInSeconds: ${REAPER_JMX_CONNECTION_TIMEOUT_IN_SECONDS}
 useAddressTranslator: ${REAPER_USE_ADDRESS_TRANSLATOR}
 maxParallelRepairs: ${REAPER_MAX_PARALLEL_REPAIRS}
+scheduleRetryOnError: ${REAPER_SCHEDULE_RETRY_ON_ERROR:-false}
+scheduleRetryDelay: ${REAPER_SCHEDULE_RETRY_DELAY:-PT1H}
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -177,6 +177,12 @@ public final class ReaperApplicationConfiguration extends Configuration {
   @Nullable
   private String persistenceStoragePath;
 
+  @JsonProperty
+  private Boolean scheduleRetryOnError;
+
+  @JsonProperty
+  private Duration scheduleRetryDelay;
+
   public HttpManagement getHttpManagement() {
     return httpManagement;
   }
@@ -531,6 +537,22 @@ public final class ReaperApplicationConfiguration extends Configuration {
   @Nullable
   public String getPersistenceStoragePath() {
     return persistenceStoragePath;
+  }
+
+  public Boolean isScheduleRetryOnError() {
+    return scheduleRetryOnError != null ? scheduleRetryOnError : false;
+  }
+
+  public void setScheduleRetryOnError(Boolean scheduleRetryOnError) {
+    this.scheduleRetryOnError = scheduleRetryOnError;
+  }
+
+  public Duration getScheduleRetryDelay() {
+    return scheduleRetryDelay != null ? scheduleRetryDelay : Duration.ofMinutes(60);
+  }
+
+  public void setScheduleRetryDelay(Duration scheduleRetryDelay) {
+    this.scheduleRetryDelay = scheduleRetryDelay;
   }
 
   public enum DatacenterAvailability {

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerHangingTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerHangingTest.java
@@ -79,6 +79,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public final class RepairRunnerHangingTest {
@@ -246,12 +248,9 @@ public final class RepairRunnerHangingTest {
     final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     storage.getClusterDao().addCluster(cluster);
     RepairUnit cf = storage.getRepairUnitDao().addRepairUnit(
-        RepairUnit.builder()
-            .clusterName(cluster.getName())
-            .keyspaceName("reaper")
-            .columnFamilies(cfNames)
-            .incrementalRepair(false)
-            .subrangeIncrementalRepair(false)
+        RepairUnit.builder().clusterName(cluster.getName())
+            .keyspaceName("reaper").columnFamilies(cfNames)
+            .incrementalRepair(false).subrangeIncrementalRepair(false)
             .nodes(nodeSet)
             .datacenters(datacenters)
             .blacklistedTables(blacklistedTables)
@@ -267,7 +266,7 @@ public final class RepairRunnerHangingTest {
         Collections.singleton(
             RepairSegment.builder(
                 Segment.builder()
-                    .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                    .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("50")))
                     .withReplicas(replicas)
                     .build(),
                 cf.getId())));
@@ -383,6 +382,9 @@ public final class RepairRunnerHangingTest {
       }
     });
     assertEquals(RepairRun.RunState.DONE, storage.getRepairRunDao().getRepairRun(runId).get().getRunState());
+    verify(jmx, times(2)).triggerRepair(
+            any(), any(), any(), any(), any(), any(), any(), anyInt()
+    );
   }
 
   @Test
@@ -403,10 +405,8 @@ public final class RepairRunnerHangingTest {
     DateTimeUtils.setCurrentMillisFixed(timeRun);
     RepairUnit cf = storage.getRepairUnitDao().addRepairUnit(
         RepairUnit.builder()
-            .clusterName(cluster.getName())
-            .keyspaceName(ksName)
-            .columnFamilies(cfNames)
-            .incrementalRepair(incrementalRepair)
+            .clusterName(cluster.getName()).keyspaceName(ksName)
+            .columnFamilies(cfNames).incrementalRepair(incrementalRepair)
             .subrangeIncrementalRepair(incrementalRepair)
             .nodes(nodeSet)
             .datacenters(datacenters)
@@ -421,7 +421,7 @@ public final class RepairRunnerHangingTest {
         Collections.singleton(
             RepairSegment.builder(
                 Segment.builder()
-                    .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                    .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("50")))
                     .withReplicas(replicas)
                     .build(),
                 cf.getId())));
@@ -535,6 +535,9 @@ public final class RepairRunnerHangingTest {
       }
     });
     assertEquals(RepairRun.RunState.DONE, storage.getRepairRunDao().getRepairRun(runId).get().getRunState());
+    verify(jmx, times(2)).triggerRepair(
+            any(), any(), any(), any(), any(), any(), any(), anyInt()
+    );
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerHangingTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerHangingTest.java
@@ -248,9 +248,12 @@ public final class RepairRunnerHangingTest {
     final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     storage.getClusterDao().addCluster(cluster);
     RepairUnit cf = storage.getRepairUnitDao().addRepairUnit(
-        RepairUnit.builder().clusterName(cluster.getName())
-            .keyspaceName("reaper").columnFamilies(cfNames)
-            .incrementalRepair(false).subrangeIncrementalRepair(false)
+        RepairUnit.builder()
+            .clusterName(cluster.getName())
+            .keyspaceName("reaper")
+            .columnFamilies(cfNames)
+            .incrementalRepair(false)
+            .subrangeIncrementalRepair(false)
             .nodes(nodeSet)
             .datacenters(datacenters)
             .blacklistedTables(blacklistedTables)
@@ -405,8 +408,10 @@ public final class RepairRunnerHangingTest {
     DateTimeUtils.setCurrentMillisFixed(timeRun);
     RepairUnit cf = storage.getRepairUnitDao().addRepairUnit(
         RepairUnit.builder()
-            .clusterName(cluster.getName()).keyspaceName(ksName)
-            .columnFamilies(cfNames).incrementalRepair(incrementalRepair)
+            .clusterName(cluster.getName())
+            .keyspaceName(ksName)
+            .columnFamilies(cfNames)
+            .incrementalRepair(incrementalRepair)
             .subrangeIncrementalRepair(incrementalRepair)
             .nodes(nodeSet)
             .datacenters(datacenters)

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTopologyChangeTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTopologyChangeTest.java
@@ -1,0 +1,768 @@
+/*
+ * Copyright 2015-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.service;
+
+import io.cassandrareaper.AppContext;
+import io.cassandrareaper.ReaperApplicationConfiguration;
+import io.cassandrareaper.ReaperApplicationConfiguration.AutoSchedulingConfiguration;
+import io.cassandrareaper.ReaperException;
+import io.cassandrareaper.core.Cluster;
+import io.cassandrareaper.core.CompactionStats;
+import io.cassandrareaper.core.Node;
+import io.cassandrareaper.core.RepairRun;
+import io.cassandrareaper.core.RepairSchedule;
+import io.cassandrareaper.core.RepairSegment;
+import io.cassandrareaper.core.RepairUnit;
+import io.cassandrareaper.core.Segment;
+import io.cassandrareaper.crypto.NoopCrypotograph;
+import io.cassandrareaper.management.ClusterFacade;
+import io.cassandrareaper.management.RepairStatusHandler;
+import io.cassandrareaper.management.jmx.CassandraManagementProxyTest;
+import io.cassandrareaper.management.jmx.JmxCassandraManagementProxy;
+import io.cassandrareaper.management.jmx.JmxManagementConnectionFactory;
+import io.cassandrareaper.storage.IStorageDao;
+import io.cassandrareaper.storage.MemoryStorageFacade;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.management.MalformedObjectNameException;
+import javax.management.ReflectionException;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
+import org.apache.cassandra.repair.RepairParallelism;
+import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class RepairRunnerTopologyChangeTest {
+
+  private static final List<BigInteger> THREE_TOKENS = Lists.newArrayList(
+          BigInteger.valueOf(0L),
+          BigInteger.valueOf(100L),
+          BigInteger.valueOf(200L));
+
+  private static final Set<String> TABLES = ImmutableSet.of("table1");
+
+  private final Cluster cluster = Cluster.builder()
+          .withName("test_" + RandomStringUtils.randomAlphabetic(12))
+          .withSeedHosts(ImmutableSet.of("127.0.0.1"))
+          .withState(Cluster.State.ACTIVE)
+          .build();
+
+  private static Map<List<String>, List<String>> addRangeToMap(
+          Map<List<String>, List<String>> map,
+          String start,
+          String end,
+          String... hosts) {
+
+    List<String> range = Lists.newArrayList(start, end);
+    List<String> endPoints = Lists.newArrayList(hosts);
+    map.put(range, endPoints);
+    return map;
+  }
+
+  private static Map<List<String>, List<String>> fourNodeClusterAfterBootstrap() {
+    Map<List<String>, List<String>> map = new HashMap<List<String>, List<String>>();
+    map = addRangeToMap(map, "0", "50", "127.0.0.1", "127.0.0.4", "127.0.0.2");
+    map = addRangeToMap(map, "50", "100", "127.0.0.4", "127.0.0.2", "127.0.0.3");
+    map = addRangeToMap(map, "100", "200", "127.0.0.2", "127.0.0.3", "127.0.0.1");
+    map = addRangeToMap(map, "200", "0", "127.0.0.3", "127.0.0.1", "127.0.0.4");
+    return map;
+  }
+
+  private static Map<List<String>, List<String>> twoNodeClusterAfterBootstrap() {
+    Map<List<String>, List<String>> map = new HashMap<List<String>, List<String>>();
+    map = addRangeToMap(map, "0", "200", "127.0.0.1", "127.0.0.3");
+    map = addRangeToMap(map, "200", "0", "127.0.0.3", "127.0.0.1");
+    return map;
+  }
+
+  private RepairRun addNewRepairRun(
+          final Map<String, String> nodeMap,
+          final double intensity,
+          final IStorageDao storage,
+          UUID cf,
+          UUID hostID
+  ) {
+    return storage.getRepairRunDao().addRepairRun(
+            RepairRun.builder(cluster.getName(), cf)
+                    .intensity(intensity)
+                    .segmentCount(1)
+                    .repairParallelism(RepairParallelism.PARALLEL)
+                    .tables(TABLES),
+            Lists.newArrayList(
+                    RepairSegment.builder(
+                                    Segment.builder()
+                                            .withTokenRange(new RingRange(BigInteger.ZERO, new BigInteger("100")))
+                                            .withReplicas(nodeMap)
+                                            .build(), cf)
+                            .withState(RepairSegment.State.RUNNING)
+                            .withStartTime(DateTime.now())
+                            .withCoordinatorHost("reaper")
+                            .withHostID(hostID),
+                    RepairSegment.builder(
+                                    Segment.builder()
+                                            .withTokenRange(new RingRange(new BigInteger("100"), new BigInteger("200")))
+                                            .withReplicas(nodeMap)
+                                            .build(), cf)
+                            .withHostID(hostID)
+            )
+    );
+  }
+
+  private Map<String, String> endpointToHostIDMap() {
+    Map<String, String> endpointToHostIDMap = new HashMap<String, String>();
+    endpointToHostIDMap.put("127.0.0.1", UUID.randomUUID().toString());
+    endpointToHostIDMap.put("127.0.0.2", UUID.randomUUID().toString());
+    endpointToHostIDMap.put("127.0.0.3", UUID.randomUUID().toString());
+
+    return endpointToHostIDMap;
+  }
+
+  @Test
+  public void testFailRepairAfterAdditiveChangeInTopology() throws ReaperException, IOException {
+    final String ksName = "reaper";
+    final Set<String> cfNames = Sets.newHashSet("reaper");
+    final boolean incrementalRepair = false;
+    final Set<String> nodeSet = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
+    final Map<String, String> nodeMap = ImmutableMap.of(
+            "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1");
+    final Set<String> datacenters = Collections.emptySet();
+    final Set<String> blacklistedTables = Collections.emptySet();
+    final double intensity = 0.5f;
+    final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
+    final List<BigInteger> tokens = THREE_TOKENS;
+    final IStorageDao storage = new MemoryStorageFacade();
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setAutoScheduling(new AutoSchedulingConfiguration());
+    context.config.setScheduleRetryOnError(true);
+    context.config.setScheduleRetryDelay(java.time.Duration.parse("PT1H"));
+    storage.getClusterDao().addCluster(cluster);
+    UUID cf = storage.getRepairUnitDao().addRepairUnit(
+                    RepairUnit.builder().clusterName(cluster.getName())
+                            .keyspaceName(ksName)
+                            .columnFamilies(cfNames)
+                            .incrementalRepair(incrementalRepair)
+                            .subrangeIncrementalRepair(incrementalRepair)
+                            .nodes(nodeSet)
+                            .datacenters(datacenters)
+                            .blacklistedTables(blacklistedTables)
+                            .repairThreadCount(repairThreadCount)
+                            .timeout(segmentTimeout))
+            .getId();
+    DateTime initialActivationDate = DateTime.now();
+    DateTime nextActivationDate = initialActivationDate.plusHours(2);
+    storage.getRepairScheduleDao().addRepairSchedule(RepairSchedule.builder(cf).daysBetween(1).intensity(1)
+            .segmentCountPerNode(64)
+            .nextActivation(nextActivationDate)
+            .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+    );
+    final Map<String, String> endpointToHostIDMap = endpointToHostIDMap();
+    RepairRun run = addNewRepairRun(nodeMap, intensity, storage, cf, null);
+    final UUID runId = run.getId();
+    final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
+    assertEquals(storage.getRepairSegmentDao().getRepairSegment(runId, segmentId).get().getState(),
+            RepairSegment.State.NOT_STARTED);
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(jmx.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
+    when(jmx.getTokens()).thenReturn(tokens);
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    context.repairManager = RepairManager.create(
+            context,
+            Executors.newScheduledThreadPool(10),
+            1,
+            TimeUnit.MILLISECONDS,
+            1,
+            context.storage.getRepairRunDao());
+    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+    when(jmx.triggerRepair(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .then(
+                    (invocation) -> {
+                      final int repairNumber = repairNumberCounter.getAndIncrement();
+                      new Thread() {
+                        @Override
+                        public void run() {
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.STARTED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.FINISHED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                        }
+                      }.start();
+                      return repairNumber;
+                    });
+    context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
+      @Override
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
+        return jmx;
+      }
+    };
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRunDao().getRepairRun(runId).get().getRunState());
+    storage.getRepairRunDao().updateRepairRun(
+            run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(runId));
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(fourNodeClusterAfterBootstrap());
+    context.repairManager.resumeRunningRepairRuns();
+    // The repair run should fail due to the token ranges for each node becoming smaller, resulting in
+    // the new ranges not completely enclosing every previously calculated segment.
+    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+      return RepairRun.RunState.ERROR == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
+    });
+    RepairSchedule updatedRepairSchedule = storage.getRepairScheduleDao()
+            .getRepairSchedulesForClusterAndKeyspace(cluster.getName(), ksName)
+            .iterator().next();
+    // Ensure that repair schedule has been updated to activate again in one hour with a delta of a minute, given
+    // test execution takes a few seconds. One hour is the default schedule retry delay.
+    assertTrue(updatedRepairSchedule.getNextActivation().isAfter(initialActivationDate.plusHours(1)));
+    assertTrue(updatedRepairSchedule.getNextActivation().isBefore(initialActivationDate.plusHours(1).plusMinutes(1)));
+  }
+
+  @Test
+  public void testAfterAdditiveChangeInTopologyNoErrorWhenRepairScheduleDoesNotExist()
+          throws ReaperException, IOException {
+    final String ksName = "reaper";
+    final Set<String> cfNames = Sets.newHashSet("reaper");
+    final boolean incrementalRepair = false;
+    final Set<String> nodeSet = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
+    final Map<String, String> nodeMap = ImmutableMap.of(
+            "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1");
+    final Set<String> datacenters = Collections.emptySet();
+    final Set<String> blacklistedTables = Collections.emptySet();
+    final double intensity = 0.5f;
+    final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
+    final List<BigInteger> tokens = THREE_TOKENS;
+    final IStorageDao storage = new MemoryStorageFacade();
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setAutoScheduling(new AutoSchedulingConfiguration());
+    context.config.setScheduleRetryOnError(true);
+    context.config.setScheduleRetryDelay(java.time.Duration.parse("PT1H"));
+    storage.getClusterDao().addCluster(cluster);
+    UUID cf = storage.getRepairUnitDao().addRepairUnit(
+                    RepairUnit.builder().clusterName(cluster.getName())
+                            .keyspaceName(ksName)
+                            .columnFamilies(cfNames)
+                            .incrementalRepair(incrementalRepair)
+                            .subrangeIncrementalRepair(incrementalRepair)
+                            .nodes(nodeSet)
+                            .datacenters(datacenters)
+                            .blacklistedTables(blacklistedTables)
+                            .repairThreadCount(repairThreadCount)
+                            .timeout(segmentTimeout))
+            .getId();
+    final Map<String, String> endpointToHostIDMap = endpointToHostIDMap();
+    RepairRun run = addNewRepairRun(nodeMap, intensity, storage, cf, null);
+    final UUID runId = run.getId();
+    final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
+    assertEquals(storage.getRepairSegmentDao()
+            .getRepairSegment(runId, segmentId).get().getState(), RepairSegment.State.NOT_STARTED);
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(jmx.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
+    when(jmx.getTokens()).thenReturn(tokens);
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    context.repairManager = RepairManager.create(
+            context,
+            Executors.newScheduledThreadPool(10),
+            1,
+            TimeUnit.MILLISECONDS,
+            1,
+            context.storage.getRepairRunDao());
+    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+    when(jmx.triggerRepair(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .then(
+                    (invocation) -> {
+                      final int repairNumber = repairNumberCounter.getAndIncrement();
+                      new Thread() {
+                        @Override
+                        public void run() {
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.STARTED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.FINISHED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                        }
+                      }.start();
+                      return repairNumber;
+                    });
+    context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
+      @Override
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
+        return jmx;
+      }
+    };
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRunDao().getRepairRun(runId).get().getRunState());
+    storage.getRepairRunDao().updateRepairRun(
+            run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(runId));
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(fourNodeClusterAfterBootstrap());
+    context.repairManager.resumeRunningRepairRuns();
+    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+      return RepairRun.RunState.ERROR == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
+    });
+  }
+
+  @Test
+  public void testAfterAdditiveChangeInTopologyNoRescheduleWhenScheduleRetryOnErrorIsFalse()
+          throws ReaperException, IOException {
+    final String ksName = "reaper";
+    final Set<String> cfNames = Sets.newHashSet("reaper");
+    final boolean incrementalRepair = false;
+    final Set<String> nodeSet = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
+    final Map<String, String> nodeMap = ImmutableMap.of(
+            "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1");
+    final Set<String> datacenters = Collections.emptySet();
+    final Set<String> blacklistedTables = Collections.emptySet();
+    final double intensity = 0.5f;
+    final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
+    final List<BigInteger> tokens = THREE_TOKENS;
+    final IStorageDao storage = new MemoryStorageFacade();
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setAutoScheduling(new AutoSchedulingConfiguration());
+    context.config.setScheduleRetryOnError(false);
+    context.config.setScheduleRetryDelay(java.time.Duration.parse("PT1H"));
+    storage.getClusterDao().addCluster(cluster);
+    UUID cf = storage.getRepairUnitDao().addRepairUnit(
+                    RepairUnit.builder().clusterName(cluster.getName())
+                            .keyspaceName(ksName)
+                            .columnFamilies(cfNames)
+                            .incrementalRepair(incrementalRepair)
+                            .subrangeIncrementalRepair(incrementalRepair)
+                            .nodes(nodeSet)
+                            .datacenters(datacenters)
+                            .blacklistedTables(blacklistedTables)
+                            .repairThreadCount(repairThreadCount)
+                            .timeout(segmentTimeout))
+            .getId();
+    DateTime initialActivationDate = DateTime.now();
+    DateTime nextActivationDate = initialActivationDate.plusHours(2);
+    storage.getRepairScheduleDao().addRepairSchedule(RepairSchedule.builder(cf)
+            .daysBetween(1).intensity(1).segmentCountPerNode(64)
+            .nextActivation(nextActivationDate)
+            .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+    );
+    final Map<String, String> endpointToHostIDMap = endpointToHostIDMap();
+    RepairRun run = addNewRepairRun(nodeMap, intensity, storage, cf, null);
+    final UUID runId = run.getId();
+    final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
+    assertEquals(storage.getRepairSegmentDao()
+            .getRepairSegment(runId, segmentId).get().getState(), RepairSegment.State.NOT_STARTED);
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(jmx.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
+    when(jmx.getTokens()).thenReturn(tokens);
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    context.repairManager = RepairManager.create(
+            context,
+            Executors.newScheduledThreadPool(10),
+            1,
+            TimeUnit.MILLISECONDS,
+            1,
+            context.storage.getRepairRunDao());
+    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+    when(jmx.triggerRepair(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .then(
+                    (invocation) -> {
+                      final int repairNumber = repairNumberCounter.getAndIncrement();
+                      new Thread() {
+                        @Override
+                        public void run() {
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.STARTED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.FINISHED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                        }
+                      }.start();
+                      return repairNumber;
+                    });
+    context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
+      @Override
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
+        return jmx;
+      }
+    };
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRunDao().getRepairRun(runId).get().getRunState());
+    storage.getRepairRunDao().updateRepairRun(
+            run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(runId));
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(fourNodeClusterAfterBootstrap());
+    context.repairManager.resumeRunningRepairRuns();
+    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+      return RepairRun.RunState.ERROR == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
+    });
+    RepairSchedule updatedRepairSchedule = storage.getRepairScheduleDao()
+            .getRepairSchedulesForClusterAndKeyspace(cluster.getName(), ksName)
+            .iterator().next();
+    // Ensure that repair schedule has not been updated
+    assertEquals(updatedRepairSchedule.getNextActivation(), nextActivationDate);
+  }
+
+  @Test
+  public void testAfterAdditiveChangeInTopologyNoRescheduleWhenScheduleRetryDelayIsLaterThanNextActivation()
+          throws ReaperException, IOException {
+    final String ksName = "reaper";
+    final Set<String> cfNames = Sets.newHashSet("reaper");
+    final boolean incrementalRepair = false;
+    final Set<String> nodeSet = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
+    final Map<String, String> nodeMap = ImmutableMap.of(
+            "127.0.0.1", "dc1", "127.0.0.2", "dc1", "127.0.0.3", "dc1");
+    final Set<String> datacenters = Collections.emptySet();
+    final Set<String> blacklistedTables = Collections.emptySet();
+    final double intensity = 0.5f;
+    final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
+    final List<BigInteger> tokens = THREE_TOKENS;
+    final IStorageDao storage = new MemoryStorageFacade();
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = new ReaperApplicationConfiguration();
+    context.config.setAutoScheduling(new AutoSchedulingConfiguration());
+    context.config.setScheduleRetryOnError(true);
+    context.config.setScheduleRetryDelay(java.time.Duration.parse("PT3H"));
+    storage.getClusterDao().addCluster(cluster);
+    UUID cf = storage.getRepairUnitDao().addRepairUnit(
+                    RepairUnit.builder().clusterName(cluster.getName())
+                            .keyspaceName(ksName)
+                            .columnFamilies(cfNames)
+                            .incrementalRepair(incrementalRepair)
+                            .subrangeIncrementalRepair(incrementalRepair)
+                            .nodes(nodeSet)
+                            .datacenters(datacenters)
+                            .blacklistedTables(blacklistedTables)
+                            .repairThreadCount(repairThreadCount)
+                            .timeout(segmentTimeout))
+            .getId();
+    DateTime initialActivationDate = DateTime.now();
+    DateTime nextActivationDate = initialActivationDate.plusHours(2);
+    storage.getRepairScheduleDao().addRepairSchedule(RepairSchedule.builder(cf).daysBetween(1).intensity(1)
+            .segmentCountPerNode(64)
+            .nextActivation(nextActivationDate)
+            .repairParallelism(RepairParallelism.DATACENTER_AWARE)
+    );
+    final Map<String, String> endpointToHostIDMap = endpointToHostIDMap();
+    RepairRun run = addNewRepairRun(nodeMap, intensity, storage, cf, null);
+    final UUID runId = run.getId();
+    final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
+    assertEquals(storage.getRepairSegmentDao()
+            .getRepairSegment(runId, segmentId).get().getState(), RepairSegment.State.NOT_STARTED);
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+    when(jmx.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
+    when(jmx.getTokens()).thenReturn(tokens);
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    context.repairManager = RepairManager.create(
+            context,
+            Executors.newScheduledThreadPool(10),
+            1,
+            TimeUnit.MILLISECONDS,
+            1,
+            context.storage.getRepairRunDao());
+    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+    when(jmx.triggerRepair(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .then(
+                    (invocation) -> {
+                      final int repairNumber = repairNumberCounter.getAndIncrement();
+                      new Thread() {
+                        @Override
+                        public void run() {
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.STARTED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.FINISHED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                        }
+                      }.start();
+                      return repairNumber;
+                    });
+    context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
+      @Override
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
+        return jmx;
+      }
+    };
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRunDao().getRepairRun(runId).get().getRunState());
+    storage.getRepairRunDao().updateRepairRun(
+            run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(runId));
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(fourNodeClusterAfterBootstrap());
+    context.repairManager.resumeRunningRepairRuns();
+    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+      return RepairRun.RunState.ERROR == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
+    });
+    RepairSchedule updatedRepairSchedule = storage.getRepairScheduleDao()
+            .getRepairSchedulesForClusterAndKeyspace(cluster.getName(), ksName)
+            .iterator().next();
+    // Ensure that repair schedule has not been updated
+    assertEquals(updatedRepairSchedule.getNextActivation(), nextActivationDate);
+  }
+
+  @Test
+  public void testSuccessAfterSubtractiveChangeInTopology() throws InterruptedException, ReaperException,
+          MalformedObjectNameException, ReflectionException, IOException {
+    final String ksName = "reaper";
+    final Set<String> cfNames = Sets.newHashSet("reaper");
+    final boolean incrementalRepair = false;
+    final Set<String> nodeSet = Sets.newHashSet("127.0.0.1", "127.0.0.2", "127.0.0.3");
+    final Map<String, String> nodeMap = ImmutableMap.of("127.0.0.1", "dc1",
+            "127.0.0.2", "dc1", "127.0.0.3", "dc1");
+    final Set<String> datacenters = Collections.emptySet();
+    final Set<String> blacklistedTables = Collections.emptySet();
+    final double intensity = 0.5f;
+    final int repairThreadCount = 1;
+    final int segmentTimeout = 30;
+    final List<BigInteger> tokens = THREE_TOKENS;
+    final IStorageDao storage = new MemoryStorageFacade();
+    AppContext context = new AppContext();
+    context.storage = storage;
+    context.config = new ReaperApplicationConfiguration();
+    storage.getClusterDao().addCluster(cluster);
+    UUID cf = storage.getRepairUnitDao().addRepairUnit(
+                    RepairUnit.builder()
+                            .clusterName(cluster.getName())
+                            .keyspaceName(ksName)
+                            .columnFamilies(cfNames)
+                            .incrementalRepair(incrementalRepair)
+                            .subrangeIncrementalRepair(incrementalRepair)
+                            .nodes(nodeSet)
+                            .datacenters(datacenters)
+                            .blacklistedTables(blacklistedTables)
+                            .repairThreadCount(repairThreadCount)
+                            .timeout(segmentTimeout))
+            .getId();
+    final Map<String, String> endpointToHostIDMap = endpointToHostIDMap();
+    RepairRun run = addNewRepairRun(nodeMap, intensity, storage, cf, null);
+    final UUID runId = run.getId();
+    final UUID segmentId = storage.getRepairSegmentDao().getNextFreeSegments(run.getId()).get(0).getId();
+    assertEquals(storage.getRepairSegmentDao()
+            .getRepairSegment(runId, segmentId).get().getState(), RepairSegment.State.NOT_STARTED);
+    final JmxCassandraManagementProxy jmx = CassandraManagementProxyTest.mockJmxProxyImpl();
+    when(jmx.getClusterName()).thenReturn(cluster.getName());
+    when(jmx.isConnectionAlive()).thenReturn(true);
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(RepairRunnerTest.threeNodeClusterWithIps());
+
+    when(jmx.getEndpointToHostId()).thenReturn(endpointToHostIDMap);
+    when(jmx.getTokens()).thenReturn(tokens);
+    EndpointSnitchInfoMBean endpointSnitchInfoMBean = mock(EndpointSnitchInfoMBean.class);
+    when(endpointSnitchInfoMBean.getDatacenter()).thenReturn("dc1");
+    try {
+      when(endpointSnitchInfoMBean.getDatacenter(anyString())).thenReturn("dc1");
+    } catch (UnknownHostException ex) {
+      throw new AssertionError(ex);
+    }
+    ClusterFacade clusterFacade = mock(ClusterFacade.class);
+    when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
+    when(clusterFacade.nodeIsDirectlyAccessible(any(), any())).thenReturn(true);
+    when(clusterFacade.tokenRangeToEndpoint(any(), anyString(), any()))
+            .thenReturn(Lists.newArrayList(nodeSet));
+    when(clusterFacade.getRangeToEndpointMap(any(), anyString()))
+            .thenReturn((Map) ImmutableMap.of(
+                    Lists.newArrayList("0", "100"), Lists.newArrayList(nodeSet),
+                    Lists.newArrayList("100", "200"), Lists.newArrayList(nodeSet)));
+    when(clusterFacade.getEndpointToHostId(any())).thenReturn(nodeMap);
+    when(clusterFacade.listActiveCompactions(any())).thenReturn(
+            CompactionStats.builder()
+                    .withActiveCompactions(Collections.emptyList())
+                    .withPendingCompactions(Optional.of(0))
+                    .build());
+    context.repairManager = RepairManager.create(
+            context,
+            clusterFacade,
+            Executors.newScheduledThreadPool(10),
+            1,
+            TimeUnit.MILLISECONDS,
+            1,
+            context.storage.getRepairRunDao());
+    AtomicInteger repairNumberCounter = new AtomicInteger(1);
+    when(jmx.triggerRepair(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+            .then(
+                    (invocation) -> {
+                      final int repairNumber = repairNumberCounter.getAndIncrement();
+                      new Thread() {
+                        @Override
+                        public void run() {
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.STARTED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.SESSION_SUCCESS),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                          ((RepairStatusHandler) invocation.getArgument(5))
+                                  .handle(
+                                          repairNumber,
+                                          Optional.of(ActiveRepairService.Status.FINISHED),
+                                          Optional.empty(),
+                                          null,
+                                          jmx);
+                        }
+                      }.start();
+                      return repairNumber;
+                    });
+    context.managementConnectionFactory = new JmxManagementConnectionFactory(context, new NoopCrypotograph()) {
+      @Override
+      protected JmxCassandraManagementProxy connectImpl(Node host) throws ReaperException {
+        return jmx;
+      }
+    };
+    assertEquals(RepairRun.RunState.NOT_STARTED, storage.getRepairRunDao().getRepairRun(runId).get().getRunState());
+    storage.getRepairRunDao().updateRepairRun(
+            run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(runId));
+    when(jmx.getRangeToEndpointMap(anyString())).thenReturn(twoNodeClusterAfterBootstrap());
+    context.repairManager.resumeRunningRepairRuns();
+    // The repair run should succeed despite the topology change. Although token ranges change,
+    // they will become larger and still entirely enclose each previously calculated segment.
+    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+      return RepairRun.RunState.DONE == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
+    });
+  }
+
+}


### PR DESCRIPTION
Token range movement occurs when a Cassandra cluster is expanded. When a cluster is expanded during an ongoing repair, repair segments that were previously calculated using old token ranges will no longer fully enclose each new token range. As a result, repairs hang as Reaper continuously retries failing segments that are no longer owned by a single Cassandra node.

This PR prevents repairs from hanging in this case by failing a repair early if there is an additive change in cluster topology. This PR also adds functionality to optionally reschedule a repair to run after a configurable amount of time. 

Fixes #1367