### PR TITLE
 Fix metric registry leak in CompactionProxy due to unique executor names

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -47,7 +47,7 @@ public final class CompactionProxy {
 
   private CompactionProxy(ICassandraManagementProxy proxy, MetricRegistry metrics) {
     this.proxy = proxy;
-    if (EXECUTOR.get() != null) {
+    if (EXECUTOR.get() == null) {
       synchronized (EXECUTOR) {
         if (EXECUTOR.get() != null) {
           EXECUTOR.set(

--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -26,9 +26,9 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
 import javax.management.MalformedObjectNameException;
 import javax.management.ReflectionException;
 
@@ -80,29 +80,29 @@ public final class CompactionProxy {
             proxy.forceKeyspaceCompaction(false, keyspaceName, tableNames);
           } catch (IOException | ExecutionException | InterruptedException ex) {
             LOG.warn(
-                    String.format(
-                            "failed compaction on %s (%s)", keyspaceName, StringUtils.join(tableNames)),
-                    ex);
+                String.format(
+                    "failed compaction on %s (%s)", keyspaceName, StringUtils.join(tableNames)),
+                ex);
           }
         });
   }
 
   public List<Compaction> listActiveCompactions()
-          throws ReflectionException, MalformedObjectNameException {
+      throws ReflectionException, MalformedObjectNameException {
     List<Compaction> activeCompactions = Lists.newArrayList();
     List<Map<String, String>> compactions = proxy.getCompactions();
     if (!compactions.isEmpty()) {
       for (Map<String, String> c : compactions) {
         Compaction compaction =
-                Compaction.builder()
-                        .withId(c.get("compactionId"))
-                        .withKeyspace(c.get("keyspace"))
-                        .withTable(c.get("columnfamily"))
-                        .withProgress(Long.parseLong(c.get("completed")))
-                        .withTotal(Long.parseLong(c.get("total")))
-                        .withUnit(c.get("unit"))
-                        .withType(c.get("taskType"))
-                        .build();
+            Compaction.builder()
+                .withId(c.get("compactionId"))
+                .withKeyspace(c.get("keyspace"))
+                .withTable(c.get("columnfamily"))
+                .withProgress(Long.parseLong(c.get("completed")))
+                .withTotal(Long.parseLong(c.get("total")))
+                .withUnit(c.get("unit"))
+                .withType(c.get("taskType"))
+                .build();
 
         activeCompactions.add(compaction);
       }

--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -26,8 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ReflectionException;
@@ -41,24 +40,20 @@ import org.slf4j.LoggerFactory;
 
 public final class CompactionProxy {
 
-  private static volatile ExecutorService EXECUTOR = null;
-  private static final Lock lock = new ReentrantLock();
+  private static final AtomicReference<ExecutorService> EXECUTOR = new AtomicReference();
   private static final Logger LOG = LoggerFactory.getLogger(CompactionProxy.class);
 
   private final ICassandraManagementProxy proxy;
 
   private CompactionProxy(ICassandraManagementProxy proxy, MetricRegistry metrics) {
     this.proxy = proxy;
-    if (EXECUTOR != null) {
-      lock.lock();
-      try {
-        if (EXECUTOR != null) {
-          EXECUTOR =
+    if (EXECUTOR.get() != null) {
+      synchronized (EXECUTOR) {
+        if (EXECUTOR.get() != null) {
+          EXECUTOR.set(
               new InstrumentedExecutorService(
-                  Executors.newCachedThreadPool(), metrics, "CompactionProxy");
+                  Executors.newCachedThreadPool(), metrics, "CompactionProxy"));
         }
-      } finally {
-        lock.unlock();
       }
     }
   }
@@ -69,22 +64,24 @@ public final class CompactionProxy {
   }
 
   public void forceCompaction(String keyspaceName, String... tableNames) {
-    EXECUTOR.submit(
-        () -> {
-          try {
-            // major compactions abort all currently running compactions on the specified table,
-            // parallel major compactions are therefore not possile,
-            // calling this multiple times on the same table is ok,
-            // but comes at the cost of time spent unnecessary compactions
-            // reference: ColumnFamilyStore.runWithCompactionsDisabled(..)
-            proxy.forceKeyspaceCompaction(false, keyspaceName, tableNames);
-          } catch (IOException | ExecutionException | InterruptedException ex) {
-            LOG.warn(
-                String.format(
-                    "failed compaction on %s (%s)", keyspaceName, StringUtils.join(tableNames)),
-                ex);
-          }
-        });
+    EXECUTOR
+        .get()
+        .submit(
+            () -> {
+              try {
+                // major compactions abort all currently running compactions on the specified table,
+                // parallel major compactions are therefore not possile,
+                // calling this multiple times on the same table is ok,
+                // but comes at the cost of time spent unnecessary compactions
+                // reference: ColumnFamilyStore.runWithCompactionsDisabled(..)
+                proxy.forceKeyspaceCompaction(false, keyspaceName, tableNames);
+              } catch (IOException | ExecutionException | InterruptedException ex) {
+                LOG.warn(
+                    String.format(
+                        "failed compaction on %s (%s)", keyspaceName, StringUtils.join(tableNames)),
+                    ex);
+              }
+            });
   }
 
   public List<Compaction> listActiveCompactions()

--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -33,7 +33,6 @@ import javax.management.ReflectionException;
 
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.MetricRegistry;
-import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -41,18 +40,16 @@ import org.slf4j.LoggerFactory;
 
 public final class CompactionProxy {
 
-  private static final AtomicReference<ExecutorService> EXECUTOR = new AtomicReference();
+  private static final AtomicReference<ExecutorService> EXECUTOR = new AtomicReference<>();
   private static final Logger LOG = LoggerFactory.getLogger(CompactionProxy.class);
 
   private final ICassandraManagementProxy proxy;
 
   private CompactionProxy(ICassandraManagementProxy proxy, MetricRegistry metrics) {
     this.proxy = proxy;
-    if (null == EXECUTOR.get()) {
-      EXECUTOR.set(
-          new InstrumentedExecutorService(
-              Executors.newCachedThreadPool(), metrics, "CompactionProxy-" + Uuids.random()));
-    }
+    EXECUTOR.compareAndExchange(null,
+        new InstrumentedExecutorService(
+            Executors.newCachedThreadPool(), metrics, "CompactionProxy"));
   }
 
   public static CompactionProxy create(ICassandraManagementProxy proxy, MetricRegistry metrics) {

--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -49,7 +49,7 @@ public final class CompactionProxy {
     this.proxy = proxy;
     if (EXECUTOR.get() == null) {
       synchronized (EXECUTOR) {
-        if (EXECUTOR.get() != null) {
+        if (EXECUTOR.get() == null) {
           EXECUTOR.set(
               new InstrumentedExecutorService(
                   Executors.newCachedThreadPool(), metrics, "CompactionProxy"));

--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 public final class CompactionProxy {
 
   private static volatile ExecutorService EXECUTOR = null;
-  private static final Lock LOCK = new ReentrantLock();
+  private static final Lock lock = new ReentrantLock();
   private static final Logger LOG = LoggerFactory.getLogger(CompactionProxy.class);
 
   private final ICassandraManagementProxy proxy;
@@ -50,13 +50,15 @@ public final class CompactionProxy {
   private CompactionProxy(ICassandraManagementProxy proxy, MetricRegistry metrics) {
     this.proxy = proxy;
     if (EXECUTOR != null) {
-      LOCK.lock();
+      lock.lock();
       try {
         if (EXECUTOR != null) {
-          EXECUTOR = new InstrumentedExecutorService(Executors.newCachedThreadPool(), metrics, "CompactionProxy");
+          EXECUTOR =
+              new InstrumentedExecutorService(
+                  Executors.newCachedThreadPool(), metrics, "CompactionProxy");
         }
       } finally {
-        LOCK.unlock();
+        lock.unlock();
       }
     }
   }
@@ -67,23 +69,22 @@ public final class CompactionProxy {
   }
 
   public void forceCompaction(String keyspaceName, String... tableNames) {
-    EXECUTOR
-            .submit(
-                    () -> {
-                      try {
-                        // major compactions abort all currently running compactions on the specified table,
-                        // parallel major compactions are therefore not possile,
-                        // calling this multiple times on the same table is ok,
-                        // but comes at the cost of time spent unnecessary compactions
-                        // reference: ColumnFamilyStore.runWithCompactionsDisabled(..)
-                        proxy.forceKeyspaceCompaction(false, keyspaceName, tableNames);
-                      } catch (IOException | ExecutionException | InterruptedException ex) {
-                        LOG.warn(
-                                String.format(
-                                        "failed compaction on %s (%s)", keyspaceName, StringUtils.join(tableNames)),
-                                ex);
-                      }
-                    });
+    EXECUTOR.submit(
+        () -> {
+          try {
+            // major compactions abort all currently running compactions on the specified table,
+            // parallel major compactions are therefore not possile,
+            // calling this multiple times on the same table is ok,
+            // but comes at the cost of time spent unnecessary compactions
+            // reference: ColumnFamilyStore.runWithCompactionsDisabled(..)
+            proxy.forceKeyspaceCompaction(false, keyspaceName, tableNames);
+          } catch (IOException | ExecutionException | InterruptedException ex) {
+            LOG.warn(
+                    String.format(
+                            "failed compaction on %s (%s)", keyspaceName, StringUtils.join(tableNames)),
+                    ex);
+          }
+        });
   }
 
   public List<Compaction> listActiveCompactions()

--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -47,7 +47,8 @@ public final class CompactionProxy {
 
   private CompactionProxy(ICassandraManagementProxy proxy, MetricRegistry metrics) {
     this.proxy = proxy;
-    EXECUTOR.compareAndExchange(null,
+    EXECUTOR.compareAndSet(
+        null,
         new InstrumentedExecutorService(
             Executors.newCachedThreadPool(), metrics, "CompactionProxy"));
   }

--- a/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/CompactionProxy.java
@@ -26,8 +26,9 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.management.MalformedObjectNameException;
 import javax.management.ReflectionException;
 
@@ -40,17 +41,24 @@ import org.slf4j.LoggerFactory;
 
 public final class CompactionProxy {
 
-  private static final AtomicReference<ExecutorService> EXECUTOR = new AtomicReference<>();
+  private static volatile ExecutorService EXECUTOR = null;
+  private static final Lock LOCK = new ReentrantLock();
   private static final Logger LOG = LoggerFactory.getLogger(CompactionProxy.class);
 
   private final ICassandraManagementProxy proxy;
 
   private CompactionProxy(ICassandraManagementProxy proxy, MetricRegistry metrics) {
     this.proxy = proxy;
-    EXECUTOR.compareAndSet(
-        null,
-        new InstrumentedExecutorService(
-            Executors.newCachedThreadPool(), metrics, "CompactionProxy"));
+    if (EXECUTOR != null) {
+      LOCK.lock();
+      try {
+        if (EXECUTOR != null) {
+          EXECUTOR = new InstrumentedExecutorService(Executors.newCachedThreadPool(), metrics, "CompactionProxy");
+        }
+      } finally {
+        LOCK.unlock();
+      }
+    }
   }
 
   public static CompactionProxy create(ICassandraManagementProxy proxy, MetricRegistry metrics) {
@@ -60,41 +68,40 @@ public final class CompactionProxy {
 
   public void forceCompaction(String keyspaceName, String... tableNames) {
     EXECUTOR
-        .get()
-        .submit(
-            () -> {
-              try {
-                // major compactions abort all currently running compactions on the specified table,
-                // parallel major compactions are therefore not possile,
-                // calling this multiple times on the same table is ok,
-                // but comes at the cost of time spent unnecessary compactions
-                // reference: ColumnFamilyStore.runWithCompactionsDisabled(..)
-                proxy.forceKeyspaceCompaction(false, keyspaceName, tableNames);
-              } catch (IOException | ExecutionException | InterruptedException ex) {
-                LOG.warn(
-                    String.format(
-                        "failed compaction on %s (%s)", keyspaceName, StringUtils.join(tableNames)),
-                    ex);
-              }
-            });
+            .submit(
+                    () -> {
+                      try {
+                        // major compactions abort all currently running compactions on the specified table,
+                        // parallel major compactions are therefore not possile,
+                        // calling this multiple times on the same table is ok,
+                        // but comes at the cost of time spent unnecessary compactions
+                        // reference: ColumnFamilyStore.runWithCompactionsDisabled(..)
+                        proxy.forceKeyspaceCompaction(false, keyspaceName, tableNames);
+                      } catch (IOException | ExecutionException | InterruptedException ex) {
+                        LOG.warn(
+                                String.format(
+                                        "failed compaction on %s (%s)", keyspaceName, StringUtils.join(tableNames)),
+                                ex);
+                      }
+                    });
   }
 
   public List<Compaction> listActiveCompactions()
-      throws ReflectionException, MalformedObjectNameException {
+          throws ReflectionException, MalformedObjectNameException {
     List<Compaction> activeCompactions = Lists.newArrayList();
     List<Map<String, String>> compactions = proxy.getCompactions();
     if (!compactions.isEmpty()) {
       for (Map<String, String> c : compactions) {
         Compaction compaction =
-            Compaction.builder()
-                .withId(c.get("compactionId"))
-                .withKeyspace(c.get("keyspace"))
-                .withTable(c.get("columnfamily"))
-                .withProgress(Long.parseLong(c.get("completed")))
-                .withTotal(Long.parseLong(c.get("total")))
-                .withUnit(c.get("unit"))
-                .withType(c.get("taskType"))
-                .build();
+                Compaction.builder()
+                        .withId(c.get("compactionId"))
+                        .withKeyspace(c.get("keyspace"))
+                        .withTable(c.get("columnfamily"))
+                        .withProgress(Long.parseLong(c.get("completed")))
+                        .withTotal(Long.parseLong(c.get("total")))
+                        .withUnit(c.get("unit"))
+                        .withType(c.get("taskType"))
+                        .build();
 
         activeCompactions.add(compaction);
       }


### PR DESCRIPTION
**Problem**:
CompactionProxy created an InstrumentedExecutorService with a unique name on every invocation ("CompactionProxy-" + Uuids.random()). Although the executor was stored in a static AtomicReference, the if (null == EXECUTOR.get()) check had a race condition — multiple threads could pass the null check simultaneously and create multiple executors. But even without the race, the main issue was different: each time an InstrumentedExecutorService was created with a new unique name, a new set of metrics was registered in the MetricRegistry and never removed. This led to unbounded metric growth (metric leak).

**Fix**:
- Replaced the if (null == EXECUTOR.get()) { EXECUTOR.set(...) } condition with atomic creation under a lock, which eliminates the race condition and guarantees a one-time initialization of the executor.
- Removed Uuids.random() from the executor name — now uses a fixed name "CompactionProxy", since the executor is created exactly once and a unique suffix is unnecessary.
