### PR TITLE
Update the dockerfile to produce ubi9 based images

### DIFF
--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -13,9 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM amazoncorretto:11-alpine
+FROM amazoncorretto:11-alpine AS builder
 
 ARG SHADED_JAR
+
+ADD src/server/src/main/docker/cassandra-reaper.yml /etc/cassandra-reaper/cassandra-reaper.yml
+ADD src/server/src/main/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+ADD src/server/src/main/docker/configure-persistence.sh /usr/local/bin/configure-persistence.sh
+ADD src/server/src/main/docker/configure-metrics.sh /usr/local/bin/configure-metrics.sh
+ADD src/server/src/main/docker/configure-jmx-credentials.sh /usr/local/bin/configure-jmx-credentials.sh
+ADD src/server/src/main/docker/configure-authentication.sh /usr/local/bin/configure-authentication.sh
+ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
+
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV REAPER_SEGMENT_COUNT_PER_NODE=64 \
     REAPER_REPAIR_PARALELLISM=DATACENTER_AWARE \
@@ -91,20 +102,22 @@ ENV REAPER_SEGMENT_COUNT_PER_NODE=64 \
     REAPER_PURGE_RECORDS_AFTER_IN_DAYS=30
 
 
-RUN apk add --update \
+RUN microdnf install -y \
+    java-11-openjdk-headless \
     bash \
-  && rm -rf /var/cache/apk/*
+    shadow-utils \
+  && microdnf clean all
 
-ADD src/server/src/main/docker/cassandra-reaper.yml /etc/cassandra-reaper/cassandra-reaper.yml
-ADD src/server/src/main/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-ADD src/server/src/main/docker/configure-persistence.sh /usr/local/bin/configure-persistence.sh
-ADD src/server/src/main/docker/configure-metrics.sh /usr/local/bin/configure-metrics.sh
-ADD src/server/src/main/docker/configure-jmx-credentials.sh /usr/local/bin/configure-jmx-credentials.sh
-ADD src/server/src/main/docker/configure-authentication.sh /usr/local/bin/configure-authentication.sh
-ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
+COPY --from=builder /etc/cassandra-reaper/cassandra-reaper.yml /etc/cassandra-reaper/cassandra-reaper.yml
+COPY --from=builder /usr/local/bin/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --from=builder /usr/local/bin/configure-persistence.sh /usr/local/bin/configure-persistence.sh
+COPY --from=builder /usr/local/bin/configure-metrics.sh /usr/local/bin/configure-metrics.sh
+COPY --from=builder /usr/local/bin/configure-jmx-credentials.sh /usr/local/bin/configure-jmx-credentials.sh
+COPY --from=builder /usr/local/bin/configure-authentication.sh /usr/local/bin/configure-authentication.sh
+COPY --from=builder /usr/local/lib/cassandra-reaper.jar /usr/local/lib/cassandra-reaper.jar
 
 
-RUN addgroup -g 1001 -S reaper && adduser -G reaper -S -u 1001 reaper && \
+RUN groupadd -g 1001 reaper && useradd -g reaper -u 1001 reaper && \
     mkdir -p /var/lib/cassandra-reaper && \
     mkdir -p /etc/cassandra-reaper/shiro && \
     mkdir -p /etc/cassandra-reaper/config && \

--- a/src/server/src/main/docker/Dockerfile
+++ b/src/server/src/main/docker/Dockerfile
@@ -13,20 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM amazoncorretto:11-alpine AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG SHADED_JAR
-
-ADD src/server/src/main/docker/cassandra-reaper.yml /etc/cassandra-reaper/cassandra-reaper.yml
-ADD src/server/src/main/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-ADD src/server/src/main/docker/configure-persistence.sh /usr/local/bin/configure-persistence.sh
-ADD src/server/src/main/docker/configure-metrics.sh /usr/local/bin/configure-metrics.sh
-ADD src/server/src/main/docker/configure-jmx-credentials.sh /usr/local/bin/configure-jmx-credentials.sh
-ADD src/server/src/main/docker/configure-authentication.sh /usr/local/bin/configure-authentication.sh
-ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
-
-
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV REAPER_SEGMENT_COUNT_PER_NODE=64 \
     REAPER_REPAIR_PARALELLISM=DATACENTER_AWARE \
@@ -108,13 +97,13 @@ RUN microdnf install -y \
     shadow-utils \
   && microdnf clean all
 
-COPY --from=builder /etc/cassandra-reaper/cassandra-reaper.yml /etc/cassandra-reaper/cassandra-reaper.yml
-COPY --from=builder /usr/local/bin/entrypoint.sh /usr/local/bin/entrypoint.sh
-COPY --from=builder /usr/local/bin/configure-persistence.sh /usr/local/bin/configure-persistence.sh
-COPY --from=builder /usr/local/bin/configure-metrics.sh /usr/local/bin/configure-metrics.sh
-COPY --from=builder /usr/local/bin/configure-jmx-credentials.sh /usr/local/bin/configure-jmx-credentials.sh
-COPY --from=builder /usr/local/bin/configure-authentication.sh /usr/local/bin/configure-authentication.sh
-COPY --from=builder /usr/local/lib/cassandra-reaper.jar /usr/local/lib/cassandra-reaper.jar
+ADD src/server/src/main/docker/cassandra-reaper.yml /etc/cassandra-reaper/cassandra-reaper.yml
+ADD src/server/src/main/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+ADD src/server/src/main/docker/configure-persistence.sh /usr/local/bin/configure-persistence.sh
+ADD src/server/src/main/docker/configure-metrics.sh /usr/local/bin/configure-metrics.sh
+ADD src/server/src/main/docker/configure-jmx-credentials.sh /usr/local/bin/configure-jmx-credentials.sh
+ADD src/server/src/main/docker/configure-authentication.sh /usr/local/bin/configure-authentication.sh
+ADD ${SHADED_JAR} /usr/local/lib/cassandra-reaper.jar
 
 
 RUN groupadd -g 1001 reaper && useradd -g reaper -u 1001 reaper && \


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the `cassandra-reaper` project to implement a multi-stage build process, switch to a Red Hat UBI base image for the runtime stage, and improve image configuration and dependency management.

### Multi-stage build and base image update:
* Introduced a multi-stage build process by adding a `builder` stage based on `amazoncorretto:11-alpine` and a runtime stage based on `registry.access.redhat.com/ubi9/ubi-minimal:latest`. This change separates the build and runtime environments, reducing the final image size and improving security.

### Dependency management improvements:
* Replaced `apk` with `microdnf` for package installation in the runtime stage to align with the UBI base image's package manager. Added `java-11-openjdk-headless`, `bash`, and `shadow-utils` as runtime dependencies.

### File handling optimizations:
* Replaced `ADD` directives with `COPY --from=builder` to transfer files from the `builder` stage to the runtime stage, ensuring a clean separation between the build and runtime environments.

### User and group creation:
* Updated user and group creation commands to use `groupadd` and `useradd` instead of `addgroup` and `adduser`, ensuring compatibility with the UBI base image.