### PR TITLE
Fix bug in replica lock release in the mem store

### DIFF
--- a/src/server/src/test/java/io/cassandrareaper/storage/memory/ReplicaLockManagerWithTtlTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/storage/memory/ReplicaLockManagerWithTtlTest.java
@@ -72,7 +72,11 @@ public class ReplicaLockManagerWithTtlTest {
   @Test
   public void testReleaseRunningRepairsForNodes() {
     assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, segmentId, replicas));
+    // Same replicas can't be locked twice
+    assertFalse(replicaLockManager.lockRunningRepairsForNodes(runId, UUID.randomUUID(), replicas));
     assertTrue(replicaLockManager.releaseRunningRepairsForNodes(runId, segmentId, replicas));
+    // After unlocking, we can lock again
+    assertTrue(replicaLockManager.lockRunningRepairsForNodes(runId, UUID.randomUUID(), replicas));
   }
 
   @Test


### PR DESCRIPTION
There's currently a bug in the release lock code that doesn't actually releases the lock. As a consequence we need to wait for the lock to expire before being able to schedule a new segment.

This PR fixes this by properly cleaning up replica locks.