### PR TITLE
Prevent poller termination during concurrent repair cleanup

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -634,11 +634,21 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
         try {
           final String jobId = entry.getKey();
           Job job = getJobStatus(jobId);
+          if (job.getStatusChanges() == null) {
+            LOG.warn("Job {} returned null statusChanges in notificationsTracker, skipping", jobId);
+            continue;
+          }
           int availableNotifications = job.getStatusChanges().size();
           int currentNotificationCount = entry.getValue().latestNotificationCount.get();
           if (currentNotificationCount < availableNotifications) {
+            String rawId = job.getId();
+            if (rawId == null || !rawId.startsWith("repair-") || rawId.length() <= 7) {
+              LOG.warn(
+                  "Job {} has malformed id '{}' in notificationsTracker, skipping", jobId, rawId);
+              continue;
+            }
             // remove "repair-" prefix once per job, not per notification
-            int repairNo = Integer.parseInt(job.getId().substring(7));
+            int repairNo = Integer.parseInt(rawId.substring(7));
             for (int i = currentNotificationCount; i < availableNotifications; i++) {
               dispatchNotification(repairNo, jobId, i, job.getStatusChanges().get(i));
               entry.getValue().latestNotificationCount.incrementAndGet();
@@ -657,7 +667,18 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
 
   private void dispatchNotification(
       int repairNo, String jobId, int index, StatusChange statusChange) {
-    ProgressEventType progressType = ProgressEventType.valueOf(statusChange.getStatus());
+    ProgressEventType progressType;
+    try {
+      progressType = ProgressEventType.valueOf(statusChange.getStatus());
+    } catch (IllegalArgumentException e) {
+      LOG.warn(
+          "Unknown ProgressEventType '{}' for repairNo={} jobId={} index={}, skipping",
+          statusChange.getStatus(),
+          repairNo,
+          jobId,
+          index);
+      return;
+    }
 
     ExecutorService executor = repairStatusExecutors.get(repairNo);
     if (executor == null) {

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -633,76 +633,69 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
         try {
           final String jobId = entry.getKey();
-          Job job;
-          try {
-            job = getJobStatus(jobId);
-          } catch (Exception e) {
-            LOG.warn("Failed to get job status for jobId={}, will retry on next tick", jobId, e);
-            continue;
-          }
-
+          Job job = getJobStatus(jobId);
           int availableNotifications = job.getStatusChanges().size();
           int currentNotificationCount = entry.getValue().latestNotificationCount.get();
-
           if (currentNotificationCount < availableNotifications) {
             // remove "repair-" prefix once per job, not per notification
             int repairNo = Integer.parseInt(job.getId().substring(7));
             for (int i = currentNotificationCount; i < availableNotifications; i++) {
-              StatusChange statusChange = job.getStatusChanges().get(i);
-              ProgressEventType progressType = ProgressEventType.valueOf(statusChange.getStatus());
-
-              ExecutorService executor = repairStatusExecutors.get(repairNo);
-              if (executor == null) {
-                // The repair was cleaned up concurrently; skip this event safely.
-                LOG.warn(
-                    "Executor for repairNo={} is null while processing jobId={} notification"
-                        + " index={}, skipping",
-                    repairNo,
-                    jobId,
-                    i);
-                entry.getValue().latestNotificationCount.incrementAndGet();
-                continue;
-              }
-
-              RepairStatusHandler handler = repairStatusHandlers.get(repairNo);
-              if (handler == null) {
-                LOG.warn(
-                    "Handler for repairNo={} is null while processing jobId={} notification"
-                        + " index={}, skipping",
-                    repairNo,
-                    jobId,
-                    i);
-                entry.getValue().latestNotificationCount.incrementAndGet();
-                continue;
-              }
-
-              try {
-                executor.submit(
-                    () ->
-                        handler.handle(
-                            repairNo, Optional.of(progressType), statusChange.getMessage(), this));
-              } catch (Exception e) {
-                // Covers RejectedExecutionException if the executor was shut down
-                // concurrently between the null check above and this call.
-                LOG.warn(
-                    "Failed to submit notification for repairNo={} jobId={} index={}",
-                    repairNo,
-                    jobId,
-                    i,
-                    e);
-              }
+              dispatchNotification(repairNo, jobId, i, job.getStatusChanges().get(i));
               entry.getValue().latestNotificationCount.incrementAndGet();
             }
           }
         } catch (Exception e) {
-          LOG.error(
-              "Unexpected error processing job entry key={} in notificationsTracker, skipping"
+          LOG.warn(
+              "Failed to process jobTracker entry key={} in notificationsTracker, skipping"
                   + " to next job",
               entry.getKey(),
               e);
         }
       }
     };
+  }
+
+  private void dispatchNotification(
+      int repairNo, String jobId, int index, StatusChange statusChange) {
+    ProgressEventType progressType = ProgressEventType.valueOf(statusChange.getStatus());
+
+    ExecutorService executor = repairStatusExecutors.get(repairNo);
+    if (executor == null) {
+      // The repair was cleaned up concurrently; skip this event safely.
+      LOG.warn(
+          "Executor for repairNo={} is null while processing jobId={} notification index={},"
+              + " skipping",
+          repairNo,
+          jobId,
+          index);
+      return;
+    }
+
+    RepairStatusHandler handler = repairStatusHandlers.get(repairNo);
+    if (handler == null) {
+      LOG.warn(
+          "Handler for repairNo={} is null while processing jobId={} notification index={},"
+              + " skipping",
+          repairNo,
+          jobId,
+          index);
+      return;
+    }
+
+    try {
+      executor.submit(
+          () ->
+              handler.handle(repairNo, Optional.of(progressType), statusChange.getMessage(), this));
+    } catch (Exception e) {
+      // Covers RejectedExecutionException if the executor was shut down
+      // concurrently between the null check above and this call.
+      LOG.warn(
+          "Failed to submit notification for repairNo={} jobId={} index={}",
+          repairNo,
+          jobId,
+          index,
+          e);
+    }
   }
 
   // Coordinator nodes such as Stargate instances do not have tokens

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -649,8 +649,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
             int repairNo = Integer.parseInt(job.getId().substring(7));
             for (int i = currentNotificationCount; i < availableNotifications; i++) {
               StatusChange statusChange = job.getStatusChanges().get(i);
-              ProgressEventType progressType =
-                  ProgressEventType.valueOf(statusChange.getStatus());
+              ProgressEventType progressType = ProgressEventType.valueOf(statusChange.getStatus());
 
               ExecutorService executor = repairStatusExecutors.get(repairNo);
               if (executor == null) {
@@ -681,10 +680,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
                 executor.submit(
                     () ->
                         handler.handle(
-                            repairNo,
-                            Optional.of(progressType),
-                            statusChange.getMessage(),
-                            this));
+                            repairNo, Optional.of(progressType), statusChange.getMessage(), this));
               } catch (Exception e) {
                 // Covers RejectedExecutionException if the executor was shut down
                 // concurrently between the null check above and this call.

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -633,7 +633,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
         try {
           processJobEntry(entry);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
           LOG.warn(
               "Failed to process jobTracker entry key={} in notificationsTracker,"
                   + " will retry on next poll",
@@ -711,7 +711,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       executor.submit(
           () ->
               handler.handle(repairNo, Optional.of(progressType), statusChange.getMessage(), this));
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       // Covers RejectedExecutionException if the executor was shut down
       // concurrently between the null check above and this call.
       LOG.warn(

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -410,13 +410,16 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
 
   @Override
   public void removeRepairStatusHandler(int repairNo) {
+    String jobId = String.format("repair-%d", repairNo);
+    // Remove the job from jobTracker first so the poller stops seeing it before the
+    // executor is torn down.  This closes the window where the poller could observe a
+    // live jobTracker entry whose executor has already been removed.
+    jobTracker.remove(jobId);
     repairStatusHandlers.remove(repairNo);
     ExecutorService repairStatusExecutor = repairStatusExecutors.remove(repairNo);
     if (null != repairStatusExecutor) {
       repairStatusExecutor.shutdown();
     }
-    String jobId = String.format("repair-%d", repairNo);
-    jobTracker.remove(jobId);
   }
 
   @Override
@@ -627,36 +630,80 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   @VisibleForTesting
   Runnable notificationsTracker() {
     return () -> {
-      if (jobTracker.size() > 0) {
-        for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
-          Job job = getJobStatus(entry.getKey());
+      for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
+        try {
+          final String jobId = entry.getKey();
+          Job job;
+          try {
+            job = getJobStatus(jobId);
+          } catch (Exception e) {
+            LOG.warn("Failed to get job status for jobId={}, will retry on next tick", jobId, e);
+            continue;
+          }
+
           int availableNotifications = job.getStatusChanges().size();
           int currentNotificationCount = entry.getValue().latestNotificationCount.get();
 
           if (currentNotificationCount < availableNotifications) {
-            // We need to process the new ones
+            // remove "repair-" prefix once per job, not per notification
+            int repairNo = Integer.parseInt(job.getId().substring(7));
             for (int i = currentNotificationCount; i < availableNotifications; i++) {
               StatusChange statusChange = job.getStatusChanges().get(i);
-              // remove "repair-" prefix
-              int repairNo = Integer.parseInt(job.getId().substring(7));
-              ProgressEventType progressType = ProgressEventType.valueOf(statusChange.getStatus());
-              repairStatusExecutors
-                  .get(repairNo)
-                  .submit(
-                      () -> {
-                        repairStatusHandlers
-                            .get(repairNo)
-                            .handle(
-                                repairNo,
-                                Optional.of(progressType),
-                                statusChange.getMessage(),
-                                this);
-                      });
+              ProgressEventType progressType =
+                  ProgressEventType.valueOf(statusChange.getStatus());
 
-              // Update the count as we process them
+              ExecutorService executor = repairStatusExecutors.get(repairNo);
+              if (executor == null) {
+                // The repair was cleaned up concurrently; skip this event safely.
+                LOG.warn(
+                    "Executor for repairNo={} is null while processing jobId={} notification"
+                        + " index={}, skipping",
+                    repairNo,
+                    jobId,
+                    i);
+                entry.getValue().latestNotificationCount.incrementAndGet();
+                continue;
+              }
+
+              RepairStatusHandler handler = repairStatusHandlers.get(repairNo);
+              if (handler == null) {
+                LOG.warn(
+                    "Handler for repairNo={} is null while processing jobId={} notification"
+                        + " index={}, skipping",
+                    repairNo,
+                    jobId,
+                    i);
+                entry.getValue().latestNotificationCount.incrementAndGet();
+                continue;
+              }
+
+              try {
+                executor.submit(
+                    () ->
+                        handler.handle(
+                            repairNo,
+                            Optional.of(progressType),
+                            statusChange.getMessage(),
+                            this));
+              } catch (Exception e) {
+                // Covers RejectedExecutionException if the executor was shut down
+                // concurrently between the null check above and this call.
+                LOG.warn(
+                    "Failed to submit notification for repairNo={} jobId={} index={}",
+                    repairNo,
+                    jobId,
+                    i,
+                    e);
+              }
               entry.getValue().latestNotificationCount.incrementAndGet();
             }
           }
+        } catch (Exception e) {
+          LOG.error(
+              "Unexpected error processing job entry key={} in notificationsTracker, skipping"
+                  + " to next job",
+              entry.getKey(),
+              e);
         }
       }
     };

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -658,8 +658,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
     }
     String rawId = job.getId();
     if (rawId == null || !rawId.startsWith("repair-") || rawId.length() <= 7) {
-      LOG.warn(
-          "Job {} has malformed id '{}' in notificationsTracker, skipping", jobId, rawId);
+      LOG.warn("Job {} has malformed id '{}' in notificationsTracker, skipping", jobId, rawId);
       return;
     }
     // remove "repair-" prefix once per job, not per notification

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -632,28 +632,7 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
     return () -> {
       for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
         try {
-          final String jobId = entry.getKey();
-          Job job = getJobStatus(jobId);
-          if (job.getStatusChanges() == null) {
-            LOG.warn("Job {} returned null statusChanges in notificationsTracker, skipping", jobId);
-            continue;
-          }
-          int availableNotifications = job.getStatusChanges().size();
-          int currentNotificationCount = entry.getValue().latestNotificationCount.get();
-          if (currentNotificationCount < availableNotifications) {
-            String rawId = job.getId();
-            if (rawId == null || !rawId.startsWith("repair-") || rawId.length() <= 7) {
-              LOG.warn(
-                  "Job {} has malformed id '{}' in notificationsTracker, skipping", jobId, rawId);
-              continue;
-            }
-            // remove "repair-" prefix once per job, not per notification
-            int repairNo = Integer.parseInt(rawId.substring(7));
-            for (int i = currentNotificationCount; i < availableNotifications; i++) {
-              dispatchNotification(repairNo, jobId, i, job.getStatusChanges().get(i));
-              entry.getValue().latestNotificationCount.incrementAndGet();
-            }
-          }
+          processJobEntry(entry);
         } catch (Exception e) {
           LOG.warn(
               "Failed to process jobTracker entry key={} in notificationsTracker,"
@@ -663,6 +642,32 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
         }
       }
     };
+  }
+
+  private void processJobEntry(Map.Entry<String, JobStatusTracker> entry) {
+    final String jobId = entry.getKey();
+    Job job = getJobStatus(jobId);
+    if (job.getStatusChanges() == null) {
+      LOG.warn("Job {} returned null statusChanges in notificationsTracker, skipping", jobId);
+      return;
+    }
+    int availableNotifications = job.getStatusChanges().size();
+    int currentNotificationCount = entry.getValue().latestNotificationCount.get();
+    if (currentNotificationCount >= availableNotifications) {
+      return;
+    }
+    String rawId = job.getId();
+    if (rawId == null || !rawId.startsWith("repair-") || rawId.length() <= 7) {
+      LOG.warn(
+          "Job {} has malformed id '{}' in notificationsTracker, skipping", jobId, rawId);
+      return;
+    }
+    // remove "repair-" prefix once per job, not per notification
+    int repairNo = Integer.parseInt(rawId.substring(7));
+    for (int i = currentNotificationCount; i < availableNotifications; i++) {
+      dispatchNotification(repairNo, jobId, i, job.getStatusChanges().get(i));
+      entry.getValue().latestNotificationCount.incrementAndGet();
+    }
   }
 
   private void dispatchNotification(

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -411,9 +411,9 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   @Override
   public void removeRepairStatusHandler(int repairNo) {
     String jobId = String.format("repair-%d", repairNo);
-    // Remove the job from jobTracker first so the poller stops seeing it before the
-    // executor is torn down.  This closes the window where the poller could observe a
-    // live jobTracker entry whose executor has already been removed.
+    // Remove the job from jobTracker first so new poller iterations do not pick it up.
+    // Entries already captured by an in-flight entrySet() iteration are handled safely
+    // by the null checks in dispatchNotification().
     jobTracker.remove(jobId);
     repairStatusHandlers.remove(repairNo);
     ExecutorService repairStatusExecutor = repairStatusExecutors.remove(repairNo);
@@ -656,8 +656,8 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
           }
         } catch (Exception e) {
           LOG.warn(
-              "Failed to process jobTracker entry key={} in notificationsTracker, skipping"
-                  + " to next job",
+              "Failed to process jobTracker entry key={} in notificationsTracker,"
+                  + " will retry on next poll",
               entry.getKey(),
               e);
         }

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -43,8 +43,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -270,6 +273,143 @@ public class HttpCassandraManagementProxyTest {
     jobStatus = httpCassandraManagementProxy.jobTracker.get(jobId);
     assertEquals(2, jobStatus.latestNotificationCount.get());
     assertEquals(2, callTimes.get());
+  }
+
+  /**
+   * Reproduces the cleanup race: the poller commits to a jobTracker entry then blocks on the
+   * HTTP response; concurrently, removeRepairStatusHandler() removes the executor from
+   * repairStatusExecutors. When the poller resumes, repairStatusExecutors.get(repairNo) returns
+   * null — the pre-fix crash site.
+   *
+   * <p>The critical contract is that {@code notificationsTracker().run()} must not throw. Per the
+   * {@link java.util.concurrent.ScheduledExecutorService} contract for {@code
+   * scheduleWithFixedDelay}, any unchecked exception escaping the Runnable permanently suppresses
+   * all future executions.
+   */
+  @Test
+  public void testNotificationsTrackerSurvivesRaceWithRemoveHandler() throws Exception {
+    // pollerReady: poller signals it has entered getJobStatus() and is past the point of no return
+    CountDownLatch pollerReady = new CountDownLatch(1);
+    // cleanupDone: cleanup thread signals removeRepairStatusHandler() has finished
+    CountDownLatch cleanupDone = new CountDownLatch(1);
+
+    DefaultApi mockClient = mock(DefaultApi.class);
+    doReturn((new RepairRequestResponse()).repairId("repair-999"))
+        .when(mockClient)
+        .putRepairV2(any());
+
+    HttpCassandraManagementProxy proxy = mockProxy(mockClient);
+
+    final AtomicInteger callTimes = new AtomicInteger(0);
+    RepairStatusHandler handler =
+        (repairNumber, progress, message, mgmtProxy) -> callTimes.incrementAndGet();
+
+    int repairNo =
+        proxy.triggerRepair(
+            "ks",
+            RepairParallelism.PARALLEL,
+            Collections.singleton("table"),
+            RepairType.SUBRANGE_FULL,
+            Collections.emptyList(),
+            handler,
+            Collections.emptyList(),
+            1);
+
+    // One START notification waiting for the poller to pick up.
+    Job job = new Job();
+    job.setId("repair-999");
+    StatusChange sc = new StatusChange();
+    sc.setStatus("START");
+    sc.setMessage("");
+    List<StatusChange> statusChanges = new ArrayList<>();
+    statusChanges.add(sc);
+    job.setStatusChanges(statusChanges);
+
+    // Block inside getJobStatus() to pin the race window: signal cleanup, then wait for it.
+    when(mockClient.getJobStatus("repair-999"))
+        .thenAnswer(
+            invocation -> {
+              pollerReady.countDown(); // unblock the cleanup thread
+              cleanupDone.await();     // wait until executor has been removed
+              return job;
+            });
+
+    // Capture any exception that would have killed the ScheduledExecutorService.
+    AtomicReference<Throwable> pollerException = new AtomicReference<>();
+    Thread pollerThread =
+        new Thread(
+            () -> {
+              try {
+                proxy.notificationsTracker().run();
+              } catch (Throwable t) {
+                pollerException.set(t);
+              }
+            },
+            "test-poller");
+
+    // Remove the executor while the poller is blocked inside getJobStatus().
+    Thread cleanupThread =
+        new Thread(
+            () -> {
+              try {
+                pollerReady.await();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+              }
+              proxy.removeRepairStatusHandler(repairNo);
+              cleanupDone.countDown();
+            },
+            "test-cleanup");
+
+    pollerThread.start();
+    cleanupThread.start();
+    pollerThread.join(5000);
+    cleanupThread.join(5000);
+
+    assertFalse("test-poller thread must not still be running", pollerThread.isAlive());
+    assertFalse("test-cleanup thread must not still be running", cleanupThread.isAlive());
+
+    // The Runnable must not throw — an escaping exception permanently kills scheduleWithFixedDelay.
+    assertThat(pollerException.get())
+        .as("notificationsTracker().run() must not throw when executor is null (cleanup race)")
+        .isNull();
+
+    // Confirm the Runnable still delivers events correctly on a subsequent invocation.
+    doReturn((new RepairRequestResponse()).repairId("repair-1000"))
+        .when(mockClient)
+        .putRepairV2(any());
+
+    final AtomicInteger secondCallTimes = new AtomicInteger(0);
+    RepairStatusHandler secondHandler =
+        (repairNumber, progress, message, mgmtProxy) -> secondCallTimes.incrementAndGet();
+
+    int repairNo2 =
+        proxy.triggerRepair(
+            "ks",
+            RepairParallelism.PARALLEL,
+            Collections.singleton("table"),
+            RepairType.SUBRANGE_FULL,
+            Collections.emptyList(),
+            secondHandler,
+            Collections.emptyList(),
+            1);
+
+    proxy.repairStatusExecutors.put(repairNo2, MoreExecutors.newDirectExecutorService());
+
+    Job job2 = new Job();
+    job2.setId("repair-1000");
+    StatusChange sc2 = new StatusChange();
+    sc2.setStatus("START");
+    sc2.setMessage("");
+    List<StatusChange> statusChanges2 = new ArrayList<>();
+    statusChanges2.add(sc2);
+    job2.setStatusChanges(statusChanges2);
+    when(mockClient.getJobStatus("repair-1000")).thenReturn(job2);
+
+    proxy.notificationsTracker().run();
+
+    assertEquals(1, secondCallTimes.get());
   }
 
   @Test

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -276,8 +275,8 @@ public class HttpCassandraManagementProxyTest {
   }
 
   /**
-   * Reproduces the cleanup race: the poller commits to a jobTracker entry then blocks on the
-   * HTTP response; concurrently, removeRepairStatusHandler() removes the executor from
+   * Reproduces the cleanup race: the poller commits to a jobTracker entry then blocks on the HTTP
+   * response; concurrently, removeRepairStatusHandler() removes the executor from
    * repairStatusExecutors. When the poller resumes, repairStatusExecutors.get(repairNo) returns
    * null — the pre-fix crash site.
    *
@@ -330,7 +329,7 @@ public class HttpCassandraManagementProxyTest {
         .thenAnswer(
             invocation -> {
               pollerReady.countDown(); // unblock the cleanup thread
-              cleanupDone.await();     // wait until executor has been removed
+              cleanupDone.await(); // wait until executor has been removed
               return job;
             });
 

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -411,6 +411,184 @@ public class HttpCassandraManagementProxyTest {
     assertEquals(1, secondCallTimes.get());
   }
 
+  /**
+   * When the Management API returns a Job whose {@code statusChanges} list is null, the poller must
+   * log a warning and skip that entry — it must not throw NullPointerException, which would
+   * permanently kill the {@code scheduleWithFixedDelay} task.
+   */
+  @Test
+  public void testNotificationsTrackerSkipsJobWithNullStatusChanges() throws Exception {
+    DefaultApi mockClient = mock(DefaultApi.class);
+    doReturn((new RepairRequestResponse()).repairId("repair-111"))
+        .when(mockClient)
+        .putRepairV2(any());
+
+    HttpCassandraManagementProxy proxy = mockProxy(mockClient);
+
+    final AtomicInteger callTimes = new AtomicInteger(0);
+    RepairStatusHandler handler =
+        (repairNumber, progress, message, mgmtProxy) -> callTimes.incrementAndGet();
+
+    int repairNo =
+        proxy.triggerRepair(
+            "ks",
+            RepairParallelism.PARALLEL,
+            Collections.singleton("table"),
+            RepairType.SUBRANGE_FULL,
+            Collections.emptyList(),
+            handler,
+            Collections.emptyList(),
+            1);
+
+    // Return a Job with null statusChanges — simulates a malformed / in-progress response.
+    Job job = new Job();
+    job.setId("repair-111");
+    job.setStatusChanges(null);
+    when(mockClient.getJobStatus("repair-111")).thenReturn(job);
+
+    // Must not throw — a NPE here would permanently kill scheduleWithFixedDelay.
+    AtomicReference<Throwable> thrown = new AtomicReference<>();
+    try {
+      proxy.notificationsTracker().run();
+    } catch (Throwable t) {
+      thrown.set(t);
+    }
+    assertThat(thrown.get())
+        .as("notificationsTracker().run() must not throw when statusChanges is null")
+        .isNull();
+
+    // No handler calls expected; notification count stays at 0.
+    assertEquals(0, callTimes.get());
+    assertEquals(
+        0,
+        proxy.jobTracker.get(String.format("repair-%d", repairNo)).latestNotificationCount.get());
+  }
+
+  /**
+   * When the Management API returns a Job whose status string does not map to a known {@link
+   * io.cassandrareaper.management.ProgressEventType}, {@code dispatchNotification} must log a
+   * warning and return — it must not throw {@link IllegalArgumentException}, which would propagate
+   * through the per-entry try/catch and prevent subsequent notifications for that job from being
+   * processed.
+   *
+   * <p>The caller's {@code latestNotificationCount} increment is unconditional after {@code
+   * dispatchNotification} returns, so the poller advances past the unknown status and does not
+   * stall in an infinite retry loop.
+   */
+  @Test
+  public void testNotificationsTrackerSkipsUnknownProgressEventType() throws Exception {
+    DefaultApi mockClient = mock(DefaultApi.class);
+    doReturn((new RepairRequestResponse()).repairId("repair-222"))
+        .when(mockClient)
+        .putRepairV2(any());
+
+    HttpCassandraManagementProxy proxy = mockProxy(mockClient);
+
+    final AtomicInteger callTimes = new AtomicInteger(0);
+    RepairStatusHandler handler =
+        (repairNumber, progress, message, mgmtProxy) -> callTimes.incrementAndGet();
+
+    int repairNo =
+        proxy.triggerRepair(
+            "ks",
+            RepairParallelism.PARALLEL,
+            Collections.singleton("table"),
+            RepairType.SUBRANGE_FULL,
+            Collections.emptyList(),
+            handler,
+            Collections.emptyList(),
+            1);
+
+    proxy.repairStatusExecutors.put(repairNo, MoreExecutors.newDirectExecutorService());
+
+    // First notification: unknown status. Second notification: valid START.
+    Job job = new Job();
+    job.setId("repair-222");
+    StatusChange unknownSc = new StatusChange();
+    unknownSc.setStatus("TOTALLY_UNKNOWN_STATUS_XYZ");
+    unknownSc.setMessage("");
+    StatusChange knownSc = new StatusChange();
+    knownSc.setStatus("START");
+    knownSc.setMessage("");
+    List<StatusChange> statusChanges = new ArrayList<>();
+    statusChanges.add(unknownSc);
+    statusChanges.add(knownSc);
+    job.setStatusChanges(statusChanges);
+    when(mockClient.getJobStatus("repair-222")).thenReturn(job);
+
+    // Must not throw.
+    AtomicReference<Throwable> thrown = new AtomicReference<>();
+    try {
+      proxy.notificationsTracker().run();
+    } catch (Throwable t) {
+      thrown.set(t);
+    }
+    assertThat(thrown.get())
+        .as("notificationsTracker().run() must not throw on unknown ProgressEventType")
+        .isNull();
+
+    // The unknown-status notification is skipped (no handler call) but the count advances past it;
+    // the subsequent START notification is dispatched normally.
+    String jobId = String.format("repair-%d", repairNo);
+    assertEquals(
+        "notification count must advance past both notifications",
+        2,
+        proxy.jobTracker.get(jobId).latestNotificationCount.get());
+    assertEquals("only the START notification should reach the handler", 1, callTimes.get());
+  }
+
+  /**
+   * When the Management API returns a Job whose {@code id} does not start with the expected {@code
+   * "repair-"} prefix (or is too short), the poller must log a warning and skip — it must not throw
+   * {@link StringIndexOutOfBoundsException} or {@link NumberFormatException}.
+   */
+  @Test
+  public void testNotificationsTrackerSkipsMalformedJobId() throws Exception {
+    DefaultApi mockClient = mock(DefaultApi.class);
+    doReturn((new RepairRequestResponse()).repairId("repair-333"))
+        .when(mockClient)
+        .putRepairV2(any());
+
+    HttpCassandraManagementProxy proxy = mockProxy(mockClient);
+
+    final AtomicInteger callTimes = new AtomicInteger(0);
+    RepairStatusHandler handler =
+        (repairNumber, progress, message, mgmtProxy) -> callTimes.incrementAndGet();
+
+    proxy.triggerRepair(
+        "ks",
+        RepairParallelism.PARALLEL,
+        Collections.singleton("table"),
+        RepairType.SUBRANGE_FULL,
+        Collections.emptyList(),
+        handler,
+        Collections.emptyList(),
+        1);
+
+    // Simulate a response where the server returns a job with a completely unexpected id format.
+    Job job = new Job();
+    job.setId("bad"); // too short and wrong prefix
+    StatusChange sc = new StatusChange();
+    sc.setStatus("START");
+    sc.setMessage("");
+    job.setStatusChanges(Collections.singletonList(sc));
+    when(mockClient.getJobStatus("repair-333")).thenReturn(job);
+
+    // Must not throw.
+    AtomicReference<Throwable> thrown = new AtomicReference<>();
+    try {
+      proxy.notificationsTracker().run();
+    } catch (Throwable t) {
+      thrown.set(t);
+    }
+    assertThat(thrown.get())
+        .as("notificationsTracker().run() must not throw on malformed job id")
+        .isNull();
+
+    // Handler should not have been called since the job was skipped.
+    assertEquals(0, callTimes.get());
+  }
+
   @Test
   public void testGetKeyspaces() throws Exception {
     DefaultApi mockClient = Mockito.mock(DefaultApi.class);


### PR DESCRIPTION
### Summary

Fix a race condition in the Reaper Management API notification poller that could terminate the notificationsTracker task during concurrent repair cleanup.

### Problem
removeRepairStatusHandler() removed the repair executor before removing the corresponding jobTracker entry. If notificationsTracker() was iterating jobTracker during this window, it could observe a live job entry whose executor had already been removed. This resulted in a NullPointerException when calling executor.submit(...).

Since notificationsTracker() is scheduled using ScheduledExecutorService.scheduleWithFixedDelay(), any uncaught exception permanently suppresses future executions of the poller, causing subsequent repairs to complete only via timeout.

### Changes
- Reordered cleanup in removeRepairStatusHandler() to remove the jobTracker entry before removing the handler and executor.
- Hardened notificationsTracker() by:
    - isolating failures on a per-job basis,
    - handling transient getJobStatus() failures,
    - guarding against concurrently removed executors and handlers,
    - preventing exceptions from escaping the scheduled poller,
    - capturing the handler before submitting work to avoid an additional race.
- Added a deterministic unit test that reproduces the concurrent cleanup race using CountDownLatch and verifies that notificationsTracker().run() completes without throwing.

### Testing
- Added deterministic race-condition unit test covering concurrent cleanup.
- Existing project tests compile successfully (environment-specific Mockito limitations under Java 25 remain unchanged).