### PR TITLE
fix: Fix CVEs in cassandra reaper

### DIFF
--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.12.0</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -358,6 +358,16 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>2.2.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>11.0.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>11.0.26</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixed CVE
<img width="120" height="17" alt="image" src="https://github.com/user-attachments/assets/38f4a362-e5c4-4c83-8e5a-9a8372436440" />

Note: Cannot use jetty-http, jetty-io v12.x package as its supported from Java 17+

CVEs present in OS of Docker image
<img width="1582" height="129" alt="image" src="https://github.com/user-attachments/assets/ccc63b15-b64f-439f-8694-53b16d27a4af" />
