### PR TITLE
Send jwt token when editing schedules

### DIFF
--- a/src/ui/app/jsx/schedule-list.jsx
+++ b/src/ui/app/jsx/schedule-list.jsx
@@ -115,7 +115,8 @@ const EditRowModal = CreateReactClass({
         method: "PATCH",
         body: JSON.stringify(body),
         headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json",
+          "Authorization": "Bearer " + sessionStorage.getItem('jwtToken')
         }
       }
     ).then(response => {


### PR DESCRIPTION
- The "Authorization: Bearer xxx" jwt-token was not sent on schedule PATCH requests
- So editing schedule failed with a 401 error in the webui
- It worked on reaper < 4, before the migration to dropwizard jwt in 4.
- Fixes #1627