### PR TITLE
Unregister CqlSession from HealthCheckRegistry after close

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MigrationManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MigrationManager.java
@@ -183,6 +183,8 @@ final class MigrationManager {
 
         LOG.info("executed Migration" + String.format("%03d", nextVersion));
       } catch (ReflectiveOperationException ignore) {
+      } finally {
+          environment.healthChecks().unregister(cassandra.getName());
       }
       LOG.info(String.format("Migrated keyspace %s to version %d", keyspaceName, nextVersion));
     }

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MigrationManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MigrationManager.java
@@ -184,7 +184,7 @@ final class MigrationManager {
         LOG.info("executed Migration" + String.format("%03d", nextVersion));
       } catch (ReflectiveOperationException ignore) {
       } finally {
-          environment.healthChecks().unregister(cassandra.getName());
+        environment.healthChecks().unregister(cassandra.getName());
       }
       LOG.info(String.format("Migrated keyspace %s to version %d", keyspaceName, nextVersion));
     }


### PR DESCRIPTION
To migrate the database schema, a CqlSession is created in MigrationManager#migrate using BasicCassandraFactory#build, where the newly created CqlSession is registered in the HealthCheckRegistry.. The code then creates org.cognitor.cassandra.migration.Database using try-with-recources. When it closes, the CqlSession is also closed, but the HealthCheckRegistry#unregister method is not called. Consequently, HealthCheck for this session will always fail because the session is closed.