### PR TITLE
Memory store leader election - REAP-2

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairManager.java
@@ -308,9 +308,7 @@ public final class RepairManager implements AutoCloseable {
       if (context.storage instanceof IDistributedStorage || !repairRunners.containsKey(repairRun.getId())) {
         // When multiple Reapers are in use, we can get stuck segments when one instance is rebooted
         // Any segment in RUNNING or STARTED state but with no leader should be killed
-        Set<UUID> leaders = context.storage instanceof IDistributedStorage
-            ? ((IDistributedStorage) context.storage).getLockedSegmentsForRun(repairRun.getId())
-            : Collections.emptySet();
+        Set<UUID> leaders = context.storage.getLockedSegmentsForRun(repairRun.getId());
 
         Collection<RepairSegment> orphanedSegments = runningSegments
             .stream()

--- a/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IDistributedStorage.java
@@ -41,7 +41,6 @@ import io.cassandrareaper.storage.metrics.IDistributedMetrics;
 import io.cassandrareaper.storage.operations.IOperationsDao;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 
@@ -61,23 +60,6 @@ public interface IDistributedStorage extends IDistributedMetrics {
   List<UUID> getLeaders();
 
   void releaseLead(UUID leaderId);
-
-  boolean lockRunningRepairsForNodes(
-      UUID repairId,
-      UUID segmentId,
-      Set<String> replicas);
-
-  boolean renewRunningRepairsForNodes(
-      UUID repairId,
-      UUID segmentId,
-      Set<String> replicas);
-
-  boolean releaseRunningRepairsForNodes(
-      UUID repairId,
-      UUID segmentId,
-      Set<String> replicas);
-
-  Set<UUID> getLockedSegmentsForRun(UUID runId);
 
   int countRunningReapers();
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/IStorageDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/IStorageDao.java
@@ -26,6 +26,9 @@ import io.cassandrareaper.storage.repairsegment.IRepairSegmentDao;
 import io.cassandrareaper.storage.repairunit.IRepairUnitDao;
 import io.cassandrareaper.storage.snapshot.ISnapshotDao;
 
+import java.util.Set;
+import java.util.UUID;
+
 import io.dropwizard.lifecycle.Managed;
 
 /**
@@ -33,6 +36,23 @@ import io.dropwizard.lifecycle.Managed;
  */
 public interface IStorageDao extends Managed,
     IMetricsDao {
+
+  boolean lockRunningRepairsForNodes(
+      UUID repairId,
+      UUID segmentId,
+      Set<String> replicas);
+
+  boolean renewRunningRepairsForNodes(
+      UUID repairId,
+      UUID segmentId,
+      Set<String> replicas);
+
+  boolean releaseRunningRepairsForNodes(
+      UUID repairId,
+      UUID segmentId,
+      Set<String> replicas);
+
+  Set<UUID> getLockedSegmentsForRun(UUID runId);
 
   boolean isStorageConnected();
 

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.google.common.io.Files;
 import org.eclipse.serializer.persistence.types.PersistenceFieldEvaluator;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
@@ -111,7 +112,7 @@ public final class MemoryStorageFacade implements IStorageDao {
   }
 
   public MemoryStorageFacade() {
-    this("/tmp/" + UUID.randomUUID().toString(), DEFAULT_LEAD_TIME);
+    this(Files.createTempDir().getAbsolutePath(), DEFAULT_LEAD_TIME);
   }
 
   public MemoryStorageFacade(String persistenceStoragePath) {
@@ -119,7 +120,7 @@ public final class MemoryStorageFacade implements IStorageDao {
   }
 
   public MemoryStorageFacade(long leadTime) {
-    this("/tmp/" + UUID.randomUUID().toString(), leadTime);
+    this(Files.createTempDir().getAbsolutePath(), leadTime);
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/MemoryStorageFacade.java
@@ -322,6 +322,7 @@ public final class MemoryStorageFacade implements IStorageDao {
 
   @Override
   public boolean releaseRunningRepairsForNodes(UUID runId, UUID segmentId, Set<String> replicas) {
+    LOG.info("Releasing locks for runId: {}, segmentId: {}, replicas: {}", runId, segmentId, replicas);
     return repairRunLockManager.releaseRunningRepairsForNodes(runId, segmentId, replicas);
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/BasicSteps.java
@@ -562,6 +562,7 @@ public final class BasicSteps {
       params.put("intensity", "0.9");
       params.put("scheduleDaysBetween", "1");
       params.put("scheduleTriggerTime", DateTime.now().plusSeconds(1).toString());
+      params.put("segmentCountPerNode", "1");
       ReaperTestJettyRunner runner = RUNNERS.get(RAND.nextInt(RUNNERS.size()));
       Response response = runner.callReaper("POST", "/repair_schedule", Optional.of(params));
       int responseStatus = response.getStatus();

--- a/src/server/src/test/java/io/cassandrareaper/acceptance/ReaperMetricsIT.java
+++ b/src/server/src/test/java/io/cassandrareaper/acceptance/ReaperMetricsIT.java
@@ -67,7 +67,11 @@ public class ReaperMetricsIT {
   }
 
   public static void deleteFolderContents(String folderPath) throws IOException {
+    // Check if the path exists
     Path path = Paths.get(folderPath);
+    if (!Files.exists(path)) {
+      return;
+    }
     try (Stream<Path> walk = Files.walk(path)) {
       walk.sorted(Comparator.reverseOrder())
           .forEach(p -> {

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairManagerTest.java
@@ -26,7 +26,6 @@ import io.cassandrareaper.core.RepairSegment;
 import io.cassandrareaper.core.RepairUnit;
 import io.cassandrareaper.core.Segment;
 import io.cassandrareaper.management.ClusterFacade;
-import io.cassandrareaper.storage.IDistributedStorage;
 import io.cassandrareaper.storage.IStorageDao;
 import io.cassandrareaper.storage.cassandra.CassandraStorageFacade;
 import io.cassandrareaper.storage.cluster.IClusterDao;
@@ -144,7 +143,7 @@ public final class RepairManagerTest {
     Mockito.doNothing().when(context.repairManager).abortSegments(any(), any());
     Mockito.doReturn(run).when(context.repairManager).startRepairRun(run);
 
-    when(((IDistributedStorage) context.storage).getLockedSegmentsForRun(any())).thenReturn(Collections.emptySet());
+    when(context.storage.getLockedSegmentsForRun(any())).thenReturn(Collections.emptySet());
     IRepairUnitDao mockedRepairUnitDao = mock(IRepairUnitDao.class);
     Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnitDao()).thenReturn(mockedRepairUnitDao);
     Mockito.when(mockedRepairUnitDao.getRepairUnit(any(UUID.class))).thenReturn(cf);
@@ -238,7 +237,7 @@ public final class RepairManagerTest {
     Mockito.when(((CassandraStorageFacade) context.storage).getRepairUnitDao()).thenReturn(mockedRepairUnitDao);
     Mockito.when(mockedRepairUnitDao.getRepairUnit(any(UUID.class))).thenReturn(cf);
 
-    when(((IDistributedStorage) context.storage).getLockedSegmentsForRun(any())).thenReturn(
+    when(context.storage.getLockedSegmentsForRun(any())).thenReturn(
         new HashSet<UUID>(Arrays.asList(segment.getId())));
 
     context.repairManager.resumeRunningRepairRuns();

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerHangingTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerHangingTest.java
@@ -83,7 +83,7 @@ import static org.mockito.Mockito.when;
 
 public final class RepairRunnerHangingTest {
 
-  private static final long LEAD_TIME = 1L;
+  private static final long LEAD_TTL = 1000L;
   private static final Logger LOG = LoggerFactory.getLogger(RepairRunnerHangingTest.class);
   private static final Set<String> TABLES = ImmutableSet.of("table1");
   private static final List<BigInteger> THREE_TOKENS = Lists.newArrayList(
@@ -243,7 +243,7 @@ public final class RepairRunnerHangingTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 1;
-    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     storage.getClusterDao().addCluster(cluster);
     RepairUnit cf = storage.getRepairUnitDao().addRepairUnit(
         RepairUnit.builder()
@@ -398,7 +398,7 @@ public final class RepairRunnerHangingTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 1;
-    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     storage.getClusterDao().addCluster(cluster);
     DateTimeUtils.setCurrentMillisFixed(timeRun);
     RepairUnit cf = storage.getRepairUnitDao().addRepairUnit(
@@ -554,7 +554,7 @@ public final class RepairRunnerHangingTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerHangingTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerHangingTest.java
@@ -83,6 +83,7 @@ import static org.mockito.Mockito.when;
 
 public final class RepairRunnerHangingTest {
 
+  private static final long LEAD_TIME = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(RepairRunnerHangingTest.class);
   private static final Set<String> TABLES = ImmutableSet.of("table1");
   private static final List<BigInteger> THREE_TOKENS = Lists.newArrayList(
@@ -242,7 +243,7 @@ public final class RepairRunnerHangingTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 1;
-    final IStorageDao storage = new MemoryStorageFacade();
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
     storage.getClusterDao().addCluster(cluster);
     RepairUnit cf = storage.getRepairUnitDao().addRepairUnit(
         RepairUnit.builder()
@@ -397,7 +398,7 @@ public final class RepairRunnerHangingTest {
     final double intensity = 0.5f;
     final int repairThreadCount = 1;
     final int segmentTimeout = 1;
-    final IStorageDao storage = new MemoryStorageFacade();
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
     storage.getClusterDao().addCluster(cluster);
     DateTimeUtils.setCurrentMillisFixed(timeRun);
     RepairUnit cf = storage.getRepairUnitDao().addRepairUnit(
@@ -553,7 +554,7 @@ public final class RepairRunnerHangingTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade();
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -805,7 +805,7 @@ public final class RepairRunnerTest {
         run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(runId));
     context.repairManager.resumeRunningRepairRuns();
 
-    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+    await().with().atMost(120, TimeUnit.SECONDS).until(() -> {
       return RepairRun.RunState.DONE == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
     });
   }

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -670,7 +670,7 @@ public final class RepairRunnerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // The repair run should succeed despite the topology change.
-    await().with().atMost(60, TimeUnit.SECONDS).until(() -> {
+    await().with().atMost(120, TimeUnit.SECONDS).until(() -> {
       return RepairRun.RunState.DONE == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
     });
   }

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -99,6 +99,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public final class RepairRunnerTest {
+  private static final long LEAD_TIME = 1L;
   private static final Set<String> TABLES = ImmutableSet.of("table1");
   private static final Duration POLL_INTERVAL = Duration.TWO_SECONDS;
   private static final List<BigInteger> THREE_TOKENS = Lists.newArrayList(
@@ -223,7 +224,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade();
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -333,8 +334,10 @@ public final class RepairRunnerTest {
         run.with().runState(RepairRun.RunState.RUNNING).startTime(DateTime.now()).build(runId));
 
     context.repairManager.resumeRunningRepairRuns();
-    Thread.sleep(1000);
-    assertEquals(RepairRun.RunState.DONE, storage.getRepairRunDao().getRepairRun(runId).get().getRunState());
+
+    await().with().pollInterval(POLL_INTERVAL).atMost(30, SECONDS).until(() -> {
+      return RepairRun.RunState.DONE == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
+    });
   }
 
   @Test(expected = ConditionTimeoutException.class)
@@ -353,7 +356,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade();
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -546,7 +549,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade();
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -667,7 +670,7 @@ public final class RepairRunnerTest {
     context.repairManager.resumeRunningRepairRuns();
 
     // The repair run should succeed despite the topology change.
-    await().with().atMost(20, TimeUnit.SECONDS).until(() -> {
+    await().with().atMost(60, TimeUnit.SECONDS).until(() -> {
       return RepairRun.RunState.DONE == storage.getRepairRunDao().getRepairRun(runId).get().getRunState();
     });
   }
@@ -687,7 +690,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade();
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -962,7 +965,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade();
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairRunnerTest.java
@@ -99,7 +99,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public final class RepairRunnerTest {
-  private static final long LEAD_TIME = 1L;
+  private static final long LEAD_TTL = 100L;
   private static final Set<String> TABLES = ImmutableSet.of("table1");
   private static final Duration POLL_INTERVAL = Duration.TWO_SECONDS;
   private static final List<BigInteger> THREE_TOKENS = Lists.newArrayList(
@@ -224,7 +224,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -356,7 +356,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -549,7 +549,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -690,7 +690,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();
@@ -965,7 +965,7 @@ public final class RepairRunnerTest {
     final int repairThreadCount = 1;
     final int segmentTimeout = 30;
     final List<BigInteger> tokens = THREE_TOKENS;
-    final IStorageDao storage = new MemoryStorageFacade(LEAD_TIME);
+    final IStorageDao storage = new MemoryStorageFacade(LEAD_TTL);
     AppContext context = new AppContext();
     context.storage = storage;
     context.config = new ReaperApplicationConfiguration();

--- a/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SegmentRunnerTest.java
@@ -193,6 +193,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
@@ -348,6 +349,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
@@ -496,6 +498,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
@@ -639,6 +642,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
@@ -782,6 +786,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
@@ -927,6 +932,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
@@ -1073,6 +1079,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
@@ -1205,6 +1212,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);
@@ -1300,6 +1308,7 @@ public final class SegmentRunnerTest {
     RepairRunner rr = mock(RepairRunner.class);
     RepairUnit ru = mock(RepairUnit.class);
     when(ru.getKeyspaceName()).thenReturn("reaper");
+    when(rr.getRepairRunId()).thenReturn(runId);
 
     ClusterFacade clusterFacade = mock(ClusterFacade.class);
     when(clusterFacade.connect(any(Cluster.class), any())).thenReturn(jmx);

--- a/src/server/src/test/java/io/cassandrareaper/storage/memory/ReplicaLockManagerWithTtlTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/storage/memory/ReplicaLockManagerWithTtlTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014-2017 Spotify AB
+ * Copyright 2016-2019 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.memory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class ReplicaLockManagerWithTtlTest {
+
+  private ReplicaLockManagerWithTtl replicaLockManager;
+  private UUID runId;
+  private UUID segmentId;
+  private Set<String> replicas;
+  private Set<String> replicasOverlap;
+
+  @BeforeEach
+  public void setUp() {
+    replicaLockManager = new ReplicaLockManagerWithTtl(1); // TTL of 60 seconds
+    runId = UUID.randomUUID();
+    segmentId = UUID.randomUUID();
+    replicas = new HashSet<>(Arrays.asList("replica1", "replica2", "replica3"));
+    replicasOverlap = new HashSet<>(Arrays.asList("replica4", "replica2", "replica5"));
+  }
+
+  @Test
+  public void testLockRunningRepairsForNodes() {
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicas));
+  }
+
+  @Test
+  public void testLockRunningRepairsForNodesAlreadyLocked() {
+    UUID anotherRunId = UUID.randomUUID();
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicas));
+    assertFalse(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicas));
+  }
+
+  @Test
+  public void testRenewRunningRepairsForNodes() {
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicas));
+    assertTrue(replicaLockManager.renewRunningRepairsForNodes(runId, segmentId, replicas));
+  }
+
+  @Test
+  public void testRenewRunningRepairsForNodesNotLocked() {
+    assertFalse(replicaLockManager.renewRunningRepairsForNodes(runId, segmentId, replicas));
+  }
+
+  @Test
+  public void testReleaseRunningRepairsForNodes() {
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicas));
+    assertTrue(replicaLockManager.releaseRunningRepairsForNodes(runId, segmentId, replicas));
+  }
+
+  @Test
+  public void testGetLockedSegmentsForRun() {
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicas));
+    Set<UUID> lockedSegments = replicaLockManager.getLockedSegmentsForRun(runId);
+    assertTrue(lockedSegments.contains(segmentId));
+  }
+
+  @Test
+  public void testCleanupExpiredLocks() throws InterruptedException {
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicas));
+    // We can lock the replica for a different run id
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(UUID.randomUUID(), UUID.randomUUID(), replicas));
+    // The following lock should fail because overlapping replicas are already locked
+    assertFalse(replicaLockManager.lockRunningRepairsForNodes(runId, UUID.randomUUID(), replicasOverlap));
+    Thread.sleep(1000); // Wait for TTL to expire
+    replicaLockManager.cleanupExpiredLocks();
+    // The following lock should succeed as the lock expired
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicasOverlap));
+  }
+}

--- a/src/server/src/test/java/io/cassandrareaper/storage/memory/ReplicaLockManagerWithTtlTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/storage/memory/ReplicaLockManagerWithTtlTest.java
@@ -39,7 +39,7 @@ public class ReplicaLockManagerWithTtlTest {
 
   @BeforeEach
   public void setUp() {
-    replicaLockManager = new ReplicaLockManagerWithTtl(1); // TTL of 60 seconds
+    replicaLockManager = new ReplicaLockManagerWithTtl(1000);
     runId = UUID.randomUUID();
     segmentId = UUID.randomUUID();
     replicas = new HashSet<>(Arrays.asList("replica1", "replica2", "replica3"));

--- a/src/server/src/test/resources/cassandra-reaper-metrics-test.yaml
+++ b/src/server/src/test/resources/cassandra-reaper-metrics-test.yaml
@@ -28,7 +28,7 @@ enableDynamicSeedList: false
 jmxConnectionTimeoutInSeconds: 10
 datacenterAvailability: LOCAL
 percentRepairedCheckIntervalMinutes: 1
-repairManagerSchedulingIntervalSeconds: 0
+repairManagerSchedulingIntervalSeconds: 1
 
 logging:
   level: WARN


### PR DESCRIPTION
Fixes #1519 

The memory storage backend didn't implement any if the `IDistributedStorage` leader election methods.
This was ok until we started using leader election for segment scheduling, which doesn't require to run in a distributed mode.
As a consequence, Reaper using the mem store would schedule one new segment at each poll, even if the replicas were already busy processing another segment.

This PR introduces a class which manages locks on replicas for segments and moves the required methods from `IDistributedStorage` to `IStorage` so they can be implemented in the memory storage implementation.