### PR TITLE
Populate metrics on startup

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -396,6 +396,9 @@ final class RepairRunner implements Runnable {
                       RepairManager.class, "repairDone", RepairRun.RunState.DONE.toString()))
               .inc();
 
+          // Update schedule metrics if this repair was triggered by a schedule
+          updateScheduleMetricsIfScheduled(repairRun.get(), repairRunCompleted);
+
           maybeAdaptRepairSchedule();
           context.schedulingManager.maybeRegisterRepairRunCompleted(repairRun.get());
         } finally {
@@ -1010,6 +1013,42 @@ final class RepairRunner implements Runnable {
   void killAndCleanupRunner() {
     context.repairManager.removeRunner(this);
     Thread.currentThread().interrupt();
+  }
+
+  /**
+   * Updates schedule metrics if this repair run was triggered by a schedule. Extracts the schedule
+   * ID from the repair run's cause field and updates the metrics.
+   *
+   * @param repairRun The completed repair run
+   * @param repairRunCompleted The completion time of the repair run
+   */
+  private void updateScheduleMetricsIfScheduled(RepairRun repairRun, DateTime repairRunCompleted) {
+    String cause = repairRun.getCause();
+    if (cause != null && cause.startsWith("scheduled run (schedule id ")) {
+      try {
+        // Extract schedule ID from cause string: "scheduled run (schedule id <UUID>)"
+        int startIdx = cause.indexOf("schedule id ") + "schedule id ".length();
+        int endIdx = cause.indexOf(')', startIdx);
+        if (startIdx > 0 && endIdx > startIdx) {
+          String scheduleIdStr = cause.substring(startIdx, endIdx);
+          UUID scheduleId = UUID.fromString(scheduleIdStr);
+
+          RepairScheduleService scheduleService =
+              RepairScheduleService.create(context, repairRunDao);
+          scheduleService.updateScheduleMetricsAfterRepair(scheduleId, repairRunCompleted);
+
+          LOG.debug(
+              "Updated schedule metrics for schedule {} after repair run {} completed",
+              scheduleId,
+              repairRun.getId());
+        }
+      } catch (Exception e) {
+        LOG.warn(
+            "Failed to update schedule metrics for repair run {}: {}",
+            repairRun.getId(),
+            e.getMessage());
+      }
+    }
   }
 
   private String metricName(

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -175,14 +175,13 @@ public final class RepairScheduleService {
     // Initialize lastRun from repair history if not set
     // This ensures metrics are accurate after restart
     LOG.debug("Last run for schedule " + schedule.getId() + " is " + schedule.getLastRun());
-    if (schedule.getLastRun() == null) {
-      Optional<UUID> lastCompletedRun = findLastCompletedRepairRun(repairUnit.getId());
-      if (lastCompletedRun.isPresent()) {
-        RepairSchedule updatedSchedule =
-            schedule.with().lastRun(lastCompletedRun.get()).build(schedule.getId());
-        context.storage.getRepairScheduleDao().updateRepairSchedule(updatedSchedule);
-        schedule = updatedSchedule;
-      }
+
+    Optional<UUID> lastCompletedRun = findLastCompletedRepairRun(repairUnit.getId());
+    if (lastCompletedRun.isPresent()) {
+      RepairSchedule updatedSchedule =
+          schedule.with().lastRun(lastCompletedRun.get()).build(schedule.getId());
+      context.storage.getRepairScheduleDao().updateRepairSchedule(updatedSchedule);
+      schedule = updatedSchedule;
     }
 
     String metricName =

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -52,8 +52,8 @@ public final class RepairScheduleService {
   private RepairScheduleService(AppContext context, IRepairRunDao repairRunDao) {
     this.context = context;
     this.repairUnitService = RepairUnitService.create(context);
-    registerRepairScheduleMetrics(context.storage.getRepairScheduleDao().getAllRepairSchedules());
     this.repairRunDao = repairRunDao;
+    registerRepairScheduleMetrics(context.storage.getRepairScheduleDao().getAllRepairSchedules());
   }
 
   public static RepairScheduleService create(AppContext context, IRepairRunDao repairRunDao) {
@@ -167,6 +167,19 @@ public final class RepairScheduleService {
         context.storage.getRepairScheduleDao().getRepairSchedule(repairScheduleId).get();
     RepairUnit repairUnit =
         context.storage.getRepairUnitDao().getRepairUnit(schedule.getRepairUnitId());
+
+    // Initialize lastRun from repair history if not set
+    // This ensures metrics are accurate after restart
+    if (schedule.getLastRun() == null) {
+      Optional<UUID> lastCompletedRun = findLastCompletedRepairRun(repairUnit.getId());
+      if (lastCompletedRun.isPresent()) {
+        RepairSchedule updatedSchedule =
+            schedule.with().lastRun(lastCompletedRun.get()).build(schedule.getId());
+        context.storage.getRepairScheduleDao().updateRepairSchedule(updatedSchedule);
+        schedule = updatedSchedule;
+      }
+    }
+
     String metricName =
         metricName(
             MILLIS_SINCE_LAST_REPAIR_METRIC_NAME,
@@ -303,6 +316,72 @@ public final class RepairScheduleService {
       // future
       return 0;
     };
+  }
+
+  /**
+   * Finds the most recent completed repair run for a given repair unit. This is used to initialize
+   * the lastRun field when it's null, ensuring metrics are accurate after restart.
+   *
+   * @param repairUnitId The repair unit ID to search for completed repairs
+   * @return Optional containing the UUID of the most recent completed repair run, or empty if none
+   *     found
+   */
+  private Optional<UUID> findLastCompletedRepairRun(UUID repairUnitId) {
+    Collection<RepairRun> repairRuns = repairRunDao.getRepairRunsForUnit(repairUnitId);
+
+    return repairRuns.stream()
+        .filter(run -> run.getRunState() == RepairRun.RunState.DONE)
+        .filter(run -> run.getEndTime() != null)
+        .max(RepairRun::compareTo)
+        .map(RepairRun::getId);
+  }
+
+  /**
+   * Updates the schedule metrics after a repair run completes. This re-registers the metrics with
+   * static gauges that capture the completion time, similar to how RepairRunner handles its
+   * metrics. This is more efficient than querying the database on every metric read.
+   *
+   * @param scheduleId The UUID of the repair schedule whose metrics should be updated
+   * @param repairRunCompleted The completion time of the repair run
+   */
+  public void updateScheduleMetricsAfterRepair(UUID scheduleId, DateTime repairRunCompleted) {
+    Optional<RepairSchedule> schedule =
+        context.storage.getRepairScheduleDao().getRepairSchedule(scheduleId);
+
+    if (schedule.isPresent()) {
+      RepairUnit repairUnit =
+          context.storage.getRepairUnitDao().getRepairUnit(schedule.get().getRepairUnitId());
+
+      String metricName =
+          metricName(
+              MILLIS_SINCE_LAST_REPAIR_METRIC_NAME,
+              repairUnit.getClusterName(),
+              repairUnit.getKeyspaceName(),
+              scheduleId);
+
+      // Remove the old dynamic gauge and register a new static one with the completion time
+      if (context.metricRegistry.getMetrics().containsKey(metricName)) {
+        context.metricRegistry.remove(metricName);
+      }
+      context.metricRegistry.register(
+          metricName,
+          (Gauge<Long>)
+              () -> DateTime.now().getMillis() - repairRunCompleted.toInstant().getMillis());
+
+      String unfulfilledRepairScheduleMetricName =
+          metricName(
+              UNFULFILLED_REPAIR_SCHEDULE_METRIC_NAME,
+              repairUnit.getClusterName(),
+              repairUnit.getKeyspaceName(),
+              scheduleId);
+
+      // Re-register the unfulfilled metric as well to reflect the latest state
+      if (context.metricRegistry.getMetrics().containsKey(unfulfilledRepairScheduleMetricName)) {
+        context.metricRegistry.remove(unfulfilledRepairScheduleMetricName);
+      }
+      context.metricRegistry.register(
+          unfulfilledRepairScheduleMetricName, getUnfulfilledRepairSchedule(scheduleId));
+    }
   }
 
   private String metricName(

--- a/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairScheduleService.java
@@ -38,8 +38,12 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.cassandra.repair.RepairParallelism;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class RepairScheduleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RepairScheduleService.class);
 
   public static final String MILLIS_SINCE_LAST_REPAIR_METRIC_NAME =
       "millisSinceLastRepairForSchedule";
@@ -170,6 +174,7 @@ public final class RepairScheduleService {
 
     // Initialize lastRun from repair history if not set
     // This ensures metrics are accurate after restart
+    LOG.debug("Last run for schedule " + schedule.getId() + " is " + schedule.getLastRun());
     if (schedule.getLastRun() == null) {
       Optional<UUID> lastCompletedRun = findLastCompletedRepairRun(repairUnit.getId());
       if (lastCompletedRun.isPresent()) {
@@ -239,81 +244,109 @@ public final class RepairScheduleService {
         });
   }
 
+  private Long getMillisSinceLastRepairForScheduleAsLong(UUID repairSchedule) {
+    Optional<RepairSchedule> schedule =
+        context.storage.getRepairScheduleDao().getRepairSchedule(repairSchedule);
+
+    Optional<UUID> latestRepairUuid =
+        Optional.ofNullable(
+            schedule
+                .orElseThrow(() -> new IllegalArgumentException("Repair schedule not found"))
+                .getLastRun());
+
+    Long millisSinceLastRepair =
+        latestRepairUuid
+            .map(uuid -> repairRunDao.getRepairRun(uuid))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(RepairRun::getEndTime)
+            .filter(Objects::nonNull)
+            .map(dateTime -> DateTime.now().getMillis() - dateTime.getMillis())
+            .orElse(
+                DateTime.now()
+                    .getMillis()); // Return epoch if no repairs from this schedule were completed
+    return millisSinceLastRepair;
+  }
+
   private Gauge<Long> getMillisSinceLastRepairForSchedule(UUID repairSchedule) {
     return () -> {
-      Optional<RepairSchedule> schedule =
-          context.storage.getRepairScheduleDao().getRepairSchedule(repairSchedule);
-
-      Optional<UUID> latestRepairUuid =
-          Optional.ofNullable(
-              schedule
-                  .orElseThrow(() -> new IllegalArgumentException("Repair schedule not found"))
-                  .getLastRun());
-
-      Long millisSinceLastRepair =
-          latestRepairUuid
-              .map(uuid -> repairRunDao.getRepairRun(uuid))
-              .filter(Optional::isPresent)
-              .map(Optional::get)
-              .map(RepairRun::getEndTime)
-              .filter(Objects::nonNull)
-              .map(dateTime -> DateTime.now().getMillis() - dateTime.getMillis())
-              .orElse(
-                  DateTime.now()
-                      .getMillis()); // Return epoch if no repairs from this schedule were completed
-      return millisSinceLastRepair;
+      return getMillisSinceLastRepairForScheduleAsLong(repairSchedule);
     };
   }
 
   @VisibleForTesting
   Gauge<Integer> getUnfulfilledRepairSchedule(UUID repairSchedule) {
     return () -> {
-      Optional<RepairSchedule> schedule =
-          context.storage.getRepairScheduleDao().getRepairSchedule(repairSchedule);
-
-      Optional<UUID> latestRepairUuid =
-          Optional.ofNullable(
-              schedule
-                  .orElseThrow(() -> new IllegalArgumentException("Repair schedule not found"))
-                  .getLastRun());
+      RepairSchedule schedule =
+          context
+              .storage
+              .getRepairScheduleDao()
+              .getRepairSchedule(repairSchedule)
+              .orElseThrow(() -> new IllegalArgumentException("Repair schedule not found"));
 
       // Cases where it is not relevant to check if the repair schedule is unfulfilled
-      if (schedule.get().getDaysBetween() == 0
-          || schedule.get().getState() == RepairSchedule.State.PAUSED
-          || schedule.get().getState() == RepairSchedule.State.DELETED) {
+      if (schedule.getDaysBetween() == 0
+          || schedule.getState() == RepairSchedule.State.PAUSED
+          || schedule.getState() == RepairSchedule.State.DELETED) {
         return 0;
       }
 
-      long intervalInMillis = schedule.get().getDaysBetween() * 24 * 60 * 60 * 1000;
-      // Fail fast if we're past the next activation time by 10% of the cycle time
-      DateTime nextActivation = schedule.get().getNextActivation();
+      long now = DateTime.now().getMillis();
+      long intervalInMillis = schedule.getDaysBetween() * 24L * 60 * 60 * 1000;
+      long graceInMillis = intervalInMillis / 10;
+      long allowedDelayInMillis = intervalInMillis + graceInMillis;
+      DateTime nextActivation = schedule.getNextActivation();
+      Long millisSinceLastRepair = getMillisSinceLastRepairForScheduleAsLong(repairSchedule);
+
+      // If the last repair was more than a year ago, we don't care about the cycle window, means it
+      // didn't run at all
+      if (millisSinceLastRepair < 365 * 24 * 60 * 60 * 1000) {
+        boolean unfulfilled = millisSinceLastRepair > allowedDelayInMillis;
+        if (unfulfilled) {
+          LOG.debug(
+              "Setting {}=1 for schedule {} because last completed repair is older than the allowed cycle window "
+                  + "(state={}, daysBetween={}, intervalInMillis={}, graceInMillis={}, allowedDelayInMillis={}, "
+                  + "now={},"
+                  + "millisSinceLastRepair={}, nextActivation={}, millisPastNextActivation={})",
+              UNFULFILLED_REPAIR_SCHEDULE_METRIC_NAME,
+              schedule.getId(),
+              schedule.getState(),
+              schedule.getDaysBetween(),
+              intervalInMillis,
+              graceInMillis,
+              allowedDelayInMillis,
+              now,
+              millisSinceLastRepair,
+              nextActivation,
+              nextActivation == null ? null : now - nextActivation.getMillis());
+        }
+        return unfulfilled ? 1 : 0;
+      }
+
       if (nextActivation != null) {
-        if (DateTime.now().getMillis() - nextActivation.getMillis() > intervalInMillis * 0.1) {
-          return 1;
+        long millisPastNextActivation = now - nextActivation.getMillis();
+        boolean unfulfilled = millisPastNextActivation > allowedDelayInMillis;
+        if (unfulfilled) {
+          LOG.debug(
+              "Setting {}=1 for schedule {} because there is no completed repair in the schedule state and the "
+                  + "next activation is older than the allowed cycle window "
+                  + "(state={}, daysBetween={}, intervalInMillis={}, graceInMillis={}, allowedDelayInMillis={}, "
+                  + "now={}, "
+                  + "nextActivation={}, millisPastNextActivation={})",
+              UNFULFILLED_REPAIR_SCHEDULE_METRIC_NAME,
+              schedule.getId(),
+              schedule.getState(),
+              schedule.getDaysBetween(),
+              intervalInMillis,
+              graceInMillis,
+              allowedDelayInMillis,
+              now,
+              nextActivation,
+              millisPastNextActivation);
         }
+        return unfulfilled ? 1 : 0;
       }
 
-      Optional<Long> millisSinceLastRepair =
-          latestRepairUuid
-              .map(uuid -> repairRunDao.getRepairRun(uuid))
-              .filter(Optional::isPresent)
-              .map(Optional::get)
-              .filter(repairRun -> repairRun.getRunState() == RepairRun.RunState.DONE)
-              .map(RepairRun::getEndTime)
-              .filter(Objects::nonNull)
-              .map(dateTime -> DateTime.now().getMillis() - dateTime.getMillis());
-
-      if (millisSinceLastRepair.isPresent()) {
-        // we have a last repair that has finished successfully
-        if (millisSinceLastRepair.get() > intervalInMillis) {
-          // Return 1 if the last completed repair was not within the repair schedule interval
-          return 1;
-        }
-        return 0;
-      }
-
-      // Repair is still running or never started but the next activation time is still in the
-      // future
       return 0;
     };
   }
@@ -329,11 +362,14 @@ public final class RepairScheduleService {
   private Optional<UUID> findLastCompletedRepairRun(UUID repairUnitId) {
     Collection<RepairRun> repairRuns = repairRunDao.getRepairRunsForUnit(repairUnitId);
 
-    return repairRuns.stream()
-        .filter(run -> run.getRunState() == RepairRun.RunState.DONE)
-        .filter(run -> run.getEndTime() != null)
-        .max(RepairRun::compareTo)
-        .map(RepairRun::getId);
+    Optional<UUID> lastRepairRun =
+        repairRuns.stream()
+            .filter(run -> run.getRunState() == RepairRun.RunState.DONE)
+            .filter(run -> run.getEndTime() != null)
+            .min(RepairRun::compareTo)
+            .map(RepairRun::getId);
+
+    return lastRepairRun;
   }
 
   /**

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -74,9 +74,7 @@ public final class SchedulingManager extends TimerTask {
   }
 
   private static boolean repairRunComesFromSchedule(RepairRun repairRun, RepairSchedule schedule) {
-    return repairRun.getRunState().isActive()
-        || (RepairRun.RunState.NOT_STARTED == repairRun.getRunState()
-            && repairRun.getCause().equals(getCauseName(schedule)));
+    return repairRun.getCause().equals(getCauseName(schedule));
   }
 
   private static String getCauseName(RepairSchedule schedule) {

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairScheduleServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairScheduleServiceTest.java
@@ -23,6 +23,7 @@ import io.cassandrareaper.core.RepairSchedule;
 import io.cassandrareaper.storage.IStorageDao;
 import io.cassandrareaper.storage.repairrun.IRepairRunDao;
 import io.cassandrareaper.storage.repairschedule.IRepairScheduleDao;
+import io.cassandrareaper.storage.repairunit.IRepairUnitDao;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -45,6 +46,7 @@ public final class RepairScheduleServiceTest {
   private AppContext context;
   private IRepairRunDao repairRunDao;
   private IRepairScheduleDao repairScheduleDao;
+  private IRepairUnitDao repairUnitDao;
   private IStorageDao storage;
   private UUID scheduleId;
   private UUID repairUnitId;
@@ -58,9 +60,11 @@ public final class RepairScheduleServiceTest {
     storage = mock(IStorageDao.class);
     repairRunDao = mock(IRepairRunDao.class);
     repairScheduleDao = mock(IRepairScheduleDao.class);
+    repairUnitDao = mock(IRepairUnitDao.class);
 
     when(storage.getRepairRunDao()).thenReturn(repairRunDao);
     when(storage.getRepairScheduleDao()).thenReturn(repairScheduleDao);
+    when(storage.getRepairUnitDao()).thenReturn(repairUnitDao);
 
     context.storage = storage;
 
@@ -647,6 +651,93 @@ public final class RepairScheduleServiceTest {
 
     assertEquals(
         "Short interval with old repair should return 1", Integer.valueOf(1), gauge.getValue());
+  }
+
+  /**
+   * Test scenario: Schedule with null lastRun is initialized from repair history Expected: lastRun
+   * field is populated from most recent completed repair
+   */
+  @Test
+  public void testMetricInitialization_populatesLastRunFromHistory() {
+    UUID completedRepairRunId = UUID.randomUUID();
+    DateTime repairEndTime = DateTime.now().minusDays(2);
+
+    RepairSchedule schedule =
+        createScheduleBuilder()
+            .state(RepairSchedule.State.ACTIVE)
+            .daysBetween(7)
+            .nextActivation(DateTime.now().plusDays(5))
+            .lastRun(null)
+            .build(scheduleId);
+
+    RepairRun completedRepairRun =
+        createRepairRunBuilder()
+            .runState(RepairRun.RunState.DONE)
+            .startTime(repairEndTime.minusHours(2))
+            .endTime(repairEndTime)
+            .build(completedRepairRunId);
+
+    // Mock RepairUnit - use mock instead of builder to avoid complex setup
+    io.cassandrareaper.core.RepairUnit repairUnit = mock(io.cassandrareaper.core.RepairUnit.class);
+    when(repairUnit.getId()).thenReturn(repairUnitId);
+    when(repairUnit.getClusterName()).thenReturn("test-cluster");
+    when(repairUnit.getKeyspaceName()).thenReturn("test-keyspace");
+
+    // Set up mocks BEFORE creating the service (service constructor calls registerScheduleMetrics)
+    when(repairScheduleDao.getRepairSchedule(scheduleId)).thenReturn(Optional.of(schedule));
+    when(repairScheduleDao.getAllRepairSchedules()).thenReturn(Sets.newHashSet(schedule));
+    when(repairUnitDao.getRepairUnit(repairUnitId)).thenReturn(repairUnit);
+    when(repairRunDao.getRepairRunsForUnit(repairUnitId))
+        .thenReturn(Sets.newHashSet(completedRepairRun));
+    when(repairRunDao.getRepairRun(completedRepairRunId))
+        .thenReturn(Optional.of(completedRepairRun));
+    when(repairScheduleDao.updateRepairSchedule(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(true);
+
+    // Create service - this triggers metric registration which should populate lastRun
+    RepairScheduleService.create(context, repairRunDao);
+
+    // Verify that updateRepairSchedule was called with the populated lastRun
+    org.mockito.Mockito.verify(repairScheduleDao, org.mockito.Mockito.times(1))
+        .updateRepairSchedule(
+            org.mockito.ArgumentMatchers.argThat(
+                updatedSchedule ->
+                    updatedSchedule.getLastRun() != null
+                        && updatedSchedule.getLastRun().equals(completedRepairRunId)));
+  }
+
+  /**
+   * Test scenario: Schedule with existing lastRun is not modified Expected: updateRepairSchedule is
+   * not called
+   */
+  @Test
+  public void testMetricInitialization_doesNotOverwriteExistingLastRun() {
+    UUID existingRepairRunId = UUID.randomUUID();
+
+    RepairSchedule schedule =
+        createScheduleBuilder()
+            .state(RepairSchedule.State.ACTIVE)
+            .daysBetween(7)
+            .nextActivation(DateTime.now().plusDays(6))
+            .lastRun(existingRepairRunId)
+            .build(scheduleId);
+
+    // Mock RepairUnit - needed for metric registration
+    io.cassandrareaper.core.RepairUnit repairUnit = mock(io.cassandrareaper.core.RepairUnit.class);
+    when(repairUnit.getId()).thenReturn(repairUnitId);
+    when(repairUnit.getClusterName()).thenReturn("test-cluster");
+    when(repairUnit.getKeyspaceName()).thenReturn("test-keyspace");
+
+    when(repairScheduleDao.getRepairSchedule(scheduleId)).thenReturn(Optional.of(schedule));
+    when(repairScheduleDao.getAllRepairSchedules()).thenReturn(Sets.newHashSet(schedule));
+    when(repairUnitDao.getRepairUnit(repairUnitId)).thenReturn(repairUnit);
+
+    // Create service - should NOT update lastRun since it's already set
+    RepairScheduleService.create(context, repairRunDao);
+
+    // Verify that updateRepairSchedule was never called (lastRun already exists)
+    org.mockito.Mockito.verify(repairScheduleDao, org.mockito.Mockito.never())
+        .updateRepairSchedule(org.mockito.ArgumentMatchers.any());
   }
 
   // Helper methods

--- a/src/server/src/test/java/io/cassandrareaper/service/RepairScheduleServiceTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/RepairScheduleServiceTest.java
@@ -173,15 +173,15 @@ public final class RepairScheduleServiceTest {
   }
 
   /**
-   * Test scenario: Past next activation time by more than 10% of cycle time Expected: Returns 1
-   * (unfulfilled - fail fast)
+   * Test scenario: Past next activation time by more than 10% of cycle time but still within the
+   * interval plus grace window Expected: Returns 0
    */
   @Test
   public void testGetUnfulfilledRepairSchedule_pastActivationMoreThan10Percent() {
     int daysBetween = 10;
-    long tenPercentOfCycleMillis = (long) (daysBetween * 24 * 60 * 60 * 1000 * 0.1);
+    long tenPercentOfCycleMillis = (long) (daysBetween * 24L * 60 * 60 * 1000 * 0.1);
     DateTime nextActivation =
-        DateTime.now().minus(tenPercentOfCycleMillis + 1000); // 1 second past threshold
+        DateTime.now().minus(tenPercentOfCycleMillis + 1000); // 1 second past 10% threshold
 
     RepairSchedule schedule =
         createScheduleBuilder()
@@ -196,7 +196,37 @@ public final class RepairScheduleServiceTest {
     RepairScheduleService service = RepairScheduleService.create(context, repairRunDao);
     Gauge<Integer> gauge = service.getUnfulfilledRepairSchedule(scheduleId);
 
-    assertEquals("Past 10% threshold should return 1", Integer.valueOf(1), gauge.getValue());
+    assertEquals(
+        "Past 10% threshold but within interval plus grace should return 0",
+        Integer.valueOf(0), gauge.getValue());
+  }
+
+  /**
+   * Test scenario: Past next activation time by more than the interval plus 10% grace Expected:
+   * Returns 1
+   */
+  @Test
+  public void testGetUnfulfilledRepairSchedule_pastActivationBeyondIntervalAndGrace() {
+    int daysBetween = 10;
+    long intervalMillis = daysBetween * 24L * 60 * 60 * 1000;
+    long graceMillis = intervalMillis / 10;
+    DateTime nextActivation = DateTime.now().minus(intervalMillis + graceMillis + 1000);
+
+    RepairSchedule schedule =
+        createScheduleBuilder()
+            .state(RepairSchedule.State.ACTIVE)
+            .daysBetween(daysBetween)
+            .nextActivation(nextActivation)
+            .lastRun(null)
+            .build(scheduleId);
+
+    when(repairScheduleDao.getRepairSchedule(scheduleId)).thenReturn(Optional.of(schedule));
+
+    RepairScheduleService service = RepairScheduleService.create(context, repairRunDao);
+    Gauge<Integer> gauge = service.getUnfulfilledRepairSchedule(scheduleId);
+
+    assertEquals(
+        "Past interval plus grace threshold should return 1", Integer.valueOf(1), gauge.getValue());
   }
 
   /**
@@ -274,7 +304,7 @@ public final class RepairScheduleServiceTest {
   }
 
   /**
-   * Test scenario: Last run exists in ERROR state (not DONE) Expected: Returns 0 (not unfulfilled -
+   * Test scenario: Last run exists in ERROR state (not DONE) Expected: Returns 1 (Unfulfilled -
    * checking only DONE repairs)
    */
   @Test
@@ -300,7 +330,7 @@ public final class RepairScheduleServiceTest {
     RepairScheduleService service = RepairScheduleService.create(context, repairRunDao);
     Gauge<Integer> gauge = service.getUnfulfilledRepairSchedule(scheduleId);
 
-    assertEquals("Error repair should return 0", Integer.valueOf(0), gauge.getValue());
+    assertEquals("Error repair should return 1", Integer.valueOf(1), gauge.getValue());
   }
 
   /**
@@ -402,13 +432,15 @@ public final class RepairScheduleServiceTest {
   }
 
   /**
-   * Test scenario: Last repair completed beyond schedule interval Expected: Returns 1 (unfulfilled)
+   * Test scenario: Last repair completed beyond schedule interval but still within 10% grace
+   * Expected: Returns 0
    */
   @Test
-  public void testGetUnfulfilledRepairSchedule_lastRepairBeyondInterval() {
+  public void testGetUnfulfilledRepairSchedule_lastRepairBeyondIntervalWithinGracePeriod() {
     int daysBetween = 7;
     long intervalMillis = daysBetween * 24L * 60 * 60 * 1000;
-    DateTime endTime = DateTime.now().minus(intervalMillis + 1000); // 1 second past interval
+    long graceMillis = intervalMillis / 10;
+    DateTime endTime = DateTime.now().minus(intervalMillis + graceMillis - 1000);
 
     RepairSchedule schedule =
         createScheduleBuilder()
@@ -431,7 +463,44 @@ public final class RepairScheduleServiceTest {
     RepairScheduleService service = RepairScheduleService.create(context, repairRunDao);
     Gauge<Integer> gauge = service.getUnfulfilledRepairSchedule(scheduleId);
 
-    assertEquals("Repair beyond interval should return 1", Integer.valueOf(1), gauge.getValue());
+    assertEquals(
+        "Repair within interval plus grace should return 0", Integer.valueOf(0), gauge.getValue());
+  }
+
+  /**
+   * Test scenario: Last repair completed beyond schedule interval plus 10% grace Expected: Returns
+   * 1 (unfulfilled)
+   */
+  @Test
+  public void testGetUnfulfilledRepairSchedule_lastRepairBeyondIntervalAndGracePeriod() {
+    int daysBetween = 7;
+    long intervalMillis = daysBetween * 24L * 60 * 60 * 1000;
+    long graceMillis = intervalMillis / 10;
+    DateTime endTime = DateTime.now().minus(intervalMillis + graceMillis + 1000);
+
+    RepairSchedule schedule =
+        createScheduleBuilder()
+            .state(RepairSchedule.State.ACTIVE)
+            .daysBetween(daysBetween)
+            .nextActivation(DateTime.now().plusDays(1))
+            .lastRun(repairRunId)
+            .build(scheduleId);
+
+    RepairRun repairRun =
+        createRepairRunBuilder()
+            .runState(RepairRun.RunState.DONE)
+            .startTime(endTime.minusHours(2))
+            .endTime(endTime)
+            .build(repairRunId);
+
+    when(repairScheduleDao.getRepairSchedule(scheduleId)).thenReturn(Optional.of(schedule));
+    when(repairRunDao.getRepairRun(repairRunId)).thenReturn(Optional.of(repairRun));
+
+    RepairScheduleService service = RepairScheduleService.create(context, repairRunDao);
+    Gauge<Integer> gauge = service.getUnfulfilledRepairSchedule(scheduleId);
+
+    assertEquals(
+        "Repair beyond interval plus grace should return 1", Integer.valueOf(1), gauge.getValue());
   }
 
   /**
@@ -552,8 +621,8 @@ public final class RepairScheduleServiceTest {
   }
 
   /**
-   * Test scenario: Last run is ABORTED (not DONE) Expected: Returns 0 (not unfulfilled - only
-   * checking DONE repairs)
+   * Test scenario: Last run is ABORTED (not DONE) Expected: Returns 1 (unfulfilled - only DONE
+   * repairs count)
    */
   @Test
   public void testGetUnfulfilledRepairSchedule_lastRunAborted() {
@@ -578,7 +647,7 @@ public final class RepairScheduleServiceTest {
     RepairScheduleService service = RepairScheduleService.create(context, repairRunDao);
     Gauge<Integer> gauge = service.getUnfulfilledRepairSchedule(scheduleId);
 
-    assertEquals("Aborted repair should return 0", Integer.valueOf(0), gauge.getValue());
+    assertEquals("Aborted repair should return 1", Integer.valueOf(1), gauge.getValue());
   }
 
   /**


### PR DESCRIPTION
The millisSinceLastRepair metrics aren't computed appropriately on startup and we lose track of whether or not we're respecting the repair schedule.
Also, the millisSinceLastRepairForSchedule metric isn't re-computed when a repair ends.

Lastly there are inaccuracies in the computation of the unfullfilled repair schedule metrics, which this PR attempts to solve.