### PR TITLE
Add clusterName to JMX connection logs

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxCassandraManagementProxy.java
@@ -176,7 +176,8 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
       int connectionTimeout,
       MetricRegistry metricRegistry,
       Cryptograph cryptograph,
-      Jmxmp jmxmp)
+      Jmxmp jmxmp,
+      String clusterName)
       throws ReaperException, InterruptedException {
 
     if (host == null) {
@@ -193,7 +194,8 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
         connectionTimeout,
         metricRegistry,
         cryptograph,
-        jmxmp);
+        jmxmp,
+        clusterName);
   }
 
   /**
@@ -213,7 +215,8 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
       int connectionTimeout,
       MetricRegistry metricRegistry,
       Cryptograph cryptograph,
-      Jmxmp jmxmp) throws ReaperException, InterruptedException {
+      Jmxmp jmxmp,
+      String clusterName) throws ReaperException, InterruptedException {
 
     JMXServiceURL jmxUrl;
     String host = originalHost;
@@ -227,7 +230,7 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
       LOG.debug("Connecting to {}...", host);
       jmxUrl = JmxAddresses.getJmxServiceUrl(host, port, jmxmp.isEnabled());
     } catch (MalformedURLException e) {
-      LOG.error(String.format("Failed to prepare the JMX connection to %s:%s", host, port));
+      LOG.error(String.format("Failed to prepare the JMX connection to %s:%s in cluster %s", host, port, clusterName));
       throw new ReaperException("Failure during preparations for JMX connection", e);
     }
     try {
@@ -287,17 +290,19 @@ public final class JmxCassandraManagementProxy implements ICassandraManagementPr
       if (smProxy.isPresent()) {
         mbeanServerConn.addNotificationListener(ObjectNames.STREAM_MANAGER, proxy, null, null);
       }
-      LOG.debug("JMX connection to {} properly connected: {}", host, jmxUrl.toString());
+      LOG.debug("JMX connection to {} in cluster {} properly connected: {}", host, clusterName, jmxUrl.toString());
 
       return proxy;
     } catch (IOException | ExecutionException | TimeoutException | InstanceNotFoundException e) {
-      throw new ReaperException("Failure when establishing JMX connection to " + host + ":" + port, e);
+      throw new ReaperException("Failure when establishing JMX connection to "
+              + host + ":" + port + " in cluster " + clusterName, e);
     } catch (InterruptedException expected) {
       LOG.debug(
-          "JMX connection to {}:{} was interrupted by Reaper. "
+          "JMX connection to {}:{} in cluster {} was interrupted by Reaper. "
               + "Another JMX connection must have succeeded before this one.",
           host,
-          port);
+          port,
+          clusterName);
       throw expected;
     }
   }

--- a/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/jmx/JmxManagementConnectionFactory.java
@@ -158,7 +158,7 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
     try {
       JmxConnectionProvider provider = new JmxConnectionProvider(
           host, jmxCredentials, context.config.getJmxConnectionTimeoutInSeconds(),
-          this.metricRegistry, cryptograph, this.jmxmp);
+          this.metricRegistry, cryptograph, this.jmxmp, node.getClusterName());
       JMX_CONNECTIONS.computeIfAbsent(host, provider::apply);
       JmxCassandraManagementProxy proxy = JMX_CONNECTIONS.get(host);
       if (!proxy.isConnectionAlive()) {
@@ -274,6 +274,7 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
     private final MetricRegistry metricRegistry;
     private final Cryptograph cryptograph;
     private final Jmxmp jmxmp;
+    private final String clusterName;
 
     JmxConnectionProvider(
         String host,
@@ -281,13 +282,15 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
         int connectionTimeout,
         MetricRegistry metricRegistry,
         Cryptograph cryptograph,
-        Jmxmp jmxmp) {
+        Jmxmp jmxmp,
+        String clusterName) {
       this.host = host;
       this.jmxCredentials = jmxCredentials;
       this.connectionTimeout = connectionTimeout;
       this.metricRegistry = metricRegistry;
       this.cryptograph = cryptograph;
       this.jmxmp = jmxmp;
+      this.clusterName = clusterName;
     }
 
     @Override
@@ -295,7 +298,8 @@ public class JmxManagementConnectionFactory implements IManagementConnectionFact
       Preconditions.checkArgument(host.equals(this.host));
       try {
         JmxCassandraManagementProxy proxy = JmxCassandraManagementProxy.connect(
-            host, jmxCredentials, addressTranslator, connectionTimeout, metricRegistry, cryptograph, jmxmp);
+            host, jmxCredentials, addressTranslator, connectionTimeout, metricRegistry,
+            cryptograph, jmxmp, clusterName);
         return proxy;
       } catch (ReaperException | InterruptedException ex) {
         throw new RuntimeException(ex);


### PR DESCRIPTION
To enhance observability of JMX connection failures and simplify troubleshooting, this patch introduces a new `clusterName` parameter in `JmxCassandraManagementProxy.connect` so that logs can include the cluster name of the node that Reaper is attempting to connect to. 


Compiled and successfully ran all server tests:

![Screenshot 2025-03-25 at 3 43 14 PM](https://github.com/user-attachments/assets/62bad511-d914-41df-9443-6ee062b39472)
