### PR TITLE
Release 4.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### 4.2.6
+- [#1715](https://github.com/thelastpickle/cassandra-reaper/pull/1715) Fix Netty and UBI package vulnerabilities for the 4.2 UBI image.
+
 ### 4.2.5 (2026/06/11 11:02 +00:00)
 - [#1683](https://github.com/thelastpickle/cassandra-reaper/pull/1683) fix: scheduled repairs never re-fire after a completed run (#1683) (#1686) (@onnos)
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.cassandrareaper</groupId>
     <artifactId>cassandra-reaper-pom</artifactId>
-    <version>4.2.6-SNAPSHOT</version>
+    <version>4.2.6</version>
     <packaging>pom</packaging>
 
     <name>Reaper for Apache Cassandra project</name>

--- a/src/server/pom.xml
+++ b/src/server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.cassandrareaper</groupId>
         <artifactId>cassandra-reaper-pom</artifactId>
-        <version>4.2.6-SNAPSHOT</version>
+        <version>4.2.6</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Reaper for Apache Cassandra server</name>


### PR DESCRIPTION
Prepares the 4.2.6 release for the SWH 5.4.0 Patch 6 Netty CVE fixes.

- Sets the Maven release version to 4.2.6
- Adds the 4.2.6 changelog entry for #1715
- Once merged, the 4.2.6 tag and GitHub Release will publish the official -ubi image.