### PR TITLE
Fix: Support configurable serial consistency for LWT queries in multi…

### DIFF
--- a/src/packaging/resource/cassandra-reaper-cassandra.yaml
+++ b/src/packaging/resource/cassandra-reaper-cassandra.yaml
@@ -117,6 +117,9 @@ cassandra:
   requestOptionsFactory:
     requestTimeout: 60s
     requestDefaultIdempotence: true
+    # Use LOCAL_SERIAL for multi-DC deployments to restrict LWT Paxos quorum to the local DC.
+    # Resolves WriteTimeoutException at consistency SERIAL in multi-DC setups.
+    # requestSerialConsistency: LOCAL_SERIAL
   authProvider:
     type: plain-text
     username: cassandra

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraConcurrencyDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraConcurrencyDao.java
@@ -50,6 +50,7 @@ public class CassandraConcurrencyDao {
   private final Version version;
   private final UUID reaperInstanceId;
   private final CqlSession session;
+  private final ConsistencyLevel serialConsistencyLevel;
   private PreparedStatement takeLeadPrepStmt;
   private PreparedStatement renewLeadPrepStmt;
   private PreparedStatement releaseLeadPrepStmt;
@@ -57,10 +58,15 @@ public class CassandraConcurrencyDao {
   private PreparedStatement setRunningRepairsPrepStmt;
   private PreparedStatement getRunningRepairsPrepStmt;
 
-  public CassandraConcurrencyDao(Version version, UUID reaperInstanceId, CqlSession session) {
+  public CassandraConcurrencyDao(
+      Version version,
+      UUID reaperInstanceId,
+      CqlSession session,
+      ConsistencyLevel serialConsistencyLevel) {
     this.version = version;
     this.reaperInstanceId = reaperInstanceId;
     this.session = session;
+    this.serialConsistencyLevel = serialConsistencyLevel;
     prepareStatements();
   }
 
@@ -72,6 +78,7 @@ public class CassandraConcurrencyDao {
                         + "reaper_instance_host, last_heartbeat)"
                         + "VALUES(?, ?, ?, toTimestamp(now())) IF NOT EXISTS USING TTL ?")
                 .setConsistencyLevel(ConsistencyLevel.QUORUM)
+                .setSerialConsistencyLevel(serialConsistencyLevel)
                 .build());
     renewLeadPrepStmt =
         session.prepare(
@@ -79,12 +86,14 @@ public class CassandraConcurrencyDao {
                     "UPDATE leader USING TTL ? SET reaper_instance_id = ?, reaper_instance_host = ?,"
                         + " last_heartbeat = toTimestamp(now()) WHERE leader_id = ? IF reaper_instance_id = ?")
                 .setConsistencyLevel(ConsistencyLevel.QUORUM)
+                .setSerialConsistencyLevel(serialConsistencyLevel)
                 .build());
     releaseLeadPrepStmt =
         session.prepare(
             SimpleStatement.builder(
                     "DELETE FROM leader WHERE leader_id = ? IF reaper_instance_id = ?")
                 .setConsistencyLevel(ConsistencyLevel.QUORUM)
+                .setSerialConsistencyLevel(serialConsistencyLevel)
                 .build());
 
     getRunningRepairsPrepStmt =
@@ -102,7 +111,7 @@ public class CassandraConcurrencyDao {
                     "UPDATE running_repairs USING TTL ?"
                         + " SET reaper_instance_host = ?, reaper_instance_id = ?, segment_id = ?"
                         + " WHERE repair_id = ? AND node = ? IF reaper_instance_id = ?")
-                .setSerialConsistencyLevel(ConsistencyLevel.SERIAL)
+                .setSerialConsistencyLevel(serialConsistencyLevel)
                 .setConsistencyLevel(ConsistencyLevel.QUORUM)
                 .setIdempotence(false)
                 .build());

--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraStorageFacade.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraStorageFacade.java
@@ -135,7 +135,12 @@ public final class CassandraStorageFacade implements IStorageDao, IDistributedSt
     this.cassMetricsDao = new CassandraMetricsDao(cassandra);
     this.cassSnapshotDao = new CassandraSnapshotDao(cassandra);
     this.operationsDao = new CassandraOperationsDao(cassandra);
-    this.concurrency = new CassandraConcurrencyDao(version, reaperInstanceId, cassandra);
+    ConsistencyLevel serialCl = Optional.ofNullable(cassandraFactory.getRequestOptionsFactory())
+        .map(RequestOptionsFactory::getRequestSerialConsistency)
+        .filter(s -> !s.isBlank())
+        .map(s -> ConsistencyLevel.valueOf(s.toUpperCase()))
+        .orElse(ConsistencyLevel.SERIAL);
+    this.concurrency = new CassandraConcurrencyDao(version, reaperInstanceId, cassandra, serialCl);
     this.cassRepairUnitDao = new CassandraRepairUnitDao(defaultTimeout, cassandra);
     this.cassRepairSegmentDao =
         new CassandraRepairSegmentDao(concurrency, cassRepairUnitDao, cassandra);


### PR DESCRIPTION
## Context

Adds support for a configurable serial consistency level for LWT (Light Weight Transaction) queries in Cassandra Reaper. The immediate problem is that in multi-DC Cassandra deployments, using the default SERIAL consistency for LWT operations (leader election, running-repairs tracking) causes WriteTimeoutException because Paxos must reach quorum across ALL datacenters. Setting LOCAL_SERIAL restricts the Paxos quorum to the local DC, resolving the issue.

## Changes in the Commit

```
┌─────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────┐
│              File               │                                            What changed                                            │
├─────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ CassandraConcurrencyDao.java    │ Added serialConsistencyLevel field; updated constructor; applied it to all 4 LWT statements        │
│                                 │ (takeLead, renewLead, releaseLead, setRunningRepairs)                                              │
├─────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ CassandraStorageFacade.java     │ Reads requestSerialConsistency from dropwizard-cassandra RequestOptionsFactory; defaults to SERIAL │
│                                 │  if absent                                                                                         │
├─────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ cassandra-reaper-cassandra.yaml │ Added commented-out requestSerialConsistency: LOCAL_SERIAL example with explanatory comments       │
└─────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

## Problem

In multi-DC Cassandra deployments, Reaper's LWT (Light Weight Transaction) operations (leader election and running-repairs tracking) use `SERIAL` consistency by default. `SERIAL` requires a Paxos quorum across **all** datacenters, which can trigger `WriteTimeoutException` when cross-DC latency is high or a remote DC is degraded.

## Solution

Make the serial consistency level for LWT prepared statements configurable via the existing `requestOptionsFactory` block in `cassandra-reaper-cassandra.yaml`. Operators running multi-DC clusters can now set `LOCAL_SERIAL` to restrict the Paxos quorum to the local DC.

### Configuration (multi-DC clusters)

```yaml
cassandra:
requestOptionsFactory:
    requestTimeout: 60s
    requestDefaultIdempotence: true
    requestSerialConsistency: LOCAL_SERIAL   # restricts Paxos quorum to local DC
```

Leave the option commented out (or omit it entirely) to retain the existing SERIAL
behavior — no breaking change for current deployments.

