### PR TITLE
Enable metrics collection through https when hitting TLS endpoints

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -85,6 +85,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   final Node node;
   final HttpMetricsProxy metricsProxy;
   OkHttpClient.Builder metricsClientBuilder;
+  final boolean metricsTlsEnabled;
 
   final ConcurrentMap<Integer, RepairStatusHandler> repairStatusHandlers = Maps.newConcurrentMap();
   final ConcurrentMap<String, JobStatusTracker> jobTracker = Maps.newConcurrentMap();
@@ -100,7 +101,8 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       DefaultApi apiClient,
       int metricsPort,
       Node node,
-      OkHttpClient.Builder metricsClientBuilder) {
+      OkHttpClient.Builder metricsClientBuilder,
+      boolean metricsTlsEnabled) {
     this.host = endpoint.getHostString();
     this.metricRegistry = metricRegistry;
     this.rootPath = rootPath;
@@ -110,6 +112,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
     this.statusTracker = executor;
     this.node = node;
     this.metricsClientBuilder = metricsClientBuilder;
+    this.metricsTlsEnabled = metricsTlsEnabled;
     this.metricsProxy = HttpMetricsProxy.create(this, node);
 
     // TODO Perhaps the poll interval should be configurable through context.config ?
@@ -134,6 +137,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
     this.statusTracker = executor;
     this.node = node;
     this.metricsProxy = metricsProxy;
+    this.metricsTlsEnabled = false; // Default to false for test constructor
 
     // TODO Perhaps the poll interval should be configurable through context.config ?
     this.scheduleJobPoller(DEFAULT_POLL_INTERVAL_IN_MILLISECONDS);
@@ -150,6 +154,10 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
 
   public OkHttpClient.Builder getMetricsClientBuilder() {
     return metricsClientBuilder;
+  }
+
+  public boolean isMetricsTlsEnabled() {
+    return metricsTlsEnabled;
   }
 
   @Override

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpManagementConnectionFactory.java
@@ -244,7 +244,8 @@ public class HttpManagementConnectionFactory implements IManagementConnectionFac
                 new InstrumentedScheduledExecutorService(jobStatusPollerExecutor, metricRegistry);
 
             OkHttpClient.Builder metricsClientBuilder = new OkHttpClient().newBuilder();
-            if (httpConfig.isMetricsTLSEnabled()) {
+            boolean metricsTlsEnabled = httpConfig.isMetricsTLSEnabled();
+            if (metricsTlsEnabled) {
               // Pass the clientBuilder to the HttpCassandraManagementProxy
               LOG.debug("Using metrics TLS connection to " + node.getHostname());
               metricsClientBuilder = clientBuilder;
@@ -258,7 +259,8 @@ public class HttpManagementConnectionFactory implements IManagementConnectionFac
                 mgmtApiClient,
                 config.getHttpManagement().getMgmtApiMetricsPort(),
                 node,
-                metricsClientBuilder);
+                metricsClientBuilder,
+                metricsTlsEnabled);
           }
         });
   }

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpMetricsProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpMetricsProxy.java
@@ -100,9 +100,11 @@ public final class HttpMetricsProxy implements MetricsProxy {
 
   private List<GenericMetric> collectMetrics(String metricNamePrefix, Optional<String> keyspaceName)
       throws IOException {
+    // Use https scheme when TLS is enabled for metrics, otherwise use http
+    String scheme = proxy.isMetricsTlsEnabled() ? "https" : "http";
     HttpUrl url =
         new HttpUrl.Builder()
-            .scheme("http")
+            .scheme(scheme)
             .host(proxy.getHost())
             .port(proxy.getMetricsPort())
             .addPathSegment("metrics")

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -523,7 +523,8 @@ public class HttpCassandraManagementProxyTest {
         mockClient,
         ReaperApplicationConfiguration.DEFAULT_MGMT_API_METRICS_PORT,
         Mockito.mock(Node.class),
-        clientBuilder);
+        clientBuilder,
+        false);
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpMetricsProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpMetricsProxyTest.java
@@ -35,6 +35,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.datastax.mgmtapi.client.api.DefaultApi;
@@ -392,5 +394,197 @@ public class HttpMetricsProxyTest {
     assertEquals("ThreadPools", pendingTasks.get(0).getMetricType());
     assertEquals("CompactionExecutor", pendingTasks.get(0).getMetricScope());
     assertEquals("PendingTasks", pendingTasks.get(0).getMetricName());
+  }
+
+  /**
+   * Test that HTTP scheme is used when TLS is disabled for metrics. Verifies the URL scheme is
+   * "http" when metricsTlsEnabled is false.
+   */
+  @Test
+  public void testCollectMetricsUsesHttpSchemeWhenTlsDisabled() throws IOException, JMException {
+    String responseBodyStr =
+        "org_apache_cassandra_metrics_thread_pools_pending_tasks{pool_name=\"TestPool\"} 0.0\n";
+
+    OkHttpClient httpClient = Mockito.mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = Mockito.mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+
+    Call call = Mockito.mock(Call.class);
+    Response response = Mockito.mock(Response.class);
+
+    when(httpClient.newCall(any())).thenReturn(call);
+    when(call.execute()).thenReturn(response);
+    when(response.isSuccessful()).thenReturn(true);
+
+    ResponseBody responseBody = Mockito.mock(ResponseBody.class);
+    when(responseBody.string()).thenReturn(responseBodyStr);
+    when(response.body()).thenReturn(responseBody);
+
+    HttpCassandraManagementProxy httpManagementProxy =
+        Mockito.mock(HttpCassandraManagementProxy.class);
+    when(httpManagementProxy.getHost()).thenReturn("172.18.0.3");
+    when(httpManagementProxy.getMetricsPort()).thenReturn(9000);
+    when(httpManagementProxy.getMetricsClientBuilder()).thenReturn(clientBuilder);
+    when(httpManagementProxy.isMetricsTlsEnabled()).thenReturn(false); // TLS disabled
+
+    Node node =
+        Node.builder()
+            .withHostname("172.18.0.3")
+            .withCluster(
+                Cluster.builder().withName("test").withSeedHosts(Sets.newSet("127.0.0.1")).build())
+            .build();
+
+    HttpMetricsProxy httpMetricsProxy = HttpMetricsProxy.create(httpManagementProxy, node);
+    httpMetricsProxy.collectTpStats();
+
+    // Verify that the request was made with HTTP scheme
+    verify(httpClient)
+        .newCall(
+            argThat(
+                request ->
+                    request.url().scheme().equals("http")
+                        && request.url().host().equals("172.18.0.3")
+                        && request.url().port() == 9000));
+  }
+
+  /**
+   * Test that HTTPS scheme is used when TLS is enabled for metrics. Verifies the URL scheme is
+   * "https" when metricsTlsEnabled is true.
+   */
+  @Test
+  public void testCollectMetricsUsesHttpsSchemeWhenTlsEnabled() throws IOException, JMException {
+    String responseBodyStr =
+        "org_apache_cassandra_metrics_thread_pools_pending_tasks{pool_name=\"TestPool\"} 0.0\n";
+
+    OkHttpClient httpClient = Mockito.mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = Mockito.mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+
+    Call call = Mockito.mock(Call.class);
+    Response response = Mockito.mock(Response.class);
+
+    when(httpClient.newCall(any())).thenReturn(call);
+    when(call.execute()).thenReturn(response);
+    when(response.isSuccessful()).thenReturn(true);
+
+    ResponseBody responseBody = Mockito.mock(ResponseBody.class);
+    when(responseBody.string()).thenReturn(responseBodyStr);
+    when(response.body()).thenReturn(responseBody);
+
+    HttpCassandraManagementProxy httpManagementProxy =
+        Mockito.mock(HttpCassandraManagementProxy.class);
+    when(httpManagementProxy.getHost()).thenReturn("172.18.0.3");
+    when(httpManagementProxy.getMetricsPort()).thenReturn(9000);
+    when(httpManagementProxy.getMetricsClientBuilder()).thenReturn(clientBuilder);
+    when(httpManagementProxy.isMetricsTlsEnabled()).thenReturn(true); // TLS enabled
+
+    Node node =
+        Node.builder()
+            .withHostname("172.18.0.3")
+            .withCluster(
+                Cluster.builder().withName("test").withSeedHosts(Sets.newSet("127.0.0.1")).build())
+            .build();
+
+    HttpMetricsProxy httpMetricsProxy = HttpMetricsProxy.create(httpManagementProxy, node);
+    httpMetricsProxy.collectTpStats();
+
+    // Verify that the request was made with HTTPS scheme
+    verify(httpClient)
+        .newCall(
+            argThat(
+                request ->
+                    request.url().scheme().equals("https")
+                        && request.url().host().equals("172.18.0.3")
+                        && request.url().port() == 9000));
+  }
+
+  /**
+   * Test that dropped messages collection uses HTTP when TLS is disabled. Ensures consistency
+   * across different metric collection methods.
+   */
+  @Test
+  public void testCollectDroppedMessagesUsesHttpWhenTlsDisabled() throws IOException, JMException {
+    String responseBodyStr =
+        "org_apache_cassandra_metrics_dropped_message_dropped_total{message_type=\"READ\"} 5.0\n";
+
+    OkHttpClient httpClient = Mockito.mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = Mockito.mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+
+    Call call = Mockito.mock(Call.class);
+    Response response = Mockito.mock(Response.class);
+
+    when(httpClient.newCall(any())).thenReturn(call);
+    when(call.execute()).thenReturn(response);
+    when(response.isSuccessful()).thenReturn(true);
+
+    ResponseBody responseBody = Mockito.mock(ResponseBody.class);
+    when(responseBody.string()).thenReturn(responseBodyStr);
+    when(response.body()).thenReturn(responseBody);
+
+    HttpCassandraManagementProxy httpManagementProxy =
+        Mockito.mock(HttpCassandraManagementProxy.class);
+    when(httpManagementProxy.getHost()).thenReturn("172.18.0.3");
+    when(httpManagementProxy.getMetricsPort()).thenReturn(9000);
+    when(httpManagementProxy.getMetricsClientBuilder()).thenReturn(clientBuilder);
+    when(httpManagementProxy.isMetricsTlsEnabled()).thenReturn(false);
+
+    Node node =
+        Node.builder()
+            .withHostname("172.18.0.3")
+            .withCluster(
+                Cluster.builder().withName("test").withSeedHosts(Sets.newSet("127.0.0.1")).build())
+            .build();
+
+    HttpMetricsProxy httpMetricsProxy = HttpMetricsProxy.create(httpManagementProxy, node);
+    httpMetricsProxy.collectDroppedMessages();
+
+    // Verify HTTP scheme is used
+    verify(httpClient).newCall(argThat(request -> request.url().scheme().equals("http")));
+  }
+
+  /**
+   * Test that latency metrics collection uses HTTPS when TLS is enabled. Ensures consistency across
+   * different metric collection methods.
+   */
+  @Test
+  public void testCollectLatencyMetricsUsesHttpsWhenTlsEnabled() throws IOException, JMException {
+    String responseBodyStr =
+        "org_apache_cassandra_metrics_client_request_latency_total{request_type=\"Read\"} 10.0\n";
+
+    OkHttpClient httpClient = Mockito.mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = Mockito.mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+
+    Call call = Mockito.mock(Call.class);
+    Response response = Mockito.mock(Response.class);
+
+    when(httpClient.newCall(any())).thenReturn(call);
+    when(call.execute()).thenReturn(response);
+    when(response.isSuccessful()).thenReturn(true);
+
+    ResponseBody responseBody = Mockito.mock(ResponseBody.class);
+    when(responseBody.string()).thenReturn(responseBodyStr);
+    when(response.body()).thenReturn(responseBody);
+
+    HttpCassandraManagementProxy httpManagementProxy =
+        Mockito.mock(HttpCassandraManagementProxy.class);
+    when(httpManagementProxy.getHost()).thenReturn("172.18.0.3");
+    when(httpManagementProxy.getMetricsPort()).thenReturn(9000);
+    when(httpManagementProxy.getMetricsClientBuilder()).thenReturn(clientBuilder);
+    when(httpManagementProxy.isMetricsTlsEnabled()).thenReturn(true);
+
+    Node node =
+        Node.builder()
+            .withHostname("172.18.0.3")
+            .withCluster(
+                Cluster.builder().withName("test").withSeedHosts(Sets.newSet("127.0.0.1")).build())
+            .build();
+
+    HttpMetricsProxy httpMetricsProxy = HttpMetricsProxy.create(httpManagementProxy, node);
+    httpMetricsProxy.collectLatencyMetrics();
+
+    // Verify HTTPS scheme is used
+    verify(httpClient).newCall(argThat(request -> request.url().scheme().equals("https")));
   }
 }


### PR DESCRIPTION
Fixes #1680
While we were building a TLS enabled http client, we were always using the `http` scheme.
This PR makes it so that https is used when TLS is enabled in the metrics client.