### PR TITLE
Fix NPE in RetryPolicyImpl caused by null request and nullable Request.isIdempotent()

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/RetryPolicyImpl.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/RetryPolicyImpl.java
@@ -34,22 +34,26 @@ public final class RetryPolicyImpl implements RetryPolicy {
     return Math.min(delay, MAX_DELAY_MS);
   }
 
-  @Override
-  public RetryDecision onReadTimeout(
-      @NotNull Request request,
-      @NotNull ConsistencyLevel cl,
-      int required,
-      int received,
-      boolean retrieved,
-      int retry) {
+  private boolean isIdempotent(Request request) {
+    return Boolean.TRUE.equals(request.isIdempotent());
+  }
 
-    if (retry >= MAX_READ_RETRIES) {
-      LOG.warn(
-          "{} Max read retries ({}) exceeded for request {}", logPrefix, MAX_READ_RETRIES, request);
+  private RetryDecision retryIfIdempotent(
+      Request request, int retry, int maxRetries, String methodName) {
+    if (request == null) {
+      LOG.warn("{} Received null request in {}, rethrowing", logPrefix, methodName);
       return RetryDecision.RETHROW;
     }
-
-    if (request.isIdempotent()) {
+    if (retry >= maxRetries) {
+      LOG.warn(
+          "{} Max retries ({}) exceeded in {} for request {}",
+          logPrefix,
+          maxRetries,
+          methodName,
+          request);
+      return RetryDecision.RETHROW;
+    }
+    if (isIdempotent(request)) {
       try {
         Thread.sleep(calculateBackoffDelay(retry));
       } catch (InterruptedException e) {
@@ -59,6 +63,17 @@ public final class RetryPolicyImpl implements RetryPolicy {
       return RetryDecision.RETRY_NEXT;
     }
     return RetryDecision.RETHROW;
+  }
+
+  @Override
+  public RetryDecision onReadTimeout(
+      @NotNull Request request,
+      @NotNull ConsistencyLevel cl,
+      int required,
+      int received,
+      boolean retrieved,
+      int retry) {
+    return retryIfIdempotent(request, retry, MAX_READ_RETRIES, "onReadTimeout");
   }
 
   @Override
@@ -69,26 +84,7 @@ public final class RetryPolicyImpl implements RetryPolicy {
       int required,
       int received,
       int retry) {
-
-    if (retry >= MAX_WRITE_RETRIES) {
-      LOG.warn(
-          "{} Max write retries ({}) exceeded for request {}",
-          logPrefix,
-          MAX_WRITE_RETRIES,
-          request);
-      return RetryDecision.RETHROW;
-    }
-
-    if (request.isIdempotent()) {
-      try {
-        Thread.sleep(calculateBackoffDelay(retry));
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return RetryDecision.RETHROW;
-      }
-      return RetryDecision.RETRY_NEXT;
-    }
-    return RetryDecision.RETHROW;
+    return retryIfIdempotent(request, retry, MAX_WRITE_RETRIES, "onWriteTimeout");
   }
 
   @Override
@@ -98,76 +94,19 @@ public final class RetryPolicyImpl implements RetryPolicy {
       int required,
       int received,
       int retry) {
-
-    if (retry >= MAX_READ_RETRIES) {
-      LOG.warn(
-          "{} Max unavailable retries ({}) exceeded for request {}",
-          logPrefix,
-          MAX_READ_RETRIES,
-          request);
-      return RetryDecision.RETHROW;
-    }
-
-    if (request.isIdempotent()) {
-      try {
-        Thread.sleep(calculateBackoffDelay(retry));
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return RetryDecision.RETHROW;
-      }
-      return RetryDecision.RETRY_NEXT;
-    }
-    return RetryDecision.RETHROW;
+    return retryIfIdempotent(request, retry, MAX_READ_RETRIES, "onUnavailable");
   }
 
   @Override
   public RetryDecision onRequestAborted(
       @NotNull Request request, @NotNull Throwable throwable, int retry) {
-
-    if (retry >= MAX_READ_RETRIES) {
-      LOG.warn(
-          "{} Max request abort retries ({}) exceeded for request {}",
-          logPrefix,
-          MAX_READ_RETRIES,
-          request);
-      return RetryDecision.RETHROW;
-    }
-
-    if (request.isIdempotent()) {
-      try {
-        Thread.sleep(calculateBackoffDelay(retry));
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return RetryDecision.RETHROW;
-      }
-      return RetryDecision.RETRY_NEXT;
-    }
-    return RetryDecision.RETHROW;
+    return retryIfIdempotent(request, retry, MAX_READ_RETRIES, "onRequestAborted");
   }
 
   @Override
   public RetryDecision onErrorResponse(
       @NotNull Request request, @NotNull CoordinatorException exception, int retry) {
-
-    if (retry >= MAX_READ_RETRIES) {
-      LOG.warn(
-          "{} Max error response retries ({}) exceeded for request {}",
-          logPrefix,
-          MAX_READ_RETRIES,
-          request);
-      return RetryDecision.RETHROW;
-    }
-
-    if (request.isIdempotent()) {
-      try {
-        Thread.sleep(calculateBackoffDelay(retry));
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return RetryDecision.RETHROW;
-      }
-      return RetryDecision.RETRY_NEXT;
-    }
-    return RetryDecision.RETHROW;
+    return retryIfIdempotent(request, retry, MAX_READ_RETRIES, "onErrorResponse");
   }
 
   @Override


### PR DESCRIPTION
This is the driver 4.x counterpart to the null-safety fix in #229 (driver 3.x).

When Reaper was migrated from driver 3.x to 4.x, the defensive null guards from #229 were not carried forward. The 4.x RetryPolicy callbacks can receive null parameters in failure paths (e.g. connection-level failures, abortAllInFlight), and Request.isIdempotent() returns Boolean (nullable). Using that value in a boolean context auto-unboxes null and throws an NPE. The driver treats the exception as a fatal error, closes the connection, and never retries. Under load this cascades into pool exhaustion, AllNodesFailedException, and a CPU-bound retry loop.

Changes:
- Restore #229-style null guards: Each callback (onReadTimeout, onWriteTimeout, onUnavailable, onRequestAborted, onErrorResponse) now checks for request == null at the top and returns RetryDecision.RETHROW with a warning log instead of dereferencing.
- Null-safe isIdempotent helper: Replace all 5 direct calls to request.isIdempotent() with a private helper that uses Boolean.TRUE.equals(), so null idempotency is treated as non-idempotent (rethrow, no retry) instead of throwing.
- No behaviour change when request is non-null and idempotency is explicitly set.