### PR TITLE
logback version was bumped to 1.5.25 to address CVE-2026-1225

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <dropwizard.version>4.0.15</dropwizard.version>
         <jersey.version>3.1.10</jersey.version>
-        <logback.version>1.5.19</logback.version>
+        <logback.version>1.5.25</logback.version>
         <cxf.version>3.4.5</cxf.version>
         <prometheus.version>0.16.0</prometheus.version>
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
This PR addresses [CVE-2026-1225](https://github.com/advisories/GHSA-qqpg-mvqg-649v), which appears in ch.qos.logback:logback-core versions <1.5.25
