### PR TITLE
Fix: Upgrade cassandra-all from version 2.1.12 to 3.11.17, Upgrade OKIO from 3.0.0 to 3.4.0, Upgrade netty-all to 4.1.116

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
       - name: Setup Maven Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven3-${{ hashFiles('**/pom.xml') }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
       - name: Setup Maven Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven3-${{ hashFiles('**/pom.xml') }}

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -64,7 +64,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>24.1.1-jre</version>
-        </dependency>
+        </dependency> 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>2.2.12</version>
+            <version>3.11.17</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -143,11 +143,7 @@
                 <exclusion>
                    <groupId>com.google.guava</groupId>
                    <artifactId>guava</artifactId>
-               </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-all</artifactId>
-                </exclusion>
+               </exclusion> 
                 <exclusion>
                     <groupId>org.hibernate</groupId>
                     <artifactId>hibernate-validator</artifactId>
@@ -171,6 +167,26 @@
             <artifactId>netty-handler</artifactId>
             <version>4.1.94.Final</version>
         </dependency>
+        <dependency>
+           <groupId>com.boundary</groupId>
+           <artifactId>high-scale-lib</artifactId>
+           <version>1.0.6</version>
+        </dependency>
+        <dependency>
+           <groupId>com.github.jbellis</groupId>
+           <artifactId>jamm</artifactId>
+           <version>0.3.0</version>
+        </dependency>
+        <dependency>
+           <groupId>io.netty</groupId>
+           <artifactId>netty-all</artifactId>
+           <version>4.1.116.Final</version>
+        </dependency>
+        <dependency>
+           <groupId>com.fasterxml.jackson.datatype</groupId>
+           <artifactId>jackson-datatype-joda</artifactId>
+           <version>2.15.2</version>
+        </dependency>                                 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
@@ -265,8 +281,6 @@
           <artifactId>jersey-guava</artifactId>
           <version>2.26-b03</version>
         </dependency>
-		<!-- https://mvnrepository.com/artifact/org.glassfish.main.external/jmxremote_optional-repackaged -->
-        <!-- Used to connect to Cassandra through JMXMP protocol-->
         <dependency>
             <groupId>org.glassfish.main.external</groupId>
             <artifactId>jmxremote_optional-repackaged</artifactId>
@@ -278,11 +292,15 @@
             <version>${management.api.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okio</groupId>
+             <artifactId>okio-jvm</artifactId>
+             <version>3.4.0</version>
+       </dependency>
+        <dependency>
             <groupId>org.eclipse.store</groupId>
             <artifactId>storage-embedded</artifactId>
             <version>${eclipsestore.version}</version>
         </dependency>
-
 
         <!--test scope -->
 

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
@@ -933,8 +933,11 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
     this.getStorageServiceMBean().takeSnapshot(var1, var2);
   }
 
-  public void takeColumnFamilySnapshot(String var1, String var2, String var3) throws IOException {
-    this.getStorageServiceMBean().takeColumnFamilySnapshot(var1, var2, var3);
+  public void takeColumnFamilySnapshot(String keySpaceName, String columnFamilyName, String tag) throws IOException {
+    Map<String, String> options = new HashMap<>();
+    String target = (columnFamilyName == null || columnFamilyName.trim().isEmpty()) ? keySpaceName
+     : keySpaceName + "." + columnFamilyName;
+    this.getStorageServiceMBean().takeSnapshot(tag, options, target);
   }
 
   public Map<String, String> getTokenToEndpointMap() {

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
@@ -936,7 +936,7 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
   public void takeColumnFamilySnapshot(String keySpaceName, String columnFamilyName, String tag) throws IOException {
     Map<String, String> options = new HashMap<>();
     String target = (columnFamilyName == null || columnFamilyName.trim().isEmpty()) ? keySpaceName
-     : keySpaceName + "." + columnFamilyName;
+        : keySpaceName + "." + columnFamilyName;
     this.getStorageServiceMBean().takeSnapshot(tag, options, target);
   }
 

--- a/src/server/src/test/java/io/cassandrareaper/service/StreamFactoryTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/StreamFactoryTest.java
@@ -19,23 +19,44 @@ package io.cassandrareaper.service;
 
 import io.cassandrareaper.core.Stream;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.UUID;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.streaming.ProgressInfo;
 import org.apache.cassandra.streaming.SessionInfo;
 import org.apache.cassandra.streaming.StreamSession;
 import org.apache.cassandra.streaming.StreamState;
 import org.apache.cassandra.streaming.StreamSummary;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 
 public final class StreamFactoryTest {
+
+   private static final String STREAM_FACTORY_TEST_CASSANDRA_FILE = "stream-factory-test-cassandra.yaml";
+
+   @BeforeClass
+   public static void setupClass() {
+     String configPath = Thread.currentThread().getContextClassLoader()
+       .getResource(STREAM_FACTORY_TEST_CASSANDRA_FILE).toString();
+     if (configPath == null) {
+        throw new IllegalStateException("Cassandra configuration file not found in resources!");
+     }
+     System.setProperty("cassandra.config", configPath);
+     new File("/tmp/cassandra/data").mkdirs();
+     new File("/tmp/cassandra/commitlog").mkdirs();
+     new File("/tmp/cassandra/saved_caches").mkdirs();
+     new File("/tmp/cassandra/hints").mkdirs();
+     new File("/tmp/cassandra/cdc_raw").mkdirs();
+     DatabaseDescriptor.daemonInitialization();
+   }
 
   @Test
   public void testCountProgressPerTableWithTable() throws UnknownHostException {

--- a/src/server/src/test/java/io/cassandrareaper/service/StreamFactoryTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/StreamFactoryTest.java
@@ -39,24 +39,23 @@ import static org.junit.Assert.assertEquals;
 
 
 public final class StreamFactoryTest {
+  private static final String STREAM_FACTORY_TEST_CASSANDRA_FILE = "stream-factory-test-cassandra.yaml";
 
-   private static final String STREAM_FACTORY_TEST_CASSANDRA_FILE = "stream-factory-test-cassandra.yaml";
-
-   @BeforeClass
-   public static void setupClass() {
-     String configPath = Thread.currentThread().getContextClassLoader()
-       .getResource(STREAM_FACTORY_TEST_CASSANDRA_FILE).toString();
-     if (configPath == null) {
-        throw new IllegalStateException("Cassandra configuration file not found in resources!");
-     }
-     System.setProperty("cassandra.config", configPath);
-     new File("/tmp/cassandra/data").mkdirs();
-     new File("/tmp/cassandra/commitlog").mkdirs();
-     new File("/tmp/cassandra/saved_caches").mkdirs();
-     new File("/tmp/cassandra/hints").mkdirs();
-     new File("/tmp/cassandra/cdc_raw").mkdirs();
-     DatabaseDescriptor.daemonInitialization();
-   }
+  @BeforeClass
+  public static void setupClass() {
+    String configPath = Thread.currentThread().getContextClassLoader()
+        .getResource(STREAM_FACTORY_TEST_CASSANDRA_FILE).toString();
+    if (configPath == null) {
+      throw new IllegalStateException("Cassandra configuration file not found in resources!");
+    }
+    System.setProperty("cassandra.config", configPath);
+    new File("/tmp/cassandra/data").mkdirs();
+    new File("/tmp/cassandra/commitlog").mkdirs();
+    new File("/tmp/cassandra/saved_caches").mkdirs();
+    new File("/tmp/cassandra/hints").mkdirs();
+    new File("/tmp/cassandra/cdc_raw").mkdirs();
+    DatabaseDescriptor.daemonInitialization();
+  }
 
   @Test
   public void testCountProgressPerTableWithTable() throws UnknownHostException {

--- a/src/server/src/test/resources/stream-factory-test-cassandra.yaml
+++ b/src/server/src/test/resources/stream-factory-test-cassandra.yaml
@@ -1,0 +1,14 @@
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+data_file_directories:
+    - /tmp/cassandra/data
+commitlog_directory: /tmp/cassandra/commitlog
+saved_caches_directory: /tmp/cassandra/saved_caches
+hints_directory: /tmp/cassandra/hints
+cdc_raw_directory: /tmp/cassandra/cdc_raw
+endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch
+seed_provider:
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      - seeds: "127.0.0.1"


### PR DESCRIPTION
As part of our security assessment, we conducted a Black Duck scan to identify vulnerabilities in various dependencies. The scan detected multiple CVE (Common Vulnerabilities and Exposures) in the following libraries, which have now been upgraded to more secure versions:
Identified CVEs and Respective Upgrades:
Cassandra-all (v2.2.12 → v3.11.17)
Fixes: https://github.com/advisories/GHSA-pqr6-cmr2-h8hf, https://github.com/advisories/GHSA-fjpj-2g6w-x25r, https://github.com/advisories/GHSA-qcwq-55hx-v3vh, https://github.com/advisories/GHSA-x59f-cpgf-vmmv, https://github.com/advisories/GHSA-24ww-mc5x-xc43, https://github.com/advisories/GHSA-2vxm-vp4c-fjfw, https://github.com/advisories/GHSA-8ffc-79xg-29w8, https://github.com/advisories/GHSA-php4-mj74-f79r, https://github.com/advisories/GHSA-55g7-9cwv-5qfv
Okio (v3.0.0 → v3.4.0)
Fixes: https://github.com/advisories/GHSA-w33c-445m-f8w7
Netty-All (v4.1.94 → v4.1.116)
Fixes: https://github.com/advisories/GHSA-qppj-fm5r-hxr3
Apache Shiro (already at v1.13.0 in Reaper 3.7.0)
Fixes: https://github.com/advisories/GHSA-pmhc-2g4f-85cg, https://github.com/advisories/GHSA-jc7h-c423-mpjc, https://github.com/advisories/GHSA-hhw5-c326-822h
Major Code Changes:
pom.xml: Updated dependencies (../cassandra-reaper/src/server/pom.xml).
JmxCassandraManagementProxy.java: Modified (./cassandra-reaper/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java).
Added a dummy cassandra.yaml file: Required to resolve test case failures.