### PR TITLE
Unregister CqlSession from HealthCheckRegistry after close (take two, in a different place)

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MigrationManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/MigrationManager.java
@@ -133,6 +133,8 @@ final class MigrationManager {
                 "Keyspace %s already at schema version %d",
                 cassandra.getKeyspace(), currentVersion));
       }
+    } finally {
+      environment.healthChecks().unregister(cassandra.getName());
     }
   }
 


### PR DESCRIPTION
addition to the commit https://github.com/thelastpickle/cassandra-reaper/pull/1619


To initialize the database schema, MigrationManager#initializeCassandraSchema creates a CqlSession using BasicCassandraFactory#build and registers it in the HealthCheckRegistry. The code then creates an org.cognitor.cassandra.migration.Database using try-with-recources. When it closes, the CqlSession is also closed, but the HealthCheckRegistry#unregister method is not called. Consequently, HealthCheck will always fail for this session because the session is closed.