### PR TITLE
INS-38047, Fix vulnerability GHSA-25qh-j22f-pwp8 logback version was bumped

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <dropwizard.version>4.0.15</dropwizard.version>
         <jersey.version>3.1.10</jersey.version>
-        <logback.version>1.5.18</logback.version>
+        <logback.version>1.5.19</logback.version>
         <cxf.version>3.4.5</cxf.version>
         <prometheus.version>0.16.0</prometheus.version>
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
This PR fixes vulnerability [GHSA-25qh-j22f-pwp8](https://github.com/advisories/GHSA-25qh-j22f-pwp8) for ch.qos.logback:logback-core package by bumping logback version.