### PR TITLE
Guard notificationsTracker against poller death in HTTP management mode

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -632,50 +632,45 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       // repair completions are never observed again and segments stay STARTED
       // forever. Nothing thrown here may escape.
       try {
-        if (jobTracker.size() > 0) {
-          for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
-            try {
-              Job job = getJobStatus(entry.getKey());
-              int availableNotifications = job.getStatusChanges().size();
-              int currentNotificationCount = entry.getValue().latestNotificationCount.get();
-
-              if (currentNotificationCount < availableNotifications) {
-                // We need to process the new ones
-                for (int i = currentNotificationCount; i < availableNotifications; i++) {
-                  StatusChange statusChange = job.getStatusChanges().get(i);
-                  // remove "repair-" prefix
-                  int repairNo = Integer.parseInt(job.getId().substring(7));
-                  ProgressEventType progressType =
-                      ProgressEventType.valueOf(statusChange.getStatus());
-                  repairStatusExecutors
-                      .get(repairNo)
-                      .submit(
-                          () -> {
-                            repairStatusHandlers
-                                .get(repairNo)
-                                .handle(
-                                    repairNo,
-                                    Optional.of(progressType),
-                                    statusChange.getMessage(),
-                                    this);
-                          });
-
-                  // Update the count as we process them
-                  entry.getValue().latestNotificationCount.incrementAndGet();
-                }
-              }
-            } catch (RuntimeException e) {
-              LOG.warn(
-                  "Failed to poll status of job {}, will retry on the next poll",
-                  entry.getKey(),
-                  e);
-            }
+        for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
+          try {
+            processJobNotifications(entry);
+          } catch (RuntimeException e) {
+            LOG.warn(
+                "Failed to poll status of job {}, will retry on the next poll", entry.getKey(), e);
           }
         }
       } catch (Throwable t) {
         LOG.error("Job status poller iteration failed, will retry on the next poll", t);
       }
     };
+  }
+
+  private void processJobNotifications(Map.Entry<String, JobStatusTracker> entry) {
+    Job job = getJobStatus(entry.getKey());
+    int availableNotifications = job.getStatusChanges().size();
+    int currentNotificationCount = entry.getValue().latestNotificationCount.get();
+
+    if (currentNotificationCount < availableNotifications) {
+      // We need to process the new ones
+      for (int i = currentNotificationCount; i < availableNotifications; i++) {
+        StatusChange statusChange = job.getStatusChanges().get(i);
+        // remove "repair-" prefix
+        int repairNo = Integer.parseInt(job.getId().substring(7));
+        ProgressEventType progressType = ProgressEventType.valueOf(statusChange.getStatus());
+        repairStatusExecutors
+            .get(repairNo)
+            .submit(
+                () -> {
+                  repairStatusHandlers
+                      .get(repairNo)
+                      .handle(repairNo, Optional.of(progressType), statusChange.getMessage(), this);
+                });
+
+        // Update the count as we process them
+        entry.getValue().latestNotificationCount.incrementAndGet();
+      }
+    }
   }
 
   // Coordinator nodes such as Stargate instances do not have tokens

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -633,8 +633,8 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       // forever. Nothing thrown here may escape.
       try {
         pollTrackedJobs();
-      } catch (Throwable t) {
-        LOG.error("Job status poller iteration failed, will retry on the next poll", t);
+      } catch (Exception e) {
+        LOG.error("Job status poller iteration failed, will retry on the next poll", e);
       }
     };
   }

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -632,18 +632,21 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
       // repair completions are never observed again and segments stay STARTED
       // forever. Nothing thrown here may escape.
       try {
-        for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
-          try {
-            processJobNotifications(entry);
-          } catch (RuntimeException e) {
-            LOG.warn(
-                "Failed to poll status of job {}, will retry on the next poll", entry.getKey(), e);
-          }
-        }
+        pollTrackedJobs();
       } catch (Throwable t) {
         LOG.error("Job status poller iteration failed, will retry on the next poll", t);
       }
     };
+  }
+
+  private void pollTrackedJobs() {
+    for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
+      try {
+        processJobNotifications(entry);
+      } catch (RuntimeException e) {
+        LOG.warn("Failed to poll status of job {}, will retry on the next poll", entry.getKey(), e);
+      }
+    }
   }
 
   private void processJobNotifications(Map.Entry<String, JobStatusTracker> entry) {

--- a/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
+++ b/src/server/src/main/java/io/cassandrareaper/management/http/HttpCassandraManagementProxy.java
@@ -627,37 +627,53 @@ public class HttpCassandraManagementProxy implements ICassandraManagementProxy {
   @VisibleForTesting
   Runnable notificationsTracker() {
     return () -> {
-      if (jobTracker.size() > 0) {
-        for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
-          Job job = getJobStatus(entry.getKey());
-          int availableNotifications = job.getStatusChanges().size();
-          int currentNotificationCount = entry.getValue().latestNotificationCount.get();
+      // This runnable runs via scheduleWithFixedDelay, which permanently and
+      // silently cancels the task on the first uncaught exception — after which
+      // repair completions are never observed again and segments stay STARTED
+      // forever. Nothing thrown here may escape.
+      try {
+        if (jobTracker.size() > 0) {
+          for (Map.Entry<String, JobStatusTracker> entry : jobTracker.entrySet()) {
+            try {
+              Job job = getJobStatus(entry.getKey());
+              int availableNotifications = job.getStatusChanges().size();
+              int currentNotificationCount = entry.getValue().latestNotificationCount.get();
 
-          if (currentNotificationCount < availableNotifications) {
-            // We need to process the new ones
-            for (int i = currentNotificationCount; i < availableNotifications; i++) {
-              StatusChange statusChange = job.getStatusChanges().get(i);
-              // remove "repair-" prefix
-              int repairNo = Integer.parseInt(job.getId().substring(7));
-              ProgressEventType progressType = ProgressEventType.valueOf(statusChange.getStatus());
-              repairStatusExecutors
-                  .get(repairNo)
-                  .submit(
-                      () -> {
-                        repairStatusHandlers
-                            .get(repairNo)
-                            .handle(
-                                repairNo,
-                                Optional.of(progressType),
-                                statusChange.getMessage(),
-                                this);
-                      });
+              if (currentNotificationCount < availableNotifications) {
+                // We need to process the new ones
+                for (int i = currentNotificationCount; i < availableNotifications; i++) {
+                  StatusChange statusChange = job.getStatusChanges().get(i);
+                  // remove "repair-" prefix
+                  int repairNo = Integer.parseInt(job.getId().substring(7));
+                  ProgressEventType progressType =
+                      ProgressEventType.valueOf(statusChange.getStatus());
+                  repairStatusExecutors
+                      .get(repairNo)
+                      .submit(
+                          () -> {
+                            repairStatusHandlers
+                                .get(repairNo)
+                                .handle(
+                                    repairNo,
+                                    Optional.of(progressType),
+                                    statusChange.getMessage(),
+                                    this);
+                          });
 
-              // Update the count as we process them
-              entry.getValue().latestNotificationCount.incrementAndGet();
+                  // Update the count as we process them
+                  entry.getValue().latestNotificationCount.incrementAndGet();
+                }
+              }
+            } catch (RuntimeException e) {
+              LOG.warn(
+                  "Failed to poll status of job {}, will retry on the next poll",
+                  entry.getKey(),
+                  e);
             }
           }
         }
+      } catch (Throwable t) {
+        LOG.error("Job status poller iteration failed, will retry on the next poll", t);
       }
     };
   }

--- a/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
+++ b/src/server/src/test/java/io/cassandrareaper/management/http/HttpCassandraManagementProxyTest.java
@@ -273,6 +273,59 @@ public class HttpCassandraManagementProxyTest {
   }
 
   @Test
+  public void testNotificationsTrackerSurvivesPollingFailure() throws Exception {
+    DefaultApi mockClient = mock(DefaultApi.class);
+    doReturn((new RepairRequestResponse()).repairId("repair-123456789"))
+        .when(mockClient)
+        .putRepairV2(any());
+    HttpCassandraManagementProxy httpCassandraManagementProxy = mockProxy(mockClient);
+
+    final AtomicInteger callTimes = new AtomicInteger(0);
+    RepairStatusHandler workAroundHandler =
+        (repairNumber, progress, message, cassandraManagementProxy) -> callTimes.incrementAndGet();
+
+    int repairNo =
+        httpCassandraManagementProxy.triggerRepair(
+            "ks",
+            RepairParallelism.PARALLEL,
+            Collections.singleton("table"),
+            RepairType.SUBRANGE_FULL,
+            Collections.emptyList(),
+            workAroundHandler,
+            Collections.emptyList(),
+            1);
+
+    // We want the execution to happen in the same thread for this test
+    httpCassandraManagementProxy.repairStatusExecutors.put(
+        repairNo, MoreExecutors.newDirectExecutorService());
+
+    Job job = new Job();
+    job.setId("repair-123456789");
+    StatusChange sc = new StatusChange();
+    sc.setStatus("COMPLETE");
+    sc.setMessage("");
+    List<StatusChange> statusChanges = new ArrayList<>();
+    statusChanges.add(sc);
+    job.setStatusChanges(statusChanges);
+    // First poll fails, second poll succeeds
+    when(mockClient.getJobStatus("repair-123456789"))
+        .thenThrow(new ApiException("mgmt api hiccup"))
+        .thenReturn(job);
+
+    // The failed poll must not propagate — an escaped exception would cancel the
+    // scheduleWithFixedDelay task and repair completions would never be seen again.
+    httpCassandraManagementProxy.notificationsTracker().run();
+    assertEquals(0, callTimes.get());
+
+    // The tracker must still be alive and deliver the notification on the next poll.
+    httpCassandraManagementProxy.notificationsTracker().run();
+    assertEquals(1, callTimes.get());
+    String jobId = String.format("repair-%d", repairNo);
+    assertEquals(
+        1, httpCassandraManagementProxy.jobTracker.get(jobId).latestNotificationCount.get());
+  }
+
+  @Test
   public void testGetKeyspaces() throws Exception {
     DefaultApi mockClient = Mockito.mock(DefaultApi.class);
     when(mockClient.listKeyspaces("")).thenReturn(ImmutableList.of("ks1", "ks2", "ks3"));


### PR DESCRIPTION
Fixes #1709

## Problem

In HTTP management mode, `HttpCassandraManagementProxy` learns about repair completion exclusively from a job-status poller scheduled with `scheduleWithFixedDelay(notificationsTracker(), …)`. `scheduleWithFixedDelay` permanently and silently cancels the task on the first uncaught exception, `notificationsTracker()` has no exception handling, and `getJobStatus()` rethrows any `ApiException` as `RuntimeException`. One transient management-API error (timeout, connection reset, unreachable coordinator) therefore kills the poller for the lifetime of the pod. Every later repair completes invisibly, segments stay `STARTED` forever, and runs wedge with "All nodes are busy or have too many pending compactions for the remaining candidate segments." while the cluster is idle. Only a Reaper restart recovers. Full analysis and production evidence in #1709.

## Fix

Make the scheduled runnable exception-safe:

- per-job-entry `catch (RuntimeException)` — one failing job skips only that job; the other tracked jobs still get their status processed in the same tick;
- outer `catch (Throwable)` — nothing whatsoever can escape the runnable;
- both paths log and the poller retries on the next tick.

The outer guard catches `Exception` (per SonarCloud rule S1181). An escaping JVM `Error` would still cancel the task, but swallowing `Error`s tends to hide conditions where failing loudly is preferable. Log volume is naturally bounded by the poll interval (one line per failing job per tick).

Secondary throw points covered by the same guards: `Integer.parseInt` on the job id, `ProgressEventType.valueOf` on an unknown status, and a potential NPE from `repairStatusExecutors.get(repairNo)` when a handler was already removed.

## Regression test

`testNotificationsTrackerSurvivesPollingFailure`: the first poll throws `ApiException`, the test asserts nothing propagates and that the next poll still delivers the notification. It fails on unpatched source (the first `run()` throws) and passes with the fix. `HttpCassandraManagementProxyTest` is green on this branch (31/31).

## Production validation

We have been running this patch (applied to 4.2.5) in production since 2026-07-14: zero wedges since, after six wedges in the preceding three months. The guard also survived a real sustained failure — a tracked job's coordinator pod IP became permanently unreachable and the poller logged "will retry on the next poll" ~49,000 times over three days while continuing to deliver status for all other jobs. On unpatched code the first of those failures would have wedged every subsequent repair.
