### PR TITLE
Resolve ARM compilation errors by replacing depreciated 'node-saas' in favor of 'sass'

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -27,7 +27,7 @@
     "jsx-loader": "^0.13.0",
     "lodash": "^4.17.0",
     "moment": "^2.22.2",
-    "node-sass": "^4.9.0",
+    "sass": "^1.89.2",
     "react": "^16.13.0",
     "react-bootstrap": "^0.33.0",
     "react-dom": "^16.12.0",


### PR DESCRIPTION
When attempting to compile the UI component on ARM, the following error was occurring:

```
  Downloading binary from https://github.com/sass/node-sass/releases/download/v4.14.1/linux-arm64-72_binding.node
  Cannot download "https://github.com/sass/node-sass/releases/download/v4.14.1/linux-arm64-72_binding.node":
  HTTP error 404 Not Found
```

We were pinning to "node-sass", as a dependency, which does not look to have published a pre-built binary for ARM. On closer inspection, I noticed this dependency is now depreciated, and the GH repo is archived:
 - https://github.com/sass/node-sass

The recommendation is to migrate to (Dart) saas, which i've implemented in this PR. This seems to work, and i'm able to compile on ARM.