### PR TITLE
Enable purge after 30 days by default

### DIFF
--- a/src/docs/content/docs/configuration/docker_vars.md
+++ b/src/docs/content/docs/configuration/docker_vars.md
@@ -54,6 +54,7 @@ The Docker environment variables listed in this section map directly to Reaper s
 <code class="codeLarge">REAPER_MAX_PARALLEL_REPAIRS</code> | [maxParallelRepairs]({{< relref "reaper_specific.md#maxParallelRepairs" >}})                                         | 2
 <code class="codeLarge">CRYPTO_SYSTEM_PROPERTY_SECRET</code> | [cryptograph/systemPropertySecret]({{< relref "reaper_specific.md#cryptograph" >}})                                  | Unset
 <code class="codeLarge">REAPER_HTTP_MANAGEMENT_ENABLE</code> | [httpManagement/enabled]({{< relref "reaper_specific.md#httpManagement" >}})                                            | false
+<code class="codeLarge">REAPER_PURGE_RECORDS_AFTER_IN_DAYS</code> | [purgeRecordsAfterInDays]({{< relref "reaper_specific.md#purgeRecordsAfterInDays" >}})                                            | 30
 
 <br/>
 

--- a/src/docs/content/docs/configuration/reaper_specific.md
+++ b/src/docs/content/docs/configuration/reaper_specific.md
@@ -375,6 +375,14 @@ In a 10 nodes cluster, setting a value of 20 segments per node will generate a r
 
 <br/>
 
+## `purgeRecordsAfterInDays`
+
+Type: *Integer*
+
+Default: *30*
+
+Defines the amount of days after which a repair run will get purged from storage.
+
 ### `server`
 
 Settings to configure the application UI server.

--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -86,7 +86,8 @@ ENV REAPER_SEGMENT_COUNT_PER_NODE=64 \
     REAPER_HTTP_MANAGEMENT_TRUSTSTORE_PATH="" \
     REAPER_HTTP_MANAGEMENT_TRUSTSTORES_DIR="" \
     REAPER_TMP_DIRECTORY="/var/tmp/cassandra-reaper" \
-    REAPER_MEMORY_STORAGE_DIRECTORY="/var/lib/cassandra-reaper/storage"
+    REAPER_MEMORY_STORAGE_DIRECTORY="/var/lib/cassandra-reaper/storage" \
+    REAPER_PURGE_RECORDS_AFTER_IN_DAYS=30
 
 
 RUN apk add --update \

--- a/src/server/src/main/docker/Dockerfile-spreaper
+++ b/src/server/src/main/docker/Dockerfile-spreaper
@@ -84,7 +84,8 @@ ENV REAPER_SEGMENT_COUNT_PER_NODE=64 \
     REAPER_HTTP_MANAGEMENT_TRUSTSTORE_PATH="" \
     REAPER_HTTP_MANAGEMENT_TRUSTSTORES_DIR="" \
     REAPER_TMP_DIRECTORY="/var/tmp/cassandra-reaper" \
-    REAPER_MEMORY_STORAGE_DIRECTORY="/var/lib/cassandra-reaper/storage"
+    REAPER_MEMORY_STORAGE_DIRECTORY="/var/lib/cassandra-reaper/storage" \
+    REAPER_PURGE_RECORDS_AFTER_IN_DAYS=30
 
 # used to run spreaper cli
 RUN apk add --update \

--- a/src/server/src/main/docker/cassandra-reaper.yml
+++ b/src/server/src/main/docker/cassandra-reaper.yml
@@ -32,6 +32,7 @@ useAddressTranslator: ${REAPER_USE_ADDRESS_TRANSLATOR}
 maxParallelRepairs: ${REAPER_MAX_PARALLEL_REPAIRS}
 scheduleRetryOnError: ${REAPER_SCHEDULE_RETRY_ON_ERROR:-false}
 scheduleRetryDelay: ${REAPER_SCHEDULE_RETRY_DELAY:-PT1H}
+purgeRecordsAfterInDays: ${REAPER_PURGE_RECORDS_AFTER_IN_DAYS}
 
 # datacenterAvailability has three possible values: ALL | LOCAL | EACH
 # the correct value to use depends on whether jmx ports to C* nodes in remote datacenters are accessible

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -140,11 +140,11 @@ public final class ReaperApplicationConfiguration extends Configuration {
   @JsonProperty
   private Integer repairThreadCount;
   /**
-   * If set to more than 0, defines how many days of run history should be kept.
+   * If set to more than 0, defines how many days of run history should be kept. Default: 30
    */
   @Nullable
   @JsonProperty
-  private Integer purgeRecordsAfterInDays;
+  private Integer purgeRecordsAfterInDays = 30;
   /**
    * If set to more than 0, defines how many runs to keep per repair unit.
    */
@@ -429,7 +429,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
   }
 
   public Integer getPurgeRecordsAfterInDays() {
-    return purgeRecordsAfterInDays == null ? 0 : purgeRecordsAfterInDays;
+    return purgeRecordsAfterInDays == null ? 30 : purgeRecordsAfterInDays;
   }
 
   @JsonProperty("purgeRecordsAfterInDays")


### PR DESCRIPTION
This pull request introduces a new configuration option, `purgeRecordsAfterInDays`, which defines the number of days after which repair run records are purged from storage. The changes include updates to documentation, configuration files, and default settings in the codebase.

### Documentation Updates:
* Added `purgeRecordsAfterInDays` to the Docker environment variables documentation (`docker_vars.md`) with a default value of 30 days.
* Documented the `purgeRecordsAfterInDays` option in the Reaper-specific configuration documentation (`reaper_specific.md`).

### Configuration and Defaults:
* Added `REAPER_PURGE_RECORDS_AFTER_IN_DAYS` to the `Dockerfile` with a default value of 30.
* Added `purgeRecordsAfterInDays` to the `cassandra-reaper.yml` configuration file, linked to the new environment variable.

### Codebase Changes:
* Set the default value of `purgeRecordsAfterInDays` to 30 in the `ReaperApplicationConfiguration` class and ensured the getter method respects this default. [[1]](diffhunk://#diff-cbda8e32a3358b7eac03101b7c8d7be28c325d9f891c1fb3d8da102d25a77a10L143-R147) [[2]](diffhunk://#diff-cbda8e32a3358b7eac03101b7c8d7be28c325d9f891c1fb3d8da102d25a77a10L432-R432)