### PR TITLE
Fix IllegalStateException on contended LWT lead (#1632)

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraConcurrencyDao.java
+++ b/src/server/src/main/java/io/cassandrareaper/storage/cassandra/CassandraConcurrencyDao.java
@@ -219,11 +219,14 @@ public class CassandraConcurrencyDao {
     }
 
     ResultSet results = session.execute(batch.build());
-    if (!results.wasApplied()) {
+    // wasApplied() must be read before logFailedLead() consumes the rows,
+    // otherwise the driver throws IllegalStateException (see #1632).
+    boolean applied = results.wasApplied();
+    if (!applied) {
       logFailedLead(results, repairId, segmentId);
     }
 
-    return results.wasApplied();
+    return applied;
   }
 
   public boolean renewRunningRepairsForNodes(UUID repairId, UUID segmentId, Set<String> replicas) {
@@ -242,11 +245,14 @@ public class CassandraConcurrencyDao {
     }
 
     ResultSet results = session.execute(batch.build());
-    if (!results.wasApplied()) {
+    // wasApplied() must be read before logFailedLead() consumes the rows,
+    // otherwise the driver throws IllegalStateException (see #1632).
+    boolean applied = results.wasApplied();
+    if (!applied) {
       logFailedLead(results, repairId, segmentId);
     }
 
-    return results.wasApplied();
+    return applied;
   }
 
   void logFailedLead(ResultSet results, UUID repairId, UUID segmentId) {
@@ -283,11 +289,14 @@ public class CassandraConcurrencyDao {
     }
 
     ResultSet results = session.execute(batch.build());
-    if (!results.wasApplied()) {
+    // wasApplied() must be read before logFailedLead() consumes the rows,
+    // otherwise the driver throws IllegalStateException (see #1632).
+    boolean applied = results.wasApplied();
+    if (!applied) {
       logFailedLead(results, repairId, segmentId);
     }
 
-    return results.wasApplied();
+    return applied;
   }
 
   public Set<UUID> getLockedSegmentsForRun(UUID runId) {

--- a/src/server/src/test/java/io/cassandrareaper/storage/cassandra/CassandraConcurrencyDaoTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/storage/cassandra/CassandraConcurrencyDaoTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024-2024 The Last Pickle Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cassandrareaper.storage.cassandra;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.Version;
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for #1632.
+ *
+ * <p>When an LWT lead cannot be taken/renewed/released, {@code logFailedLead()} iterates the {@link
+ * ResultSet}. The DataStax driver forbids calling {@link ResultSet#wasApplied()} once the rows have
+ * been consumed, so calling it a second time (after {@code logFailedLead()}) throws {@code
+ * IllegalStateException: This method must be called before consuming all the rows}. These tests
+ * assert that {@code wasApplied()} is read exactly once and the not-applied path returns {@code
+ * false} without throwing.
+ */
+public final class CassandraConcurrencyDaoTest {
+
+  private static final UUID REPAIR_ID = UUID.randomUUID();
+  private static final UUID SEGMENT_ID = UUID.randomUUID();
+  private static final Set<String> REPLICAS = Collections.singleton("127.0.0.1");
+
+  private ResultSet results;
+  private CassandraConcurrencyDao dao;
+
+  @Before
+  public void setUp() {
+    CqlSession session = mock(CqlSession.class);
+    PreparedStatement preparedStatement = mock(PreparedStatement.class);
+    BoundStatement boundStatement = mock(BoundStatement.class);
+    results = mock(ResultSet.class);
+
+    when(session.prepare(any(SimpleStatement.class))).thenReturn(preparedStatement);
+    when(session.prepare(anyString())).thenReturn(preparedStatement);
+    when(preparedStatement.bind(any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(boundStatement);
+    when(session.execute(any(BatchStatement.class))).thenReturn(results);
+
+    // First read returns false (not applied); any second read reproduces the driver contract
+    // violation reported in #1632 by throwing.
+    when(results.wasApplied())
+        .thenReturn(false)
+        .thenThrow(
+            new IllegalStateException("This method must be called before consuming all the rows"));
+    when(results.iterator()).thenReturn(Collections.emptyIterator());
+
+    dao = new CassandraConcurrencyDao(Version.parse("4.0.0"), UUID.randomUUID(), session);
+  }
+
+  @Test
+  public void lockRunningRepairsForNodesReadsWasAppliedOnce() {
+    assertFalse(dao.lockRunningRepairsForNodes(REPAIR_ID, SEGMENT_ID, REPLICAS));
+    verify(results, times(1)).wasApplied();
+  }
+
+  @Test
+  public void renewRunningRepairsForNodesReadsWasAppliedOnce() {
+    assertFalse(dao.renewRunningRepairsForNodes(REPAIR_ID, SEGMENT_ID, REPLICAS));
+    verify(results, times(1)).wasApplied();
+  }
+
+  @Test
+  public void releaseRunningRepairsForNodesReadsWasAppliedOnce() {
+    assertFalse(dao.releaseRunningRepairsForNodes(REPAIR_ID, SEGMENT_ID, REPLICAS));
+    verify(results, times(1)).wasApplied();
+  }
+}


### PR DESCRIPTION
### Problem
`CassandraConcurrencyDao.lockRunningRepairsForNodes` (and the renew/release
siblings) call `ResultSet.wasApplied()` a second time *after* `logFailedLead()`
has already iterated the result set. The DataStax Java driver forbids calling
`wasApplied()` once rows are consumed and throws:

    IllegalStateException: This method must be called before consuming all the rows

The exception only occurs on the *not-applied* (contended) path, since that's
when `logFailedLead()` runs. In `datacenterAvailability: SIDECAR` /
multi-instance deployments, lead contention is the normal case — so every
contended segment throws, `takeLead()` never succeeds, and repairs are silently
abandoned (anti-entropy effectively disabled).

### Fix
Read `wasApplied()` once, before `logFailedLead()` consumes the rows, in all
three methods (`lock` / `renew` / `releaseRunningRepairsForNodes`).

### Test
Adds `CassandraConcurrencyDaoTest` which reproduces the failure for all three
methods (fails with the exact `IllegalStateException` before the fix, passes
after).

Fixes #1632
