### PR TITLE
Switch spreaper CLI to dropwizard jwt-based authentication

### DIFF
--- a/src/packaging/bin/spreaper
+++ b/src/packaging/bin/spreaper
@@ -493,14 +493,10 @@ class ReaperCLI(object):
         payload = {'username':args.username, 'password':password, 'rememberMe':False}
         reply = reaper.postFormData("login", 
                             payload=payload)
-        # Use shiro's session id to request a JWT
-        COOKIES["JSESSIONID"] = reply.cookies["JSESSIONID"]
-        jwt = reaper.get("jwt")
+        auth_content = json.loads(reply.content)
+        jwt = auth_content['token']
         printq("You are now authenticated to Reaper.")
         ReaperCLI.save_jwt(jwt)
-
-        # remove the session id and set the auth header with the JWT
-        COOKIES.pop("JSESSIONID", None)
 
     def ping(self):
         reaper, args = ReaperCLI.prepare_reaper(


### PR DESCRIPTION
- Reaper switched to dropwizard auth in 4.0, but spreaper CLI script has not been updated
- Switch spreaper to dropwizard jwt-based auth
- Fixes #1607