### PR TITLE
Forward merge 4.2.6 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - [#1697](https://github.com/thelastpickle/cassandra-reaper/pull/1697) Fix Reaper image CVEs (#1697) (@gmanojDS)
 - [#1687](https://github.com/thelastpickle/cassandra-reaper/pull/1687) Upgrade to Java 17 + Dropwizard 5 (Jakarta EE 10 / Jetty 12.1) (#1687) (@vasiliy-mikhailov)
 
+### 4.2.6
+- [#1715](https://github.com/thelastpickle/cassandra-reaper/pull/1715) Fix Netty and UBI package vulnerabilities for the 4.2 UBI image.
+
 ### 4.2.5 (2026/06/11 11:02 +00:00)
 - [#1683](https://github.com/thelastpickle/cassandra-reaper/pull/1683) fix: scheduled repairs never re-fire after a completed run (#1683) (#1686) (@onnos)
 


### PR DESCRIPTION
Cherry-picks the 4.2.6 changelog update from the 4.2 release branch.