### PR TITLE
fix: scheduled repairs never re-fire after a completed run (#1683)

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -78,14 +78,14 @@ public final class SchedulingManager extends TimerTask {
   }
 
   /**
-   * Postpone a schedule only while a conflicting run is still in flight: any active run on the
-   * unit, or a not-yet-started run from this schedule. Terminated runs must not block it, else the
+   * Postpone a schedule only while one of its own runs is still in flight: an active or
+   * not-yet-started run that comes from this schedule. Terminated runs must not block it, else the
    * schedule stays stuck until the completed run is purged.
    */
   private static boolean repairRunBlocksSchedule(RepairRun repairRun, RepairSchedule schedule) {
-    return repairRun.getRunState().isActive()
-        || (RepairRun.RunState.NOT_STARTED == repairRun.getRunState()
-            && repairRunComesFromSchedule(repairRun, schedule));
+    return (repairRun.getRunState().isActive()
+            || RepairRun.RunState.NOT_STARTED == repairRun.getRunState())
+        && repairRunComesFromSchedule(repairRun, schedule);
   }
 
   private static String getCauseName(RepairSchedule schedule) {

--- a/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SchedulingManager.java
@@ -77,6 +77,17 @@ public final class SchedulingManager extends TimerTask {
     return repairRun.getCause().equals(getCauseName(schedule));
   }
 
+  /**
+   * Postpone a schedule only while a conflicting run is still in flight: any active run on the
+   * unit, or a not-yet-started run from this schedule. Terminated runs must not block it, else the
+   * schedule stays stuck until the completed run is purged.
+   */
+  private static boolean repairRunBlocksSchedule(RepairRun repairRun, RepairSchedule schedule) {
+    return repairRun.getRunState().isActive()
+        || (RepairRun.RunState.NOT_STARTED == repairRun.getRunState()
+            && repairRunComesFromSchedule(repairRun, schedule));
+  }
+
   private static String getCauseName(RepairSchedule schedule) {
     return "scheduled run (schedule id " + schedule.getId().toString() + ')';
   }
@@ -253,7 +264,7 @@ public final class SchedulingManager extends TimerTask {
     Collection<RepairRun> repairRuns =
         repairRunDao.getRepairRunsForUnit(schedule.getRepairUnitId());
     for (RepairRun repairRun : repairRuns) {
-      if (repairRunComesFromSchedule(repairRun, schedule)) {
+      if (repairRunBlocksSchedule(repairRun, schedule)) {
         LOG.info(
             "there is repair (id {}) in state '{}' for repair unit '{}', "
                 + "postponing current schedule trigger until next scheduling",

--- a/src/server/src/test/java/io/cassandrareaper/service/SchedulingManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SchedulingManagerTest.java
@@ -438,6 +438,106 @@ public final class SchedulingManagerTest {
     Mockito.verify(context.repairManager, Mockito.times(0)).startRepairRun(any());
   }
 
+  // A terminated run (DONE/ERROR/ABORTED) must not block the schedule from firing again.
+  @Test
+  public void manageScheduleStartsNewRunWhenPreviousRunIsDone() throws ReaperException {
+    RepairUnit unit = testUnit();
+    UUID scheduleId = Uuids.timeBased();
+    RepairSchedule schedule = dueSchedule(unit.getId(), scheduleId);
+    AppContext context =
+        contextWithExistingRuns(unit, scheduledRun(unit.getId(), scheduleId, RunState.DONE));
+    when(context.storage.getClusterDao()).thenReturn(mock(IClusterDao.class));
+
+    RepairRunService repairRunService = mock(RepairRunService.class);
+    when(repairRunService.registerRepairRun(any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(scheduledRun(unit.getId(), scheduleId, RunState.NOT_STARTED));
+    SchedulingManager schedulingManager =
+        SchedulingManager.create(
+            context, () -> repairRunService, context.storage.getRepairRunDao());
+
+    assertTrue(
+        "A completed previous run must not block the schedule from firing again",
+        schedulingManager.manageSchedule(schedule));
+    Mockito.verify(context.repairManager).startRepairRun(any());
+  }
+
+  // Counterpart to the above: an in-flight run from this schedule must postpone the trigger rather
+  // than start a concurrent run.
+  @Test
+  public void manageScheduleDoesNotStartNewRunWhenPreviousRunIsActive() throws ReaperException {
+    RepairUnit unit = testUnit();
+    UUID scheduleId = Uuids.timeBased();
+    RepairSchedule schedule = dueSchedule(unit.getId(), scheduleId);
+    AppContext context =
+        contextWithExistingRuns(unit, scheduledRun(unit.getId(), scheduleId, RunState.RUNNING));
+    SchedulingManager schedulingManager =
+        SchedulingManager.create(
+            context, () -> mock(RepairRunService.class), context.storage.getRepairRunDao());
+
+    assertFalse(
+        "An in-flight run from the same schedule must postpone the trigger",
+        schedulingManager.manageSchedule(schedule));
+    Mockito.verify(context.repairManager, Mockito.never()).startRepairRun(any());
+  }
+
+  private static RepairUnit testUnit() {
+    return RepairUnit.builder()
+        .clusterName("test")
+        .incrementalRepair(false)
+        .subrangeIncrementalRepair(false)
+        .keyspaceName("test")
+        .repairThreadCount(1)
+        .timeout(30)
+        .build(Uuids.timeBased());
+  }
+
+  private static RepairSchedule dueSchedule(UUID unitId, UUID scheduleId) {
+    return RepairSchedule.builder(unitId)
+        .daysBetween(7)
+        .nextActivation(DateTime.now().minusMinutes(1))
+        .repairParallelism(RepairParallelism.PARALLEL)
+        .intensity(1)
+        .segmentCountPerNode(10)
+        .state(RepairSchedule.State.ACTIVE)
+        .build(scheduleId);
+  }
+
+  private static RepairRun scheduledRun(UUID unitId, UUID scheduleId, RunState state) {
+    RepairRun.Builder builder =
+        RepairRun.builder("test", unitId)
+            .repairParallelism(RepairParallelism.PARALLEL)
+            .intensity(1.0)
+            .segmentCount(10)
+            .tables(Collections.emptySet())
+            .cause("scheduled run (schedule id " + scheduleId + ')')
+            .runState(state);
+    if (state != RunState.NOT_STARTED) {
+      builder.startTime(DateTime.now().minusHours(1));
+    }
+    if (state.isTerminated()) {
+      builder.endTime(DateTime.now().minusMinutes(30));
+    }
+    return builder.build(Uuids.timeBased());
+  }
+
+  private static AppContext contextWithExistingRuns(RepairUnit unit, RepairRun... existingRuns) {
+    AppContext context = new AppContext();
+    context.config = new ReaperApplicationConfiguration();
+    context.repairManager = mock(RepairManager.class);
+    context.storage = mock(CassandraStorageFacade.class);
+
+    IRepairUnitDao repairUnitDao = mock(IRepairUnitDao.class);
+    when(context.storage.getRepairUnitDao()).thenReturn(repairUnitDao);
+    when(repairUnitDao.getRepairUnit(any(UUID.class))).thenReturn(unit);
+
+    IRepairRunDao repairRunDao = mock(IRepairRunDao.class);
+    when(context.storage.getRepairRunDao()).thenReturn(repairRunDao);
+    when(repairRunDao.getRepairRunsForUnit(any())).thenReturn(Lists.newArrayList(existingRuns));
+
+    when(context.storage.getRepairScheduleDao()).thenReturn(mock(IRepairScheduleDao.class));
+    return context;
+  }
+
   @Test
   public void cleanupMetricsRegistryTest() {
     AppContext context = new AppContext();

--- a/src/server/src/test/java/io/cassandrareaper/service/SchedulingManagerTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/service/SchedulingManagerTest.java
@@ -461,6 +461,30 @@ public final class SchedulingManagerTest {
     Mockito.verify(context.repairManager).startRepairRun(any());
   }
 
+  // An in-flight run that does not come from this schedule (e.g. a manual run or another schedule
+  // on the same unit) must not postpone this schedule.
+  @Test
+  public void manageScheduleStartsNewRunWhenActiveRunIsFromAnotherCause() throws ReaperException {
+    RepairUnit unit = testUnit();
+    UUID scheduleId = Uuids.timeBased();
+    RepairSchedule schedule = dueSchedule(unit.getId(), scheduleId);
+    RepairRun otherRun = scheduledRun(unit.getId(), Uuids.timeBased(), RunState.RUNNING);
+    AppContext context = contextWithExistingRuns(unit, otherRun);
+    when(context.storage.getClusterDao()).thenReturn(mock(IClusterDao.class));
+
+    RepairRunService repairRunService = mock(RepairRunService.class);
+    when(repairRunService.registerRepairRun(any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(scheduledRun(unit.getId(), scheduleId, RunState.NOT_STARTED));
+    SchedulingManager schedulingManager =
+        SchedulingManager.create(
+            context, () -> repairRunService, context.storage.getRepairRunDao());
+
+    boolean started = schedulingManager.manageSchedule(schedule);
+
+    assertTrue("A run that does not come from this schedule must not block it", started);
+    Mockito.verify(context.repairManager).startRepairRun(any());
+  }
+
   // Counterpart to the above: an in-flight run from this schedule must postpone the trigger rather
   // than start a concurrent run.
   @Test


### PR DESCRIPTION
Fixes #1683.

PR #1672 reduced `repairRunComesFromSchedule()` to a pure cause-string match. That made `repairRunAlreadyScheduled()` treat terminated runs (DONE/ERROR/ABORTED) carrying the schedule's cause as still blocking, so a schedule stayedpostponed until the previous run was purged from storage - effectively running on the purge interval (default 30 days) instead of its configured cadence.
Regression in 4.2.2; not present in 4.0.x–4.2.1.

Rather than reverting #1672 (which would re-couple `maybeRegisterRepairRunCompleted()` to the run's transient state), this restores the pre-#1672 postponement predicate in a dedicated `repairRunBlocksSchedule()` helper - any active run on the unit, or a NOT_STARTED run from this schedule - while keeping the cause-only match for the schedule-metrics path added in #1672.

Adds `SchedulingManagerTest` coverage for re-firing after a completed run and for postponing while a run from the same schedule is still in flight.

Tested this against a .deb built with the same process as in CI and seems to work as expected.
