### PR TITLE
Use mTLS client for metrics endpoint also if configured

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -690,7 +690,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
     @JsonProperty private Integer managementApiPort;
 
-    @JsonProperty private Boolean metricsTLSEnabled;
+    @JsonProperty private Boolean metricsTLSEnabled = false;
 
     public Boolean isEnabled() {
       return enabled;
@@ -747,7 +747,7 @@ public final class ReaperApplicationConfiguration extends Configuration {
       this.mgmtApiMetricsPort = mgmtApiMetricsPort;
     }
 
-    public Boolean getMetricsTLSEnabled() {
+    public Boolean isMetricsTLSEnabled() {
       return metricsTLSEnabled;
     }
 

--- a/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
+++ b/src/server/src/main/java/io/cassandrareaper/ReaperApplicationConfiguration.java
@@ -690,6 +690,8 @@ public final class ReaperApplicationConfiguration extends Configuration {
 
     @JsonProperty private Integer managementApiPort;
 
+    @JsonProperty private Boolean metricsTLSEnabled;
+
     public Boolean isEnabled() {
       return enabled;
     }
@@ -743,6 +745,15 @@ public final class ReaperApplicationConfiguration extends Configuration {
     @JsonProperty("mgmtApiMetricsPort")
     public void setMgmtApiMetricsPort(int mgmtApiMetricsPort) {
       this.mgmtApiMetricsPort = mgmtApiMetricsPort;
+    }
+
+    public Boolean getMetricsTLSEnabled() {
+      return metricsTLSEnabled;
+    }
+
+    @VisibleForTesting
+    public void setMetricsTLSEnabled(Boolean metricsTLSEnabled) {
+      this.metricsTLSEnabled = metricsTLSEnabled;
     }
   }
 

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -66,6 +66,7 @@ import com.datastax.mgmtapi.client.model.TokenRangeToEndpoints;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import jakarta.validation.constraints.NotNull;
+import okhttp3.OkHttpClient;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.cassandra.utils.progress.ProgressEventType;
 import org.slf4j.Logger;
@@ -83,6 +84,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   final int metricsPort;
   final Node node;
   final HttpMetricsProxy metricsProxy;
+  OkHttpClient.Builder metricsClientBuilder;
 
   final ConcurrentMap<Integer, RepairStatusHandler> repairStatusHandlers = Maps.newConcurrentMap();
   final ConcurrentMap<String, JobStatusTracker> jobTracker = Maps.newConcurrentMap();
@@ -97,7 +99,8 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       ScheduledExecutorService executor,
       DefaultApi apiClient,
       int metricsPort,
-      Node node) {
+      Node node,
+      OkHttpClient.Builder metricsClientBuilder) {
     this.host = endpoint.getHostString();
     this.metricRegistry = metricRegistry;
     this.rootPath = rootPath;
@@ -106,6 +109,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
     this.metricsPort = metricsPort;
     this.statusTracker = executor;
     this.node = node;
+    this.metricsClientBuilder = metricsClientBuilder;
     this.metricsProxy = HttpMetricsProxy.create(this, node);
 
     // TODO Perhaps the poll interval should be configurable through context.config ?
@@ -142,6 +146,10 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
 
   public int getMetricsPort() {
     return metricsPort;
+  }
+
+  public OkHttpClient.Builder getMetricsClientBuilder() {
+    return metricsClientBuilder;
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
@@ -244,7 +244,7 @@ public class HttpManagementConnectionFactory implements IManagementConnectionFac
                 new InstrumentedScheduledExecutorService(jobStatusPollerExecutor, metricRegistry);
 
             OkHttpClient.Builder metricsClientBuilder = new OkHttpClient().newBuilder();
-            if (httpConfig.getMetricsTLSEnabled()) {
+            if (httpConfig.isMetricsTLSEnabled()) {
               // Pass the clientBuilder to the HttpCassandraManagementProxy
               LOG.debug("Using metrics TLS connection to " + node.getHostname());
               metricsClientBuilder = clientBuilder;

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
@@ -243,6 +243,13 @@ public class HttpManagementConnectionFactory implements IManagementConnectionFac
             InstrumentedScheduledExecutorService statusTracker =
                 new InstrumentedScheduledExecutorService(jobStatusPollerExecutor, metricRegistry);
 
+            OkHttpClient.Builder metricsClientBuilder = new OkHttpClient().newBuilder();
+            if (httpConfig.getMetricsTLSEnabled()) {
+              // Pass the clientBuilder to the HttpCassandraManagementProxy
+              LOG.debug("Using metrics TLS connection to " + node.getHostname());
+              metricsClientBuilder = clientBuilder;
+            }
+
             return new HttpCassandraManagementProxy(
                 metricRegistry,
                 rootPath,
@@ -250,7 +257,8 @@ public class HttpManagementConnectionFactory implements IManagementConnectionFac
                 statusTracker,
                 mgmtApiClient,
                 config.getHttpManagement().getMgmtApiMetricsPort(),
-                node);
+                node,
+                metricsClientBuilder);
           }
         });
   }

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpMetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpMetricsProxy.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -61,21 +60,14 @@ public final class HttpMetricsProxy implements MetricsProxy {
   private final OkHttpClient httpClient;
   private final Node node;
 
-  private HttpMetricsProxy(
-      HttpCassandraManagementProxy proxy, Node node, Supplier<OkHttpClient> httpClientSupplier) {
+  private HttpMetricsProxy(HttpCassandraManagementProxy proxy, Node node) {
     this.proxy = proxy;
     this.node = node;
-    this.httpClient = httpClientSupplier.get();
+    this.httpClient = proxy.getMetricsClientBuilder().build();
   }
 
   public static HttpMetricsProxy create(HttpCassandraManagementProxy proxy, Node node) {
-    return new HttpMetricsProxy(proxy, node, () -> new OkHttpClient.Builder().build());
-  }
-
-  @VisibleForTesting
-  static HttpMetricsProxy create(
-      HttpCassandraManagementProxy proxy, Node node, Supplier<OkHttpClient> httpClientSupplier) {
-    return new HttpMetricsProxy(proxy, node, httpClientSupplier);
+    return new HttpMetricsProxy(proxy, node);
   }
 
   @Override

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -81,6 +81,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
+import okhttp3.OkHttpClient;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
 import org.junit.Test;
@@ -510,6 +511,10 @@ public class HttpCassandraManagementProxyTest {
               return ConcurrentUtils.constantFuture(null);
             });
 
+    OkHttpClient httpClient = Mockito.mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = Mockito.mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+
     return new HttpCassandraManagementProxy(
         null,
         "/",
@@ -517,7 +522,8 @@ public class HttpCassandraManagementProxyTest {
         executorService,
         mockClient,
         ReaperApplicationConfiguration.DEFAULT_MGMT_API_METRICS_PORT,
-        Mockito.mock(Node.class));
+        Mockito.mock(Node.class),
+        clientBuilder);
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpMetricsProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpMetricsProxyTest.java
@@ -287,6 +287,9 @@ public class HttpMetricsProxyTest {
             + "rack=\"default\",pod_name=\"test-dc1-default-sts-0\",node_name=\"mc-0-worker3\",le=\"3379391\",} 0.0\n";
 
     OkHttpClient httpClient = Mockito.mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = Mockito.mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+
     Call call = Mockito.mock(Call.class);
     Response response = Mockito.mock(Response.class);
 
@@ -302,6 +305,7 @@ public class HttpMetricsProxyTest {
         Mockito.mock(HttpCassandraManagementProxy.class);
     when(httpManagementProxy.getMetricsPort()).thenReturn(9000);
     when(httpManagementProxy.getHost()).thenReturn("172.18.0.3");
+    when(httpManagementProxy.getMetricsClientBuilder()).thenReturn(clientBuilder);
 
     Node node =
         Node.builder()
@@ -310,8 +314,7 @@ public class HttpMetricsProxyTest {
                 Cluster.builder().withName("test").withSeedHosts(Sets.newSet("127.0.0.1")).build())
             .build();
 
-    HttpMetricsProxy httpMetricsProxy =
-        HttpMetricsProxy.create(httpManagementProxy, node, () -> httpClient);
+    HttpMetricsProxy httpMetricsProxy = HttpMetricsProxy.create(httpManagementProxy, node);
     List<GenericMetric> tpStats = httpMetricsProxy.collectTpStats();
     assertEquals(5, tpStats.size());
     assertEquals("org.apache.cassandra.metrics", tpStats.get(0).getMetricDomain());
@@ -354,6 +357,9 @@ public class HttpMetricsProxyTest {
             + "le=\"3379391\",} 0.0\n";
 
     OkHttpClient httpClient = Mockito.mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = Mockito.mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+
     Call call = Mockito.mock(Call.class);
     Response response = Mockito.mock(Response.class);
 
@@ -369,6 +375,7 @@ public class HttpMetricsProxyTest {
         Mockito.mock(HttpCassandraManagementProxy.class);
     when(httpManagementProxy.getHost()).thenReturn("172.18.0.3");
     when(httpManagementProxy.getMetricsPort()).thenReturn(9000);
+    when(httpManagementProxy.getMetricsClientBuilder()).thenReturn(clientBuilder);
 
     Node node =
         Node.builder()
@@ -377,8 +384,7 @@ public class HttpMetricsProxyTest {
                 Cluster.builder().withName("test").withSeedHosts(Sets.newSet("127.0.0.1")).build())
             .build();
 
-    HttpMetricsProxy httpMetricsProxy =
-        HttpMetricsProxy.create(httpManagementProxy, node, () -> httpClient);
+    HttpMetricsProxy httpMetricsProxy = HttpMetricsProxy.create(httpManagementProxy, node);
 
     List<GenericMetric> pendingTasks = httpMetricsProxy.collectTpPendingTasks();
     assertEquals(1, pendingTasks.size()); // there's only 1 that is a CompactionExecutor metric


### PR DESCRIPTION
Fixes #1633 

We don't seem to have any tests for the connectImpl/connectAny without a lot of mocks (which will not test this change). 