### PR TITLE
fix: disable attestations for Reaper UBI image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -565,6 +565,8 @@ jobs:
         id: docker_build_ubi
         uses: docker/build-push-action@v4
         with:
+          provenance: false
+          sbom: false
           file: src/server/src/main/docker/Dockerfile-ubi
           context: .
           build-args: |


### PR DESCRIPTION
Disable Buildx provenance and SBOM attestations for the Reaper UBI image to avoid OCI artifact manifests that are incompatible with downstream manifest conversion.